### PR TITLE
Add preview_max_size option.

### DIFF
--- a/ranger/container/file.py
+++ b/ranger/container/file.py
@@ -68,6 +68,8 @@ class File(FileSystemObject):
             return False
         if not self.accessible:
             return False
+        if self.size > self.fm.settings.preview_max_size:
+            return False
         if self.fm.settings.preview_script and \
                 self.fm.settings.use_preview_script:
             return True

--- a/ranger/container/settings.py
+++ b/ranger/container/settings.py
@@ -31,6 +31,7 @@ ALLOWED_SETTINGS = {
     'preview_files': bool,
     'preview_images': bool,
     'preview_script': (str, type(None)),
+    'preview_max_size': int,
     'save_console_history': bool,
     'scroll_offset': int,
     'shorten_title': int,


### PR DESCRIPTION
Preview of large archives is loads a CPU until archive unpacking is complete. This patch adds option for turning off the preview of the large files.
