### PR TITLE
Change how column widths are calculated

### DIFF
--- a/ranger/gui/widgets/view_multipane.py
+++ b/ranger/gui/widgets/view_multipane.py
@@ -42,11 +42,11 @@ class ViewMultipane(ViewBase):
 
     def resize(self, y, x, hei, wid):
         ViewBase.resize(self, y, x, hei, wid)
-        column_width = int(float(wid) / len(self.columns))
+        column_width = int((float(wid) - len(self.columns) + 1) / len(self.columns))
         left = 0
         top = 0
         for i, column in enumerate(self.columns):
-            column.resize(top, left, hei, max(1, column_width - 1))
-            left += column_width
+            column.resize(top, left, hei, max(1, column_width))
+            left += column_width + 1
             column.need_redraw = True
         self.need_redraw = True


### PR DESCRIPTION
By changing it, this means the columns will use the entire width if the geometry allows for it.

Instead of using a hard offset of one for the width of the column, this just changes the next position of the column to be one further than the column width.
