### PR TITLE
Refactor and improve the TERMCMD handling

### DIFF
--- a/ranger/config/commands.py
+++ b/ranger/config/commands.py
@@ -493,14 +493,8 @@ class terminal(Command):
     Spawns an "x-terminal-emulator" starting in the current directory.
     """
     def execute(self):
-        import os
-        from ranger.ext.get_executables import get_executables
-        command = os.environ.get('TERMCMD', os.environ.get('TERM'))
-        if command not in get_executables():
-            command = 'x-terminal-emulator'
-        if command not in get_executables():
-            command = 'xterm'
-        self.fm.run(command, flags='f')
+        from ranger.ext.get_executables import get_term
+        self.fm.run(get_term(), flags='f')
 
 
 class delete(Command):

--- a/ranger/core/runner.py
+++ b/ranger/core/runner.py
@@ -25,7 +25,7 @@ t: run application in a new terminal window
 import os
 import sys
 from subprocess import Popen, PIPE
-from ranger.ext.get_executables import get_executables
+from ranger.ext.get_executables import get_executables, get_term
 from ranger.ext.popen_forked import Popen_forked
 
 
@@ -194,11 +194,7 @@ class Runner(object):
         if 't' in context.flags:
             if 'DISPLAY' not in os.environ:
                 return self._log("Can not run with 't' flag, no display found!")
-            term = os.environ.get('TERMCMD', os.environ.get('TERM'))
-            if term not in get_executables():
-                term = 'x-terminal-emulator'
-            if term not in get_executables():
-                term = 'xterm'
+            term = get_term()
             if isinstance(action, str):
                 action = term + ' -e ' + action
             else:

--- a/ranger/ext/get_executables.py
+++ b/ranger/ext/get_executables.py
@@ -4,6 +4,7 @@
 from stat import S_IXOTH, S_IFREG
 from ranger.ext.iter_tools import unique
 from os import listdir, environ, stat
+import shlex
 
 
 _cached_executables = None
@@ -44,3 +45,16 @@ def get_executables_uncached(*paths):
             if filestat.st_mode & (S_IXOTH | S_IFREG):
                 executables.add(item)
     return executables
+
+
+def get_term():
+    """Get the user terminal executable name.
+
+    Either $TERMCMD, $TERM, "x-terminal-emulator" or "xterm", in this order.
+    """
+    command = environ.get('TERMCMD', environ.get('TERM'))
+    if shlex.split(command)[0] not in get_executables():
+        command = 'x-terminal-emulator'
+        if command not in get_executables():
+            command = 'xterm'
+    return command


### PR DESCRIPTION
Now only the first token of TERMCMD needs to exist in PATH. Previously
the whole value was checked, which could contain additional parameters.

The check and term guessing were performed in two places. Now it's done
by the get_term() function to reduce the code duplication. In that
function the second check was indented one level deeper (relative to the
original code). Keeping both checks on the same level, while visually
pleasing, was conveying the wrong message. One never wants to perform
the second check if the first one fails. Nesting shouldn't be a problem:
if the nesting will need to be any deeper than this, this code will need
to be refactored anyway.

Fixes #613.