### PR TITLE
Added preview option for OpenDocument Text files using odt2txt

### DIFF
--- a/ranger/data/scope.sh
+++ b/ranger/data/scope.sh
@@ -80,6 +80,9 @@ case "$extension" in
     # BitTorrent Files
     torrent)
         try transmission-show "$path" && { dump | trim; exit 5; } || exit 1;;
+    # ODT Files
+    odt|ods|odp|sxw)
+        try odt2txt "$path" && { dump | trim; exit 5; } || exit 1;;
     # HTML Pages:
     htm|html|xhtml)
         try w3m    -dump "$path" && { dump | trim | fmt -s -w $width; exit 4; }


### PR DESCRIPTION
Added a line to scope.sh for OpenDocument Text files (odt, ods, odp, sxw). I've used it for quiet some time and the preview seems to work. However I'm not sure about the exit code(s).

The preview is generated by [odt2txt](https://github.com/dstosberg/odt2txt). It is contained in the Arch Linux community repository as well as in the repositories of Ubuntu, Debian, Fedora, OpenSuse and probably more distributions.

Tell me what you think.