### PR TITLE
Remove sxiv_workaround_hook function

### DIFF
--- a/ranger/core/fm.py
+++ b/ranger/core/fm.py
@@ -138,6 +138,7 @@ class FM(Actions, SignalDispatcher):
         # 1. set open_all_images to true
         # 2. ensure no files are marked
         # 3. call rifle with a command that starts with "sxiv " or "feh "
+        """
         def sxiv_workaround_hook(command):
             import re
             from ranger.ext.shell_escape import shell_quote
@@ -181,6 +182,7 @@ class FM(Actions, SignalDispatcher):
             return old_preprocessing_hook(command)
 
         self.rifle.hook_command_preprocessing = sxiv_workaround_hook
+        """
 
         def mylogfunc(text):
             self.notify(text, bad=True)


### PR DESCRIPTION
I'm getting an error while I'm trying to open image with _sxiv_ in a folder with thousands image files. The error is: 
> Argument list is too long

After getting this one I'm not able to quit from ranger by pressing _q_ key.
Also, if I close the terminal with ranger after this error, ranger's process uses a 100% of one core of the CPU in the background.

Without this function (exactly as in this commit) everything works well.

Log with ```--debug``` option:
```
Traceback (most recent call last):
  File "ranger/ranger/core/main.py", line 145, in main
    fm.loop()
  File "ranger/ranger/core/fm.py", line 368, in loop
    ui.handle_input()
  File "ranger/ranger/gui/ui.py", line 230, in handle_input
    self.handle_key(key)
  File "ranger/ranger/gui/ui.py", line 166, in handle_key
    self.press(key)
  File "ranger/ranger/gui/ui.py", line 181, in press
    quantifier=keybuffer.quantifier)
  File "ranger/ranger/core/actions.py", line 221, in execute_console
    cmd_class(string, quantifier=quantifier).execute()
  File "ranger/ranger/api/commands.py", line 416, in execute
    return self._based_function(*args, **keywords)
  File "ranger/ranger/core/actions.py", line 444, in move
    result = self.execute_file(selection, mode=mode)
  File "ranger/ranger/core/actions.py", line 401, in execute_file
    return self.rifle.execute(filenames, mode, label, flags, None)
  File "ranger/ranger/ext/rifle.py", line 371, in execute
    Popen_forked(cmd, env=self.hook_environment(os.environ))
  File "ranger/ranger/ext/popen_forked.py", line 21, in Popen_forked
    subprocess.Popen(*args, **kwargs)
  File "/usr/lib/python2.7/subprocess.py", line 711, in __init__
    errread, errwrite)
  File "/usr/lib/python2.7/subprocess.py", line 1343, in _execute_child
    raise child_exception
OSError: [Errno 7] Argument list too long
```
Version of Python: 2.7.

Please remove this function or do something with it.
Thanks.