### PR TITLE
Add correct path to ranger on OS X

### DIFF
--- a/examples/bash_automatic_cd.sh
+++ b/examples/bash_automatic_cd.sh
@@ -6,6 +6,8 @@
 # the last visited one after ranger quits.
 # To undo the effect of this function, you can type "cd -" to return to the
 # original directory.
+# 
+# On OS X 10 or later, replace `usr/bin/ranger` with `/usr/local/bin/ranger`.
 
 function ranger-cd {
     tempfile="$(mktemp -t tmp.XXXXXX)"


### PR DESCRIPTION
Spent a while trying to figure out why the example script in `bash_automatic_cd.sh` didn't work on my Mac (OS X 10.11.6). Running `which ranger` on my machine produces `/usr/local/bin/ranger`, not `/usr/bin/ranger` (which I'm guessing applies to linux). Versions I'm using:
- ranger-stable 1.7.2
- Python 2.7.10
