### PR TITLE
fix issue #695: FileInfo Linemode crashes Ranger on Python 2.6

### DIFF
--- a/ranger/core/linemode.py
+++ b/ranger/core/linemode.py
@@ -99,7 +99,7 @@ class FileInfoLinemode(LinemodeBase):
         if not file.is_directory:
             from subprocess import Popen, PIPE, CalledProcessError
             try:
-                process = Popen(stdout=PIPE, "file", "-bL", file.path)
+                process = Popen(["file", "-bL", file.path], stdout=PIPE)
                 output, unused_err = process.communicate()
                 retcode = process.poll()
                 if retcode:

--- a/ranger/core/linemode.py
+++ b/ranger/core/linemode.py
@@ -97,9 +97,16 @@ class FileInfoLinemode(LinemodeBase):
 
     def infostring(self, file, metadata):
         if not file.is_directory:
-            from subprocess import check_output, CalledProcessError
+            from subprocess import Popen, PIPE, CalledProcessError
             try:
-                fileinfo = check_output(["file", "-bL", file.path]).strip()
+                process = Popen(stdout=PIPE, "file", "-bL", file.path)
+                output, unused_err = process.communicate()
+                retcode = process.poll()
+                if retcode:
+                    error = subprocess.CalledProcessError(retcode, "file")
+                    error.output = output
+                    raise error
+                fileinfo = output.strip()
             except CalledProcessError:
                 return "unknown"
             if sys.version_info[0] >= 3:

--- a/ranger/ext/vcs/vcs.py
+++ b/ranger/ext/vcs/vcs.py
@@ -119,7 +119,7 @@ class Vcs(object):  # pylint: disable=too-many-instance-attributes
         with open(os.devnull, 'w') as devnull:
             try:
                 if catchout:
-                    process = subprocess.Popen(stdout=subprocess.PIPE, cmd, cwd=path, stderr=devnull)
+                    process = subprocess.Popen(cmd, cwd=path, stdout=subprocess.PIPE, stderr=devnull)
                     output, unused_err = process.communicate()
                     retcode = process.poll()
                     if retcode:

--- a/ranger/ext/vcs/vcs.py
+++ b/ranger/ext/vcs/vcs.py
@@ -119,7 +119,13 @@ class Vcs(object):  # pylint: disable=too-many-instance-attributes
         with open(os.devnull, 'w') as devnull:
             try:
                 if catchout:
-                    output = subprocess.check_output(cmd, cwd=path, stderr=devnull)
+                    process = subprocess.Popen(stdout=subprocess.PIPE, cmd, cwd=path, stderr=devnull)
+                    output, unused_err = process.communicate()
+                    retcode = process.poll()
+                    if retcode:
+                        error = subprocess.CalledProcessError(retcode, cmd)
+                        error.output = output
+                        raise error
                     if retbytes:
                         return output
                     else:


### PR DESCRIPTION
- replaced calls to subprocess.check_output by code downported from
  Python 2.7
