### PR TITLE
pressing <CR> directly after scout -ek doesn't delete the complete console line anymore

### DIFF
--- a/ranger/config/commands.py
+++ b/ranger/config/commands.py
@@ -1044,11 +1044,11 @@ class scout(Command):
                 self.fm.move(right=1)
 
         if self.KEEP_OPEN in flags and thisdir != self.fm.thisdir:
-             # reopen the console:
-             if not pattern:
-                 self.fm.open_console(self.line)
-             else:
-                 self.fm.open_console(self.line[0:-len(pattern)])
+            # reopen the console:
+            if not pattern:
+                self.fm.open_console(self.line)
+            else:
+                self.fm.open_console(self.line[0:-len(pattern)])
 
         if thisdir != self.fm.thisdir and pattern != "..":
             self.fm.block_input(0.5)


### PR DESCRIPTION
To reproduce the fix: While selecting a folder call scout -ek and press <CR> immediately 
This should dive into the folder while scout is still active, but it will delete the console line
