### PR TITLE
Unnecessary list literal - rewrite as a set literal.

### DIFF
--- a/doc/tools/convert_papermode_to_metadata.py
+++ b/doc/tools/convert_papermode_to_metadata.py
@@ -64,7 +64,7 @@ def replace(source, target):
         print("Skipping writing `%s' due to a lack of data" % target)
 
 if __name__ == "__main__":
-    if set(['--help', '-h']) & set(sys.argv[1:]):
+    if {'--help', '-h'} & set(sys.argv[1:]):
         print(__doc__.strip())
     else:
         replace(".paperinfo", ".metadata.json")

--- a/ranger/ext/direction.py
+++ b/ranger/ext/direction.py
@@ -71,10 +71,10 @@ class Direction(dict):
         return (right > 0) - (right < 0)
 
     def vertical(self):
-        return set(self) & set(['up', 'down'])
+        return set(self) & {'up', 'down'}
 
     def horizontal(self):
-        return set(self) & set(['left', 'right'])
+        return set(self) & {'left', 'right'}
 
     def pages(self):
         return 'pages' in self and self['pages']


### PR DESCRIPTION
It's unnecessary to use a list literal within a call to `set` since there is literal syntax for these types. 