### PR TITLE
Update AUTHORS

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -2,27 +2,27 @@ Copyright 2009-2016  Roman Zimbelmann <hut@hut.pm>
 Copyright 2010  David Barnett <davidbarnett2@gmail.com>
 Copyright 2010  Lucas de Vries <lucas@glacicle.org>
 Copyright 2010  Sitaram Chamarty <sitaram@atc.tcs.com>
-Copyright 2011-2012  Abdó Roig-Maranges <abdo.roig@gmail.com>
-Copyright 2011-2012  M Rawash <mrawash@gmail.com>
 Copyright 2011  David Pugnasse <david.pugnasse@gmail.com>
 Copyright 2011  ornicar <thibault.duplessis@gmail.com>
-Copyright 2012  joe <joebodo@gmail.com>
+Copyright 2011-2012  Abdó Roig-Maranges <abdo.roig@gmail.com>
+Copyright 2011-2012  M Rawash <mrawash@gmail.com>
 Copyright 2012  Serge Broslavsky <serge.broslavsky@gmail.com>
-Copyright 2013-2014  GermainZ <germanosz@gmail.com>
+Copyright 2012  joe <joebodo@gmail.com>
 Copyright 2013  Emanuel Guevel
 Copyright 2013  Joseph Tannhuber <sepp.tannhuber@yahoo.de>
+Copyright 2013-2014  GermainZ <germanosz@gmail.com>
 Copyright 2014  Célestin Matte <celestin.matte@gmail.com>
 Copyright 2014  Milan Svoboda <milan.svoboda@centrum.cz>
 Copyright 2014  rukai <rubickent@gmail.com>
 Copyright 2015  Alexander Buddenbrock <a.buddenbrock@ish.de>
-Copyright 2015  anekos <anekos@snca.net>
-Copyright 2015  bastorran
 Copyright 2015  Delisa Mason <iskanamagus@gmail.com>
 Copyright 2015  No Suck <admin@nosuck.org>
 Copyright 2015  Randy Nance <randynobx@gmail.com>
-Copyright 2015  Wojciech Siewierski <wojciech.siewierski@onet.pl>
 Copyright 2015  Ryan Burns <rdburns@gmail.com>
+Copyright 2015  anekos <anekos@snca.net>
+Copyright 2015  bastorran
 Copyright 2015  nfnty <git@nfnty.se>
+Copyright 2015-2016  Wojciech Siewierski <wojciech.siewierski@onet.pl>
 
 Ideally, all contributors of non-trivial code are named here to the extent that
 a name and e-mail address is available.  Please write a mail to hut@hut.pm if


### PR DESCRIPTION
Prolong Vifon Copyright to 2016, make list in alphabetical order.