### PR TITLE
remove 'file' dependency

### DIFF
--- a/ranger/ext/rifle.py
+++ b/ranger/ext/rifle.py
@@ -15,7 +15,7 @@ Example usage:
 	rifle.execute(["file1", "file2"])
 """
 
-from mimetype import guess_type
+from mimetypes import guess_type
 import os.path
 import re
 from subprocess import Popen, PIPE

--- a/ranger/fsobject/fsobject.py
+++ b/ranger/fsobject/fsobject.py
@@ -6,6 +6,7 @@ CONTAINER_EXTENSIONS = ('7z', 'ace', 'ar', 'arc', 'bz', 'bz2', 'cab', 'cpio',
 	'shar', 'tar', 'tbz', 'tgz', 'xar', 'xpi', 'xz', 'zip')
 
 import re
+from mimetypes import guess_type
 from os import lstat, stat
 from os.path import abspath, basename, dirname, realpath, splitext, extsep
 from ranger.core.shared import FileManagerAware
@@ -88,10 +89,7 @@ class FileSystemObject(FileManagerAware):
 
 	@lazy_property
 	def filetype(self):
-		try:
-			return spawn(["file", '-Lb', '--mime-type', self.path])
-		except OSError:
-			return ""
+		return guess_type(self.path)[0]
 
 	@lazy_property
 	def basename_natural(self):


### PR DESCRIPTION
Uses python's built-in mimetypes module to detect filetype rather than Popen
