### PR TITLE
Add missing trailing commas

### DIFF
--- a/ranger/container/settings.py
+++ b/ranger/container/settings.py
@@ -64,7 +64,7 @@ ALLOWED_SETTINGS = {
     'vcs_backend_hg': str,
     'vcs_backend_svn': str,
     'xterm_alt_key': bool,
-    'clear_filters_on_dir_change': bool
+    'clear_filters_on_dir_change': bool,
 }
 
 ALLOWED_VALUES = {

--- a/ranger/ext/img_display.py
+++ b/ranger/ext/img_display.py
@@ -28,7 +28,7 @@ W3MIMGDISPLAY_PATHS = [
     '/usr/lib/w3m/w3mimgdisplay',
     '/usr/libexec/w3m/w3mimgdisplay',
     '/usr/lib64/w3m/w3mimgdisplay',
-    '/usr/libexec64/w3m/w3mimgdisplay'
+    '/usr/libexec64/w3m/w3mimgdisplay',
 ]
 
 


### PR DESCRIPTION
Fixed according to:
https://github.com/ranger/ranger/pull/600#issuecomment-228470987
> The first two would make sense in my opinion. Especially the one in settings.py as some dicts there already have trailing commas. 