### PR TITLE
New show_selection_in_titlebar setting

### DIFF
--- a/ranger/config/rc.conf
+++ b/ranger/config/rc.conf
@@ -166,6 +166,9 @@ set cd_bookmarks true
 # disable this feature.
 set preview_max_size 0
 
+# Add the highlighted file to the path in the titlebar
+set show_selection_in_titlebar true
+
 # ===================================================================
 # == Local Options
 # ===================================================================

--- a/ranger/container/settings.py
+++ b/ranger/container/settings.py
@@ -39,6 +39,7 @@ ALLOWED_SETTINGS = {
     'scroll_offset': int,
     'shorten_title': int,
     'show_cursor': bool,  # TODO: not working?
+    'show_selection_in_titlebar': bool,
     'show_hidden_bookmarks': bool,
     'show_hidden': bool,
     'sort_case_insensitive': bool,

--- a/ranger/gui/widgets/titlebar.py
+++ b/ranger/gui/widgets/titlebar.py
@@ -115,7 +115,8 @@ class TitleBar(Widget):
             bar.add(path.basename, clr, directory=path)
             bar.add('/', clr, fixed=True, directory=path)
 
-        if self.fm.thisfile is not None:
+        if self.fm.thisfile is not None and \
+                self.settings.show_selection_in_titlebar:
             bar.add(self.fm.thisfile.basename, 'file')
 
     def _get_right_part(self, bar):


### PR DESCRIPTION
That the selected file is added to the path in the titlebar confused me a lot, so I have added an option to disable this
