### PR TITLE
Fixed the sxiv workaround to handle spaces and be more POSIX compliant.

### DIFF
--- a/examples/rifle_sxiv.sh
+++ b/examples/rifle_sxiv.sh
@@ -1,30 +1,44 @@
 #!/bin/sh
 # Compatible with ranger 1.6.*
 #
-# This script searches image files in a directory, opens them all with sxiv
-# and sets the first argument to the first image displayed by sxiv.
+# This script searches image files in a directory, opens them all with sxiv and
+# sets the first argument to the first image displayed by sxiv.
 #
 # This is supposed to be used in rifle.conf as a workaround for the fact that
-# sxiv takes no file name arguments for the first image, just the number.
-# Copy this file somewhere into your $PATH and add this at the top of rifle.conf:
+# sxiv takes no file name arguments for the first image, just the number.  Copy
+# this file somewhere into your $PATH and add this at the top of rifle.conf:
 #
 #   mime ^image, has sxiv, X, flag f = path/to/this/script -- "$@"
 #
+# Implementation notes: this script is quite slow because of POSIX limitations
+# and portability concerns. First calling the shell function 'abspath' is
+# quicker than calling 'realpath' because it would fork a whole process, which
+# is slow. Second, we need to append a file list to sxiv, which can only be done
+# properly in two ways: arrays (which are not POSIX) or \0 sperated
+# strings. Unfortunately, assigning \0 to a variable is not POSIX either (will
+# not work in dash and others), so we cannot store the result of listfiles to a
+# variable.
+
+if [ $# -eq 0 ]; then
+    echo "Usage: ${0##*/} PICTURES"
+    exit
+fi
 
 [ "$1" == '--' ] && shift
 
-function abspath {
+abspath () {
     case "$1" in
         /*) printf "%s\n" "$1";;
         *)  printf "%s\n" "$PWD/$1";;
     esac
 }
-function listfiles {
+
+listfiles () {
     find -L "$(dirname "$target")" -maxdepth 1 -type f -iregex \
       '.*\(jpe?g\|bmp\|png\|gif\)$' -print0 | sort -z
 }
 
-target="$(abspath $1)"
+target="$(abspath "$1")"
 count="$(listfiles | grep -m 1 -Zznx "$target" | cut -d: -f1)"
 
 if [ -n "$count" ]; then


### PR DESCRIPTION
The previous sxiv scripts would not allow sxiv to browse files if selected file contained spaces. This is  because of the missing doubequotes around the abspath argument.

Functions in Bourne Shell are declared like this:
myFunctionname () {
...
}
There is no 'function' keyword, that's a bashism.

I added a check on script arguments to display a "Usage:" line. This should help when the script is used interactively.

I added some comments on the implementation. It is slow but I do not see another way to do this while conforming to POSIX. This script has very poor performances indeed. listfiles is called two times, which mean the 'find' and the 'sort' get performed two times. This is not acceptable for big folders.  I bet a python script would be much better.
