### PR TITLE
core.main: fix --selectfile argument

### DIFF
--- a/ranger/core/main.py
+++ b/ranger/core/main.py
@@ -108,12 +108,12 @@ def main():
 			from ranger.ext import curses_interrupt_handler
 			curses_interrupt_handler.install_interrupt_handler()
 
-		if arg.selectfile:
-			fm.select_file(arg.selectfile)
-
 		# Run the file manager
 		fm.initialize()
 		fm.ui.initialize()
+
+		if arg.selectfile:
+			fm.select_file(arg.selectfile)
 
 		if arg.cmd:
 			for command in arg.cmd:


### PR DESCRIPTION
Another little fix.
Invoking ranger with --selectfile argument make it crash.
We try to access fm.thistab before it is assigned.
