### PR TITLE
Save tabs on exit and restore when opening ranger

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 /ranger_fm.egg-info
 
 /stuff/*
+.idea

--- a/doc/ranger.pod
+++ b/doc/ranger.pod
@@ -1,5 +1,6 @@
 =head1 NAME
 
+
 ranger - visual file manager
 
 
@@ -910,6 +911,11 @@ Enable this if key combinations with the Alt Key don't work for you.
 =item clear_filters_on_dir_change [bool]
 
 If set to 'true', persistent filters would be cleared upon leaving the directory
+
+=item save_tabs_on_exit [bool]
+
+If set to 'true', all the tabs, except the active, are saved on exit. When opening ranger again, the active tab would
+be the current shell directory and all the other tabs would be reopened.
 
 =back
 

--- a/ranger/config/rc.conf
+++ b/ranger/config/rc.conf
@@ -215,6 +215,9 @@ set clear_filters_on_dir_change false
 # Disable displaying line numbers in main column
 set line_numbers false
 
+# Save tabs on exit
+set save_tabs_on_exit false
+
 # Enable scroll wrapping - moving down while on the last item will wrap around to
 # the top and vice versa.
 set wrap_scroll false

--- a/ranger/container/settings.py
+++ b/ranger/container/settings.py
@@ -81,6 +81,7 @@ ALLOWED_SETTINGS = {
     'wrap_scroll': bool,
     'xterm_alt_key': bool,
     'clear_filters_on_dir_change': bool,
+    'save_tabs_on_exit': bool,
 }
 
 ALLOWED_VALUES = {

--- a/ranger/core/fm.py
+++ b/ranger/core/fm.py
@@ -402,3 +402,14 @@ class FM(Actions,  # pylint: disable=too-many-instance-attributes
                     fobj.write(self.thisdir.path)
             self.bookmarks.remember(self.thisdir)
             self.bookmarks.save()
+
+            if self.settings.save_tabs_on_exit:
+                tabs_file_path = self.confpath('tabs')
+                if len(self.tabs) > 1:
+                    # Don't save active tab since launching ranger in a
+                    # directory changes the active tab
+                    not_active_tabs = \
+                        [self.tabs[i].path for i in self.tabs if i != self.current_tab]
+                    open(tabs_file_path, 'w').write("\n".join(not_active_tabs))
+                elif os.path.exists(tabs_file_path):
+                    os.remove(tabs_file_path)

--- a/ranger/core/main.py
+++ b/ranger/core/main.py
@@ -90,6 +90,20 @@ def main(
         args.selectfile = os.path.abspath(args.selectfile)
         args.paths.insert(0, os.path.dirname(args.selectfile))
 
+    fm = FM()
+    FileManagerAware.fm_set(fm)
+    load_settings(fm, args.clean)
+
+    tab_config_exists = os.path.exists(fm.confpath('tabs'))
+    save_tabs_on_exit_enabled = fm.settings.save_tabs_on_exit
+    if save_tabs_on_exit_enabled and len(args.paths) <= 1 and tab_config_exists:
+        # if ranger is opened with no paths, put current directory as first tab
+        # otherwise, append the session tabs to it
+        if len(args.paths) == 0:
+            args.paths.insert(0, '.')
+
+        args.paths += open(fm.confpath('tabs'), 'r').read().splitlines()
+
     paths = args.paths or ['.']
     paths_inaccessible = []
     for path in paths:


### PR DESCRIPTION
Fixes #502. 

The logic is as following:
- On exit, if more than 1 tab open, save all the tabs, except active, to file
- When opening ranger, open a tab for current directory (or the given target) AND for each line in tab file create a new tab. 
- If ranger is opened with more than 1 target (i.e. user wants to open ranger with multiple tabs from command line) then tabs file is ignored
