### PR TITLE
Cleaned up exit routine code

### DIFF
--- a/ranger/gui/ui.py
+++ b/ranger/gui/ui.py
@@ -164,6 +164,8 @@ class UI(  # pylint: disable=too-many-instance-attributes,too-many-public-method
 
     def destroy(self):
         """Destroy all widgets and turn off curses"""
+        if 'vcsthread' in self.__dict__:
+            self.vcsthread.stop()
         DisplayableContainer.destroy(self)
 
         # Restore tmux setting `automatic-rename`


### PR DESCRIPTION
The exit routine code is executed on every program run, thus
I consider it pretty important.
I found out that this part of the code was very confuse and complex,
thus very difficult to modify.

Moreover the message and the exit code brought up with the
`sys.exit` function or the `SystemExit` exception were completely ignored.
In fact the `return` statement into the exception handler was bypassed by
the `finally` block.

I made a little bit of refracotring and I hope that this will make easier to
mantain this part of the code.

The second commit is a simple pep8 error fix