### PR TITLE
Document -r flag for scout command

### DIFF
--- a/doc/ranger.pod
+++ b/doc/ranger.pod
@@ -1220,6 +1220,7 @@ influence its behaviour:
  -m = mark the matching files after pressing enter
  -M = unmark the matching files after pressing enter
  -p = permanent filter: hide non-matching files after pressing enter
+ -r = interpret pattern as a regular expression pattern
  -s = smart case; like -i unless pattern contains upper case letters
  -t = apply filter and search pattern as you type
  -v = inverts the match

--- a/ranger/config/commands.py
+++ b/ranger/config/commands.py
@@ -1131,6 +1131,7 @@ class scout(Command):
     -m = mark the matching files after pressing enter
     -M = unmark the matching files after pressing enter
     -p = permanent filter: hide non-matching files after pressing enter
+    -r = interpret pattern as a regular expression pattern
     -s = smart case; like -i unless pattern contains upper case letters
     -t = apply filter and search pattern as you type
     -v = inverts the match


### PR DESCRIPTION
The default `rc.conf` uses `scout` with the `-r` flag in several places, but the flag isn't documented.