### PR TITLE
Fix full folder size being shown incorrectly

### DIFF
--- a/ranger/gui/widgets/statusbar.py
+++ b/ranger/gui/widgets/statusbar.py
@@ -258,7 +258,7 @@ class StatusBar(Widget):
             right.add("', ", "space")
 
         if target.marked_items:
-            if len(target.marked_items) == len(target.files):
+            if len(target.marked_items) == target.size:
                 right.add(human_readable(target.disk_usage, separator=''))
             else:
                 sumsize = sum(f.size for f in target.marked_items if not


### PR DESCRIPTION
The full folder size was previously being shown when all files currently displayed were being shown, however in combination with filtering and hidden files this could make the size totally wrong.