### PR TITLE
Fixed trailing space bug in config parsing.

### DIFF
--- a/ranger/core/actions.py
+++ b/ranger/core/actions.py
@@ -346,7 +346,7 @@ class Actions(FileManagerAware, SettingsAware):
         filename = os.path.expanduser(filename)
         with open(filename, 'r') as f:
             for line in f:
-                line = line.lstrip().rstrip(" \r\n")
+                line = line.strip(" \r\n")
                 if line.startswith("#") or not line.strip():
                     continue
                 try:

--- a/ranger/core/actions.py
+++ b/ranger/core/actions.py
@@ -346,7 +346,7 @@ class Actions(FileManagerAware, SettingsAware):
         filename = os.path.expanduser(filename)
         with open(filename, 'r') as f:
             for line in f:
-                line = line.lstrip().rstrip("\r\n")
+                line = line.lstrip().rstrip(" \r\n")
                 if line.startswith("#") or not line.strip():
                     continue
                 try:


### PR DESCRIPTION
Fixed the trailing space in config bug.
Basically, trailing spaces were not stripped, and if one unknowingly leaves a trailing space in config file, the line is ignored. Fixed by adding space to rstrip in actons.py.