### PR TITLE
Added redrawing when we return to Vim without opening any file

### DIFF
--- a/doc/examples/vim_file_chooser.vim
+++ b/doc/examples/vim_file_chooser.vim
@@ -14,11 +14,13 @@ function! RangeChooser()
     "exec 'silent !ranger --choosefile=' . shellescape(temp)
     exec 'silent !ranger --choosefiles=' . shellescape(temp)
     if !filereadable(temp)
+        redraw!
         " Nothing to read.
         return
     endif
     let names = readfile(temp)
     if empty(names)
+        redraw!
         " Nothing to open.
         return
     endif


### PR DESCRIPTION
Scenario: Using Ranger as file manager for Vim.
Problem: I get blank display in Vim when I return from Ranger without opening any file. Redrawing the screen fixed this for me.
