### PR TITLE
Commands "yp", "yd", "yn" now copy to X11 clipboard selection too.

### DIFF
--- a/ranger/config/rc.conf
+++ b/ranger/config/rc.conf
@@ -299,9 +299,9 @@ map g? cd /usr/share/doc/ranger
 map E  edit
 map du shell -p du --max-depth=1 -h --apparent-size
 map dU shell -p du --max-depth=1 -h --apparent-size | sort -rh
-map yp shell -f echo -n %d/%f | xsel -i
-map yd shell -f echo -n %d    | xsel -i
-map yn shell -f echo -n %f    | xsel -i
+map yp shell -f echo -n %d/%f | xsel -i; xsel -o | xsel -i -b
+map yd shell -f echo -n %d    | xsel -i; xsel -o | xsel -i -b
+map yn shell -f echo -n %f    | xsel -i; xsel -o | xsel -i -b
 
 # Filesystem Operations
 map =  chmod


### PR DESCRIPTION
It fixes problem in XFCE environment (for instance), when yanked paths and names can't be inserted with Ctrl+v in gui applications.
