### PR TITLE
Do not enable line_numbers when it is not set to any value

### DIFF
--- a/ranger/container/settings.py
+++ b/ranger/container/settings.py
@@ -246,6 +246,12 @@ class Settings(SignalDispatcher, FileManagerAware):
     def _raw_set_with_signal(self, signal):
         self._raw_set(signal.setting, signal.value, signal.path, signal.tags)
 
+    def valid_value(self, name):
+        if self._settings[name] in ALLOWED_VALUES[name]:
+            return True
+        else:
+            return False
+
 
 class LocalSettings():
     def __init__(self, path, parent):

--- a/ranger/gui/widgets/browsercolumn.py
+++ b/ranger/gui/widgets/browsercolumn.py
@@ -290,7 +290,7 @@ class BrowserColumn(Pager):
             # Check if current line has not already computed and cached
             if key in drawn.display_data:
                 # Recompute line numbers because they can't be reliably cached.
-                if self.main_column and self.settings.line_numbers != 'false':
+                if self.main_column and self.settings.valid_value('line_numbers') and self.settings.line_numbers != 'false':
                     line_number_text = self._format_line_number(linum_format,
                                                                 i,
                                                                 selected_i)
@@ -315,7 +315,7 @@ class BrowserColumn(Pager):
             space = self.wid
 
             # line number field
-            if self.settings.line_numbers != 'false':
+            if self.settings.valid_value('line_numbers') and self.settings.line_numbers != 'false':
                 if self.main_column and space - linum_text_len > 2:
                     line_number_text = self._format_line_number(linum_format,
                                                                 i,


### PR DESCRIPTION
Currently if the option `line_numbers` is not set to any value whatsoever in the config, it gets enabled by default. It's due to checking if it's `!= 'false'` which is true if it's an empty string. It seems `settings.ALLOWED_VALUES` is not enforced anywhere so I've added a helper function that checks for it and added it to these value comparisons. I do not consider it a final solution (manually calling `valid_value()` is ugly and still prone to bugs) but it's a good start.
