### PR TITLE
fix the code move to load_vcs

### DIFF
--- a/ranger/fsobject/directory.py
+++ b/ranger/fsobject/directory.py
@@ -228,7 +228,7 @@ class Directory(FileSystemObject, Accumulator, Loadable, SettingsAware):
 
                 if self.settings.vcs_aware:
                     self.has_vcschild = False
-                    self.load_vcs()
+                    self.load_vcs(None)
 
                 for name in filenames:
                     try:
@@ -257,7 +257,7 @@ class Directory(FileSystemObject, Accumulator, Loadable, SettingsAware):
 
                     # Load vcs data
                     if self.settings.vcs_aware:
-                        item.load_vcs()
+                        item.load_vcs(self)
                         if item.vcs_enabled:
                             self.has_vcschild = True
 

--- a/ranger/fsobject/fsobject.py
+++ b/ranger/fsobject/fsobject.py
@@ -193,7 +193,7 @@ class FileSystemObject(FileManagerAware):
                 return None  # it is impossible to get the link destination
         return self.path
 
-    def load_vcs(self):
+    def load_vcs(self, parent):
         """
         Reads data regarding the version control system the object is on.
         Does not load content specific data.
@@ -221,7 +221,7 @@ class FileSystemObject(FileManagerAware):
             rootdir.load_if_outdated()
 
             # Get the Vcs object from rootdir
-            rootdir.load_vcs()
+            rootdir.load_vcs(None)
             self.vcs = rootdir.vcs
             if rootdir.vcs_outdated:
                 self.vcs_outdated = True
@@ -239,7 +239,7 @@ class FileSystemObject(FileManagerAware):
             self.vcs_enabled = backend_state in set(['enabled', 'local'])
             if self.vcs_enabled:
                 try:
-                    if self.vcs_outdated or self.vcs_outdated:
+                    if self.vcs_outdated or (parent and parent.vcs_outdated):
                         self.vcs_outdated = False
                         # this caches the file status for get_file_status():
                         self.vcs.get_status()
@@ -249,9 +249,9 @@ class FileSystemObject(FileManagerAware):
                                 backend_state == 'enabled':
                             self.vcsremotestatus = \
                                     self.vcs.get_remote_status()
-                    else:
-                        self.vcsbranch = self.vcsbranch
-                        self.vcshead = self.vcshead
+                    elif parent:
+                        self.vcsbranch = parent.vcsbranch
+                        self.vcshead = parent.vcshead
                     self.vcsfilestatus = self.vcs.get_file_status(self.path)
                 except VcsError as err:
                     self.vcsbranch = None


### PR DESCRIPTION
In the move of code from load_bit_by_bit to load_vcs some functionality broke.

That particular block of code used 'item' and 'self' to refer to an item, and the containing directory respectively. After the move, item should go to 'self' (in the new context), but then we need to pass the old self as a 'parent' argument to load_vcs.
