### PR TITLE
Fixed runner to use system SHELL env in ':shell' command

### DIFF
--- a/ranger/core/runner.py
+++ b/ranger/core/runner.py
@@ -142,6 +142,10 @@ class Runner(object):
 
         if 'shell' not in popen_kws:
             popen_kws['shell'] = isinstance(action, str)
+        if popen_kws['shell']:
+            # Set default shell for Popen
+            popen_kws['executable'] = os.environ['SHELL']
+
         if 'stdout' not in popen_kws:
             popen_kws['stdout'] = sys.stdout
         if 'stderr' not in popen_kws:


### PR DESCRIPTION
I use zsh with extended globbing, etc, and miss it in ranger -- so there it is.
Variant of spawning subshell for one command a time is too slow, comparing to ':'
