### PR TITLE
Fixed references to doc/HACKING

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ out which program to use for what file type.
 ![screenshot](doc/screenshot.png)
 
 This file describes ranger and how to get it to run.  For instructions on the
-usage, please read the man page.  See doc/HACKING.md for development specific
+usage, please read the man page.  See HACKING.md for development specific
 information.  For configuration, check the files in ranger/config/.  They
 are usually installed to /usr/lib/python*/site-packages/ranger/config/
 and can be obtained with ranger's --copy-config option.  The doc/examples/

--- a/doc/ranger.1
+++ b/doc/ranger.1
@@ -160,7 +160,7 @@ commands and \fI3?\fR for settings.
 .PP
 The \fI\s-1README\s0\fR contains install instructions.
 .PP
-The file \fIdoc/HACKING.md\fR contains guidelines for code modification.
+The file \fIHACKING.md\fR contains guidelines for code modification.
 .PP
 The directory \fIdoc/configs\fR contains configuration files.  They are usually
 installed to \fI/usr/lib/python*/site\-packages/ranger/config\fR and can be

--- a/doc/ranger.pod
+++ b/doc/ranger.pod
@@ -33,7 +33,7 @@ commands and I<3?> for settings.
 
 The F<README> contains install instructions.
 
-The file F<doc/HACKING.md> contains guidelines for code modification.
+The file F<HACKING.md> contains guidelines for code modification.
 
 The directory F<doc/configs> contains configuration files.  They are usually
 installed to F</usr/lib/python*/site-packages/ranger/config> and can be

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ if __name__ == '__main__':
             ('share/doc/ranger',
                 ['README.md',
                  'CHANGELOG',
-                 'doc/HACKING.md',
+                 'HACKING.md',
                  'doc/colorschemes.txt']),
             ('share/doc/ranger/config/colorschemes',
                 _findall('doc/config/colorschemes')),


### PR DESCRIPTION
This patch replaces all references to `doc/HACKING` with `doc/HACKING.md`, to
include the one in `setup.py` that was preventing a successful build. Some
trailing whitespace was incidentally removed.
