### PR TITLE
Handle CDPATH

### DIFF
--- a/ranger/core/actions.py
+++ b/ranger/core/actions.py
@@ -451,7 +451,19 @@ class Actions(FileManagerAware, EnvironmentAware, SettingsAware):
     def enter_dir(self, path, remember=False, history=True):
         """Enter the directory at the given path"""
         cwd = self.thisdir
+        # bash and ksh syntax
+        cdpath = os.environ.get('CDPATH', None)
+        if cdpath == "":
+            # zsh and csh syntax
+            os.environ.get('cdpath', None)
+        paths = cdpath.split(':')
         result = self.thistab.enter_dir(path, history=history)
+        if result == 0:
+            for p in paths:
+                curpath = p + '/' + path
+                if os.path.isdir(curpath):
+                    result = self.thistab.enter_dir(curpath, history=history)
+                    break
         if cwd != self.thisdir:
             if remember:
                 self.bookmarks.remember(cwd)


### PR DESCRIPTION
This shell feature allows one to cd directly to remote directories located
in paths defined in the variable. Allow handling of such variable in ranger.
Compatible with: bash, ksh, zsh, csh, and possibly others.
