### PR TITLE
fix crash in sha encode of previews

### DIFF
--- a/ranger/core/actions.py
+++ b/ranger/core/actions.py
@@ -828,6 +828,9 @@ class Actions(FileManagerAware, EnvironmentAware, SettingsAware):
         pager = self.ui.get_pager()
         path = file.realpath
 
+        if not path:
+            return None
+
         if self.settings.preview_images and file.image:
             pager.set_image(path)
             return None


### PR DESCRIPTION
When opening certain filetypes, for which Ranger can't render a preview
(they appear as 0 bytes), Ranger will crash on the sha1_encode:

```
    Traceback (most recent call last):
    File "~/ranger/ranger/core/main.py", line 139, in main
        cacheimg = os.path.join(ranger.CACHEDIR, self.sha1_encode(path))
    File "~/ranger/ranger/core/actions.py", line 821, in sha1_encode
        sha1(path.encode('utf-8')).hexdigest()) + '.jpg'
    AttributeError: 'NoneType' object has no attribute 'encode'
```

In the example above, I'm doing something ugly (navigating procfs for a PID with ranger), but it still shouldn't be crashing.

This solves that by checking at the beginning of get_preview() that
`file.realpath` is not None, and returning early if it is None.
