### PR TITLE
added MATE edition of image and PDF viewer

### DIFF
--- a/ranger/config/rifle.conf
+++ b/ranger/config/rifle.conf
@@ -133,6 +133,7 @@ mime ^video, terminal, !X, has mplayer   = mplayer -- "$@"
 # Image Viewing:
 #-------------------------------------------
 mime ^image, has eog,    X, flag f = eog -- "$@"
+mime ^image, has eom,    X, flag f = eom -- "$@"
 mime ^image, has sxiv,   X, flag f = sxiv -- "$@"
 mime ^image, has feh,    X, flag f = feh -- "$@"
 mime ^image, has mirage, X, flag f = mirage -- "$@"
@@ -148,6 +149,7 @@ ext pdf, has mupdf,    X, flag f = mupdf -- "$@"
 ext pdf, has apvlv,    X, flag f = apvlv -- "$@"
 ext pdf, has xpdf,     X, flag f = xpdf -- "$@"
 ext pdf, has evince,   X, flag f = evince -- "$@"
+ext pdf, has atril,    X, flag f = atril -- "$@"
 ext pdf, has okular,   X, flag f = okular -- "$@"
 ext pdf, has epdfview, X, flag f = epdfview -- "$@"
 
@@ -160,6 +162,7 @@ ext od[dfgpst]|docx?|sxc|xlsx?|xlt|xlw|gnm|gnumeric, has soffice,     X, flag f 
 ext od[dfgpst]|docx?|sxc|xlsx?|xlt|xlw|gnm|gnumeric, has ooffice,     X, flag f = ooffice "$@"
 
 ext djvu, has evince, X, flag f = evince -- "$@"
+ext djvu, has atril,  X, flag f = atril -- "$@"
 
 #-------------------------------------------
 # Archives


### PR DESCRIPTION
For Linux distributions that use MATE as desktop environment (e.g. Linux Mint): "eom" replaces "eog", "atril" replaces "evince".
