### PR TITLE
Change ambiguous variable name 'l' to more meaningful 'line'

### DIFF
--- a/ranger/core/loader.py
+++ b/ranger/core/loader.py
@@ -211,10 +211,10 @@ class CommandLoader(Loadable, SignalDispatcher, FileManagerAware):
                 except select.error:
                     sleep(0.03)
             if not self.silent:
-                for l in process.stderr.readlines():
+                for line in process.stderr.readlines():
                     if py3:
-                        l = safeDecode(l)
-                    self.fm.notify(l, bad=True)
+                        line = safeDecode(line)
+                    self.fm.notify(line, bad=True)
             if self.read:
                 read = process.stdout.read()
                 if py3:


### PR DESCRIPTION
In some fonts, character 'l' are indistinguishable from the numeral one. So better use 'L' instead.