### PR TITLE
fixed 7z crash

### DIFF
--- a/ranger/config/rifle.conf
+++ b/ranger/config/rifle.conf
@@ -182,7 +182,8 @@ ext xcf,                    X, flag f = gimp -- "$@"
 # Archives
 #-------------------------------------------
 # This requires atool
-ext 7z|ace|ar|arc|bz2?|cab|cpio|cpt|deb|dgc|dmg|gz,  has als     = als -- "$@" | "$PAGER"
+ext 7z, has 7z = 7z -p l "$@" | "$PAGER"
+ext ace|ar|arc|bz2?|cab|cpio|cpt|deb|dgc|dmg|gz,  has als     = als -- "$@" | "$PAGER"
 ext iso|jar|msi|pkg|rar|shar|tar|tgz|xar|xpi|xz|zip, has als     = als -- "$@" | "$PAGER"
 ext 7z|ace|ar|arc|bz2?|cab|cpio|cpt|deb|dgc|dmg|gz,  has aunpack = aunpack -- "$@"
 ext iso|jar|msi|pkg|rar|shar|tar|tgz|xar|xpi|xz|zip, has aunpack = aunpack -- "$@"

--- a/ranger/data/scope.sh
+++ b/ranger/data/scope.sh
@@ -65,7 +65,7 @@ fi
 
 case "$extension" in
     # Archive extensions:
-    7z|a|ace|alz|arc|arj|bz|bz2|cab|cpio|deb|gz|jar|lha|lz|lzh|lzma|lzo|\
+    a|ace|alz|arc|arj|bz|bz2|cab|cpio|deb|gz|jar|lha|lz|lzh|lzma|lzo|\
     rpm|rz|t7z|tar|tbz|tbz2|tgz|tlz|txz|tZ|tzo|war|xpi|xz|Z|zip)
         try als "$path" && { dump | trim; exit 0; }
         try acat "$path" && { dump | trim; exit 3; }
@@ -73,6 +73,8 @@ case "$extension" in
         exit 1;;
     rar)
         try unrar -p- lt "$path" && { dump | trim; exit 0; } || exit 1;;
+    7z)
+	try 7z -p l "$path" && { dump | trim; exit 0; } || exit 1;;
     # PDF documents:
     pdf)
         try pdftotext -l 10 -nopgbrk -q "$path" - && \


### PR DESCRIPTION
When 7zip archives created with -mhe=on (also known as "encrypt file list") are selected by ranger, the application crashes, because als (or rather 7z) promps for a password to list the files in the preview.

To prevent this, the 7z command can use the -p option with an empty string, preventing the preview for 7z archives with encrypted file lists.
The same applies when such archives are opened, causing an error about a wrong password instead. Archives without the -mhe=on option are not affected by this.

Alternatively "als -O-p" can be used to pass the option to 7z instead of using it directly.
