### PR TITLE
Fix map of open_with command

### DIFF
--- a/ranger/config/rc.conf
+++ b/ranger/config/rc.conf
@@ -259,7 +259,7 @@ map !  console shell%space
 map @  console -p6 shell  %%s
 map #  console shell -p%space
 map s  console shell%space
-map r  chain draw_possible_programs; console open_with%space
+map r  chain draw_possible_programs; console open_with%%space
 map f  console find%space
 map cd console cd%space
 


### PR DESCRIPTION
When I hit the `r` key, there was no white space after the prompt `open_with`...

It can be solved by simply adding one more `%` before `%space` to escape.

related to: #293 