### PR TITLE
add hash as an escaped character in shell commands

### DIFF
--- a/ranger/ext/shell_escape.py
+++ b/ranger/ext/shell_escape.py
@@ -3,7 +3,7 @@
 
 """Functions to escape metacharacters of arguments for shell commands."""
 
-META_CHARS = (' ', "'", '"', '`', '&', '|', ';',
+META_CHARS = (' ', "'", '"', '`', '&', '|', ';', '#',
         '$', '!', '(', ')', '[', ']', '<', '>', '\t')
 UNESCAPABLE = set(map(chr, list(range(9)) + list(range(10, 32))
         + list(range(127, 256))))


### PR DESCRIPTION
This is required for shell commands to succeed with filenames that
start with the hash character. The 'mv' command invoked by 'bulkrename',
for instance, will fail with such files unless hashes are escaped.