### PR TITLE
Fix cursor being lost when changing viewmodes

### DIFF
--- a/ranger/gui/displayable.py
+++ b/ranger/gui/displayable.py
@@ -211,6 +211,7 @@ class DisplayableContainer(Displayable):
     New methods:
 
     add_child(object) -- add the object to the container.
+    replace_child(old_obj, new_obj) -- replaces old object with new object.
     remove_child(object) -- remove the object from the container.
 
     New attributes:
@@ -289,6 +290,11 @@ class DisplayableContainer(Displayable):
             obj.parent.remove_child(obj)
         self.container.append(obj)
         obj.parent = self
+
+    def replace_child(self, old_obj, new_obj):
+        """Replace the old object with the new instance in the container."""
+        self.container[self.container.index(old_obj)] = new_obj
+        new_obj.parent = self
 
     def remove_child(self, obj):
         """Remove the object from the container."""

--- a/ranger/gui/ui.py
+++ b/ranger/gui/ui.py
@@ -437,18 +437,18 @@ class UI(DisplayableContainer):
         if value in self.ALLOWED_VIEWMODES:
             if self._viewmode != value:
                 self._viewmode = value
-                resize = False
+                new_browser = self._viewmode_to_class(value)(self.win)
+
                 if hasattr(self, 'browser'):
                     old_size = self.browser.y, self.browser.x, self.browser.hei, self.browser.wid
-                    self.remove_child(self.browser)
+                    self.replace_child(self.browser, new_browser)
                     self.browser.destroy()
-                    resize = True
+                    new_browser.resize(*old_size)
+                else:
+                    self.add_child(new_browser)
 
-                self.browser = self._viewmode_to_class(value)(self.win)
+                self.browser = new_browser
                 self.redraw_window()
-                self.add_child(self.browser)
-                if resize:
-                    self.browser.resize(*old_size)
         else:
             raise ValueError("Attempting to set invalid viewmode `%s`, should "
                     "be one of `%s`." % (value, "`, `".join(self.ALLOWED_VIEWMODES)))


### PR DESCRIPTION
This results from finalize being called in order for the widgets. Previously when ranger changed viewmodes, it would delete then readd the widget object which meant that the finalize for the viewmode was called last instead of before console, which meant the finalize of the viewmode was setting
and overriding the cursor position.

Fixes #639.