### PR TITLE
Allow sxiv_workaround_hook to Work if Command Contains "sxiv "

### DIFF
--- a/ranger/core/fm.py
+++ b/ranger/core/fm.py
@@ -133,7 +133,7 @@ class FM(Actions, SignalDispatcher):
 
             if self.settings.open_all_images and \
                     len(self.thisdir.marked_items) == 0 and \
-                    re.match(r'^(feh|sxiv) ', command):
+                    re.match(r'^.*(feh|sxiv) ', command):
 
                 images = [f.basename for f in self.thisdir.files if f.image]
                 escaped_filenames = " ".join(shell_quote(f) \
@@ -143,12 +143,12 @@ class FM(Actions, SignalDispatcher):
                         "$@" in command:
                     new_command = None
 
-                    if command[0:5] == 'sxiv ':
+                    if 'sxiv ' in command:
                         number = images.index(self.thisfile.basename) + 1
                         new_command = command.replace("sxiv ",
                                 "sxiv -n %d " % number, 1)
 
-                    if command[0:4] == 'feh ':
+                    if 'feh ' in command:
                         new_command = command.replace("feh ",
                             "feh --start-at %s " % \
                             shell_quote(self.thisfile.basename), 1)


### PR DESCRIPTION
Currently the command in the `rifle.conf` must start with "sxiv " for all images in the directory to be opened. My sxiv command for opening images, however, does not start with sxiv and calls another script first. Is there a reason that the command should start with "sxiv " (or "feh ") as opposed to just containing it?
