### PR TITLE
add javascript file type to mime.types and rifle.conf

### DIFF
--- a/ranger/config/rifle.conf
+++ b/ranger/config/rifle.conf
@@ -82,8 +82,8 @@ ext x?html?, has w3m,             terminal = w3m "$@"
 # Define the "editor" for text files as first action
 mime ^text,  label editor = $EDITOR -- "$@"
 mime ^text,  label pager  = "$PAGER" -- "$@"
-!mime ^text, label editor, ext xml|csv|tex|py|pl|rb|sh|php = $EDITOR -- "$@"
-!mime ^text, label pager,  ext xml|csv|tex|py|pl|rb|sh|php = "$PAGER" -- "$@"
+!mime ^text, label editor, ext xml|csv|tex|py|pl|rb|js|sh|php = $EDITOR -- "$@"
+!mime ^text, label pager,  ext xml|csv|tex|py|pl|rb|js|sh|php = "$PAGER" -- "$@"
 
 ext 1                         = man "$1"
 ext s[wmf]c, has zsnes, X     = zsnes "$1"
@@ -98,6 +98,7 @@ name ^[mM]akefile$            = make
 ext py  = python -- "$1"
 ext pl  = perl -- "$1"
 ext rb  = ruby -- "$1"
+ext js  = node -- "$1"
 ext sh  = sh -- "$1"
 ext php = php -- "$1"
 
@@ -188,6 +189,6 @@ label wallpaper, number 13, mime ^image, X = feh --bg-center "$1"
 label wallpaper, number 14, mime ^image, X = feh --bg-fill "$1"
 
 # Define the editor for non-text files + pager as last action
-              !mime ^text, !ext xml|csv|tex|py|pl|rb|sh|php  = ask
-label editor, !mime ^text, !ext xml|csv|tex|py|pl|rb|sh|php  = $EDITOR -- "$@"
-label pager,  !mime ^text, !ext xml|csv|tex|py|pl|rb|sh|php  = "$PAGER" -- "$@"
+              !mime ^text, !ext xml|csv|tex|py|pl|rb|js|sh|php  = ask
+label editor, !mime ^text, !ext xml|csv|tex|py|pl|rb|js|sh|php  = $EDITOR -- "$@"
+label pager,  !mime ^text, !ext xml|csv|tex|py|pl|rb|js|sh|php  = "$PAGER" -- "$@"

--- a/ranger/data/mime.types
+++ b/ranger/data/mime.types
@@ -10,15 +10,17 @@
 #
 ###############################################################################
 
-audio/flac       flac
-audio/musepack   mpc mpp mp+
-audio/ogg        oga ogg spx
-audio/wavpack    wv wvc
+audio/flac              flac
+audio/musepack          mpc mpp mp+
+audio/ogg               oga ogg spx
+audio/wavpack           wv wvc
 
-video/mkv        mkv
-video/webm       webm
-video/flash      flv
-video/ogg        ogv ogm
-video/divx       div divx
+video/mkv               mkv
+video/webm              webm
+video/flash             flv
+video/ogg               ogv ogm
+video/divx              div divx
 
-text/x-ruby      rb
+text/x-ruby             rb
+application/javascript  js
+


### PR DESCRIPTION
ranger will not ask which program to use to open a javascript file anymore, it will use the editor defined by `$EDITOR`
