### PR TITLE
Fix preview column displayed unintentionally

### DIFF
--- a/ranger/gui/widgets/view_miller.py
+++ b/ranger/gui/widgets/view_miller.py
@@ -256,9 +256,8 @@ class ViewMiller(ViewBase):
 
         # Show the preview column when it has a preview but has
         # been hidden (e.g. because of padding_right = False)
-        if not self.pager.visible and not self.columns[-1].visible and \
-        self.columns[-1].target and self.columns[-1].target.is_directory \
-        or self.columns[-1].has_preview() and not self.pager.visible:
+        if not self.columns[-1].visible and self.columns[-1].has_preview() \
+        and not self.pager.visible:
             self.columns[-1].visible = True
 
         if self.preview and self.is_collapsed != self._collapse():


### PR DESCRIPTION
The incorrect part of the conditional checks whether a folder is currently focused but does not check if the setting `preview_directories` is `True`. This condition is already covered in the `self.columns[-1].has_preview()` function thus can be removed from the conditional.