### PR TITLE
get_cumulative_size now also calculates the cumulated items count of …

### DIFF
--- a/ranger/config/rc.conf
+++ b/ranger/config/rc.conf
@@ -428,6 +428,7 @@ map <a-9>     tab_open 9
 map or set sort_reverse!
 map oz set sort=random
 map os chain set sort=size;      set sort_reverse=False
+map oi chain set sort=itemcount; set sort_reverse=False
 map ob chain set sort=basename;  set sort_reverse=False
 map on chain set sort=natural;   set sort_reverse=False
 map om chain set sort=mtime;     set sort_reverse=False
@@ -437,6 +438,7 @@ map ot chain set sort=type;      set sort_reverse=False
 map oe chain set sort=extension; set sort_reverse=False
 
 map oS chain set sort=size;      set sort_reverse=True
+map oI chain set sort=itemcount; set sort_reverse=True
 map oB chain set sort=basename;  set sort_reverse=True
 map oN chain set sort=natural;   set sort_reverse=True
 map oM chain set sort=mtime;     set sort_reverse=True

--- a/ranger/container/fsobject.py
+++ b/ranger/container/fsobject.py
@@ -22,7 +22,7 @@ from ranger.core.shared import FileManagerAware, SettingsAware
 from ranger.ext.shell_escape import shell_escape
 from ranger.ext.spawn import spawn
 from ranger.ext.lazy_property import lazy_property
-from ranger.ext.human_readable import human_readable
+from ranger.ext.human_readable import human_readable, format_count
 
 if hasattr(str, 'maketrans'):
     maketrans = str.maketrans
@@ -75,6 +75,9 @@ class FileSystemObject(FileManagerAware, SettingsAware):
     video) = (False,) * 21
 
     size = 0
+    count = 1
+
+    _cumulative_size_count_calculated = False
 
     vcsstatus = None
     vcsremotestatus = None
@@ -175,7 +178,8 @@ class FileSystemObject(FileManagerAware, SettingsAware):
         """Used in garbage-collecting.  Override in Directory"""
 
     def look_up_cumulative_size(self):
-        pass  # normal files have no cumulative size
+        self._cumulative_size_count_calculated = True
+        self.load()
 
     def set_mimetype(self):
         """assign attributes such as self.video according to the mimetype"""
@@ -289,6 +293,8 @@ class FileSystemObject(FileManagerAware, SettingsAware):
             if new_stat:
                 self.size = new_stat.st_size
                 self.infostring = ' ' + human_readable(self.size)
+                if self._cumulative_size_count_calculated:
+                    self.infostring += ' ' + format_count(None)
             else:
                 self.size = 0
                 self.infostring = '?'

--- a/ranger/ext/human_readable.py
+++ b/ranger/ext/human_readable.py
@@ -1,6 +1,13 @@
 # This file is part of ranger, the console file manager.
 # License: GNU GPL version 3, see the file "AUTHORS" for details.
 
+def format_count(cnt, width=6):
+    if cnt is None:
+        return ' ' * width
+    elif cnt >= 100000:
+        return '>100k'.rjust(width, " ")
+    else:
+        return '{{:>{:d},}}'.format(width).format(cnt)
 
 def human_readable(byte, separator=' '):
     """Convert a large number of bytes to an easily readable format.


### PR DESCRIPTION
New feature: when calculating the cumulative size of selected directories, calculate the cumulative items count (files + directories) too.

Items count are displayed like `ncdu`, so that we have a fixed-width column and everything is kept aligned.

Added sorting option `oi` and `oI`.
Slightly adapted the statusbar layout.

I could rename all the methods to be `get_cumulative_size_count` but in this case I should also change config options like `autoupdate_cumulative_size`. This would break backward compatibility and I'm not sure whether it makes sense to do it now.