### PR TITLE
Clear images without full redraw + allow w3mimgdisplay options

### DIFF
--- a/ranger/ext/img_display.py
+++ b/ranger/ext/img_display.py
@@ -78,3 +78,17 @@ def draw(path, start_x, start_y, max_width, max_height):
 			h = height,
 			filename = path)
 	_w3mimgdisplay(cmd)
+
+def clear(start_x, start_y, width, height):
+	"""
+	Clear a part of terminal display.
+	"""
+	fontw, fonth = _get_font_dimensions()
+
+	cmd = "6;{x};{y};{w};{h}\n4;\n3;".format(
+			x = start_x * fontw,
+			y = start_y * fonth,
+			w = width * fontw,
+			h = height * fonth)
+
+	_w3mimgdisplay(cmd)

--- a/ranger/gui/widgets/pager.py
+++ b/ranger/gui/widgets/pager.py
@@ -39,11 +39,13 @@ class Pager(Widget):
 
 	def clear_image(self):
 		if self.need_clear_image:
-			self.win.clear()
-			self.win.refresh()
+			img_display.clear(self.x, self.y, self.wid, self.hei)
 			self.need_clear_image = False
 
 	def close(self):
+		if self.image:
+			self.need_clear_image = True
+			self.clear_image()
 		if self.source and self.source_is_stream:
 			self.source.close()
 


### PR DESCRIPTION
According to w3m documentation, passing options to w3mimgdisplay may be required in some specific cases.
For example, an unknown terminal emulator may require to change display offset.
W3mimgdisplay draws a rectangle of the background color over the display area to clear it. Therefore, it needs to know which background color is used. The background color of X terminal emulators is detected automatically but not Linux frame buffer one (it defaults to black).
