### PR TITLE
Allow $EDITOR to contain spaces

### DIFF
--- a/ranger/config/rifle.conf
+++ b/ranger/config/rifle.conf
@@ -79,9 +79,9 @@ ext x?html?, has w3m,             terminal = w3m "$@"
 # Misc
 #-------------------------------------------
 # Define the "editor" for text files as first action
-mime ^text,  label editor = "$EDITOR" -- "$@"
+mime ^text,  label editor = $EDITOR -- "$@"
 mime ^text,  label pager  = "$PAGER" -- "$@"
-!mime ^text, label editor, ext xml|csv|tex|py|pl|rb|sh|php = "$EDITOR" -- "$@"
+!mime ^text, label editor, ext xml|csv|tex|py|pl|rb|sh|php = $EDITOR -- "$@"
 !mime ^text, label pager,  ext xml|csv|tex|py|pl|rb|sh|php = "$PAGER" -- "$@"
 
 ext 1                         = man "$1"
@@ -184,5 +184,5 @@ label wallpaper, number 14, mime ^image, X = feh --bg-fill "$1"
 
 # Define the editor for non-text files + pager as last action
               !mime ^text, !ext xml|csv|tex|py|pl|rb|sh|php  = ask
-label editor, !mime ^text, !ext xml|csv|tex|py|pl|rb|sh|php  = "$EDITOR" -- "$@"
+label editor, !mime ^text, !ext xml|csv|tex|py|pl|rb|sh|php  = $EDITOR -- "$@"
 label pager,  !mime ^text, !ext xml|csv|tex|py|pl|rb|sh|php  = "$PAGER" -- "$@"


### PR DESCRIPTION
$EDITOR variables consisting of "program name + options" are not handled
correctly because of quotes around $EDITOR. As a result, if $EDITOR is not
a simple program name (i.e. if it includes options, as in "emacs -nw"), the
full string is taken as a program and fails to run.
Error message: (/bin/sh: 1: emacs -nw: not found)
Removing quotes fixes this problem.
