### PR TITLE
Migration to standard logging library

### DIFF
--- a/ranger/__init__.py
+++ b/ranger/__init__.py
@@ -29,44 +29,9 @@ CACHEDIR = os.path.expanduser("~/.cache/ranger")
 USAGE = '%prog [options] [path]'
 VERSION = 'ranger-master %s\n\nPython %s' % (__version__, sys.version)
 
-try:
-    ExceptionClass = FileNotFoundError
-except NameError:
-    ExceptionClass = IOError
-try:
-    LOGFILE = tempfile.gettempdir() + '/ranger_errorlog'
-except ExceptionClass:
-    LOGFILE = '/dev/null'
-del ExceptionClass
 
 # If the environment variable XDG_CONFIG_HOME is non-empty, CONFDIR is ignored
 # and the configuration directory will be $XDG_CONFIG_HOME/ranger instead.
 CONFDIR = '~/.config/ranger'
-
-# Debugging functions.  These will be activated when run with --debug.
-# Example usage in the code:
-# import ranger; ranger.log("hello world")
-
-
-def log(*objects, **keywords):
-    """Writes objects to a logfile (for the purpose of debugging only.)
-    Has the same arguments as print() in python3.
-    """
-    from ranger import arg
-    if LOGFILE is None or not arg.debug or arg.clean:
-        return
-    start = keywords.get('start', 'ranger:')
-    sep   = keywords.get('sep', ' ')
-    end   = keywords.get('end', '\n')
-    _file = keywords['file'] if 'file' in keywords else open(LOGFILE, 'a')
-    _file.write(sep.join(map(str, (start, ) + objects)) + end)
-
-
-def log_traceback():
-    from ranger import arg
-    if LOGFILE is None or not arg.debug or arg.clean:
-        return
-    import traceback
-    traceback.print_stack(file=open(LOGFILE, 'a'))
 
 from ranger.core.main import main

--- a/ranger/api/commands.py
+++ b/ranger/api/commands.py
@@ -236,6 +236,11 @@ class Command(FileManagerAware):
                     break
         return flags, rest
 
+    @lazy_property
+    def log(self):
+        import logging
+        return logging.getLogger('ranger.commands.' + self.__class__.__name__)
+
     # XXX: Lazy properties? Not so smart? self.line can change after all!
     @lazy_property
     def _tabinsert_left(self):

--- a/ranger/core/actions.py
+++ b/ranger/core/actions.py
@@ -869,11 +869,13 @@ class Actions(FileManagerAware, SettingsAware):
             self.notify("Could not find manpage.", bad=True)
 
     def display_log(self):
+        logs = list(self.get_log())
         pager = self.ui.open_pager()
-        if self.log:
-            pager.set_source(["Message Log:"] + list(self.log))
+        if logs:
+            pager.set_source(["Message Log:"] + logs)
         else:
             pager.set_source(["Message Log:", "No messages!"])
+        pager.move(to=100, percentage=True)
 
     def display_file(self):
         if not self.thisfile or not self.thisfile.is_file:

--- a/ranger/core/actions.py
+++ b/ranger/core/actions.py
@@ -13,6 +13,7 @@ from inspect import cleandoc
 from stat import S_IEXEC
 from hashlib import sha1
 from sys import version_info
+from logging import getLogger
 
 import ranger
 from ranger.ext.direction import Direction
@@ -30,6 +31,8 @@ from ranger.container.settings import ALLOWED_SETTINGS, ALLOWED_VALUES
 from ranger.core.linemode import DEFAULT_LINEMODE
 
 MACRO_FAIL = "<\x01\x01MACRO_HAS_NO_VALUE\x01\01>"
+
+log = getLogger(__name__)
 
 
 class _MacroTemplate(string.Template):
@@ -152,7 +155,7 @@ class Actions(FileManagerAware, SettingsAware):
         elif bad is True and ranger.arg.debug:
             raise Exception(str(text))
         text = str(text)
-        self.log.appendleft(text)
+        log.debug("Command notify invoked: [Bad: {0}, Text: '{1}']".format(bad, text))
         if self.ui and self.ui.is_on:
             self.ui.status.notify("  ".join(text.split("\n")),
                     duration=duration, bad=bad)

--- a/ranger/core/actions.py
+++ b/ranger/core/actions.py
@@ -347,6 +347,7 @@ class Actions(FileManagerAware, SettingsAware):
         Load a config file.
         """
         filename = os.path.expanduser(filename)
+        log.debug("Sourcing config file '{0}'".format(filename))
         with open(filename, 'r') as f:
             for line in f:
                 line = line.lstrip().rstrip("\r\n")

--- a/ranger/core/fm.py
+++ b/ranger/core/fm.py
@@ -5,6 +5,7 @@
 
 from time import time
 from collections import deque
+import logging
 import mimetypes
 import os.path
 import pwd
@@ -27,6 +28,9 @@ from ranger.container.directory import Directory
 from ranger.ext.signals import SignalDispatcher
 from ranger import __version__
 from ranger.core.loader import Loader
+from ranger.ext import logutils
+
+log = logging.getLogger(__name__)
 
 
 class FM(Actions, SignalDispatcher):
@@ -50,7 +54,6 @@ class FM(Actions, SignalDispatcher):
             self.ui = ui
         self.start_paths = paths
         self.directories = dict()
-        self.log = deque(maxlen=1000)
         self.bookmarks = bookmarks
         self.current_tab = 1
         self.tabs = {}
@@ -204,6 +207,15 @@ class FM(Actions, SignalDispatcher):
             except Exception:
                 if debug:
                     raise
+
+    def get_log(self):
+        """Return the current log
+
+        The log is returned as a list of string
+        """
+        for log in logutils.log_queue:
+            for line in log.split('\n'):
+                yield line
 
     def _get_image_displayer(self):
         if self.settings.preview_images_method == "w3m":

--- a/ranger/core/fm.py
+++ b/ranger/core/fm.py
@@ -26,7 +26,6 @@ from ranger.core.metadata import MetadataManager
 from ranger.ext.rifle import Rifle
 from ranger.container.directory import Directory
 from ranger.ext.signals import SignalDispatcher
-from ranger import __version__
 from ranger.core.loader import Loader
 from ranger.ext import logutils
 
@@ -73,10 +72,6 @@ class FM(Actions, SignalDispatcher):
             self.username = 'uid:' + str(os.geteuid())
         self.hostname = socket.gethostname()
         self.home_path = os.path.expanduser('~')
-
-        log.info('ranger {0} started! Process ID is {1}'
-                .format(__version__, os.getpid()))
-        log.info('Running on Python ' + sys.version.replace('\n', ''))
 
         mimetypes.knownfiles.append(os.path.expanduser('~/.mime.types'))
         mimetypes.knownfiles.append(self.relpath('data/mime.types'))

--- a/ranger/core/fm.py
+++ b/ranger/core/fm.py
@@ -74,9 +74,9 @@ class FM(Actions, SignalDispatcher):
         self.hostname = socket.gethostname()
         self.home_path = os.path.expanduser('~')
 
-        self.log.appendleft('ranger {0} started! Process ID is {1}.'
+        log.info('ranger {0} started! Process ID is {1}'
                 .format(__version__, os.getpid()))
-        self.log.appendleft('Running on Python ' + sys.version.replace('\n', ''))
+        log.info('Running on Python ' + sys.version.replace('\n', ''))
 
         mimetypes.knownfiles.append(os.path.expanduser('~/.mime.types'))
         mimetypes.knownfiles.append(self.relpath('data/mime.types'))

--- a/ranger/core/main.py
+++ b/ranger/core/main.py
@@ -73,8 +73,6 @@ def main():
                    "deprecated.\nPlease use the standalone file launcher "
                    "'rifle' instead.\n")
 
-            def print_function(string):
-                print(string)
             from ranger.ext.rifle import Rifle
             fm = FM()
             if not arg.clean and os.path.isfile(fm.confpath('rifle.conf')):

--- a/ranger/core/main.py
+++ b/ranger/core/main.py
@@ -6,6 +6,9 @@
 import os.path
 import sys
 import tempfile
+from logging import getLogger
+
+log = getLogger(__name__)
 
 
 def main():
@@ -15,6 +18,10 @@ def main():
     from ranger.container.settings import Settings
     from ranger.core.shared import FileManagerAware, SettingsAware
     from ranger.core.fm import FM
+    from ranger.ext.logutils import setup_logging
+
+    ranger.arg = arg = parse_arguments()
+    setup_logging(debug=arg.debug, logfile=arg.logfile)
 
     try:
         locale.setlocale(locale.LC_ALL, '')
@@ -31,7 +38,6 @@ def main():
     if 'SHELL' not in os.environ:
         os.environ['SHELL'] = 'sh'
 
-    ranger.arg = arg = parse_arguments()
     if arg.copy_config is not None:
         fm = FM()
         fm.copy_config_files(arg.copy_config)

--- a/ranger/core/main.py
+++ b/ranger/core/main.py
@@ -6,6 +6,7 @@
 import os.path
 import sys
 import tempfile
+from ranger import __version__
 from logging import getLogger
 
 log = getLogger(__name__)
@@ -22,6 +23,10 @@ def main():
 
     ranger.arg = arg = parse_arguments()
     setup_logging(debug=arg.debug, logfile=arg.logfile)
+
+    log.info("Ranger version {0}".format(__version__))
+    log.info('Running on Python ' + sys.version.replace('\n', ''))
+    log.info("Process ID is {0}".format(os.getpid()))
 
     try:
         locale.setlocale(locale.LC_ALL, '')

--- a/ranger/core/main.py
+++ b/ranger/core/main.py
@@ -116,7 +116,7 @@ def main():
         if fm.username == 'root':
             fm.settings.preview_files = False
             fm.settings.use_preview_script = False
-            fm.log.appendleft("Running as root, disabling the file previews.")
+            log.info("Running as root, disabling the file previews.")
         if not arg.debug:
             from ranger.ext import curses_interrupt_handler
             curses_interrupt_handler.install_interrupt_handler()
@@ -319,10 +319,9 @@ def load_settings(fm, clean):
                     else:
                         module = importlib.import_module('plugins.' + plugin)
                         fm.commands.load_commands_from_module(module)
-                    fm.log.appendleft("Loaded plugin '%s'." % plugin)
-                except Exception:
-                    import traceback
-                    fm.log.extendleft(reversed(traceback.format_exc().splitlines()))
+                    log.info("Loaded plugin '%s'." % plugin)
+                except Exception as e:
+                    log.exception(e)
                     fm.notify("Error in plugin '%s'" % plugin, bad=True)
             ranger.fm = None
 

--- a/ranger/core/main.py
+++ b/ranger/core/main.py
@@ -197,6 +197,8 @@ def parse_arguments():
             help="activate debug mode")
     parser.add_option('-c', '--clean', action='store_true',
             help="don't touch/require any config files. ")
+    parser.add_option('--logfile', type='string', metavar='file',
+            help="log file to use, '-' for stderr")
     parser.add_option('-r', '--confdir', type='string',
             metavar='dir', default=default_confdir,
             help="change the configuration directory. (%default)")

--- a/ranger/ext/logutils.py
+++ b/ranger/ext/logutils.py
@@ -1,0 +1,78 @@
+import logging
+from collections import deque
+
+LOG_FORMAT = "[%(levelname)s] %(message)s"
+LOG_FORMAT_EXT = "%(asctime)s,%(msecs)d [%(name)s] |%(levelname)s| %(message)s"
+LOG_DATA_FORMAT = "%H:%M:%S"
+
+
+class QueueHandler(logging.Handler):
+    """
+    This handler store logs events into a queue.
+    """
+
+    def __init__(self, queue):
+        """
+        Initialize an instance, using the passed queue.
+        """
+        logging.Handler.__init__(self)
+        self.queue = queue
+
+    def enqueue(self, record):
+        """
+        Enqueue a log record.
+        """
+        self.queue.append(record)
+
+    def emit(self, record):
+        self.enqueue(self.format(record))
+
+
+log_queue = deque(maxlen=1000)
+concise_formatter = logging.Formatter(fmt=LOG_FORMAT, datefmt=LOG_DATA_FORMAT)
+extended_formatter = logging.Formatter(fmt=LOG_FORMAT_EXT, datefmt=LOG_DATA_FORMAT)
+
+
+def setup_logging(debug=True, logfile=None):
+    """
+    All the produced logs using the standard logging function
+    will be collected in a queue by the `queue_handler` as well
+    as outputted on the standard error `stderr_handler`.
+
+    The verbosity and the format of the log message is
+    controlled by the `debug` parameter
+
+     - debug=False:
+            a concise log format will be used, debug messsages will be discarded
+            and only important message will be passed to the `stderr_handler`
+
+     - debug=True:
+            an extended log format will be used, all messages will be processed
+            by both the handlers
+    """
+    root_logger = logging.getLogger()
+
+    if debug:
+        # print all logging in extended format
+        log_level = logging.DEBUG
+        formatter = extended_formatter
+    else:
+        # print only warning and critical message
+        # in a concise format
+        log_level = logging.INFO
+        formatter = concise_formatter
+
+    handlers = []
+    handlers.append(QueueHandler(log_queue))
+    if logfile:
+        if logfile is '-':
+            handlers.append(logging.StreamHandler())
+        else:
+            handlers.append(logging.FileHandler(logfile))
+
+    for handler in handlers:
+        handler.setLevel(log_level)
+        handler.setFormatter(formatter)
+        root_logger.addHandler(handler)
+
+    root_logger.setLevel(0)

--- a/ranger/ext/vcs/vcs.py
+++ b/ranger/ext/vcs/vcs.py
@@ -7,6 +7,7 @@ import os
 import subprocess
 import threading
 import time
+from logging import getLogger
 from ranger.ext.spawn import spawn
 
 # Python2 compatibility
@@ -19,6 +20,7 @@ try:
 except NameError:
     FileNotFoundError = OSError  # pylint: disable=redefined-builtin
 
+log = getLogger(__name__)
 
 class VcsError(Exception):
     """VCS exception"""
@@ -470,9 +472,8 @@ class VcsThread(threading.Thread):  # pylint: disable=too-many-instance-attribut
                             column.need_redraw = True
                     self.ui.status.need_redraw = True
                     self.ui.redraw()
-            except Exception:  # pylint: disable=broad-except
-                import traceback
-                self.ui.fm.log.extendleft(reversed(traceback.format_exc().splitlines()))
+            except Exception as e:  # pylint: disable=broad-except
+                log.exception(e)
                 self.ui.fm.notify('VCS Exception', bad=True)
 
     def pause(self):


### PR DESCRIPTION
# Migration to standard logging library

## Introduction
You can read about the reason behind this PR on this issue:
https://github.com/ranger/ranger/issues/713

## Old logs and output managment

Four different ways of outputting stuff were used:
 - printing out on stdout:
	can be used only when the curses interface is not running,
    is usually used on critical error before exit ranger.
 - printing out on stderr:
	can be used only when the curses interface is not running,
	is usually used for warnings.
 - appending string to a queue in the FM class
	(these are the logs shown by the curses log viewer)
 - background processes and task usually use the `FM.notify` function
   to show a message on the bottom bar of ranger. Moreover this fuction,
   if the debug mode is active, will print the stack trace and exit the program.

### Problems
First of all it is difficult for new dev to understand which method of output
should be used for that particular case.
Moreover the logs (collected on the FM.log object) can only be seen through the
curses log viewer at runtime and it isn't possible to export them, for instance on a file.
For these reasons logs are almost not used at all in ranger. 


## New logging approach
The goal is to provide an easy api to log stuff and a straigthforward way of inspect them. This has been achieved using the standard logging library. The default behaviour is pretty similar to the old one, in the sense that all the the produced logs will be collected in a queue that can be inspected with the curses log viewer (`display_log` command). Moreover the `--logfile` cli option has been added and it can be used to specify a destination file for all the logs in such a way that the same log can be viewed at runtime as well as inspected after a program crash.

The verbosity and the format of the log message is controlled by the already existent `--debug` command line flag:

 - Normal mode:
	A concise log format will be used and only important message will be logged (log level > INFO)
	
	Example:
	```
	[INFO] Ranger version 1.7.2
	[INFO] Running on Python 3.5.2 (default, Jun 28 2016, 08:46:01) [GCC 6.1.1 20160602]
	[INFO] Process ID is 1497

	```

 - Debug mode:
	An extended log format will be used and all the message will be logged.
	
	Example:
	```
	23:17:43,719 [ranger.core.main] |INFO| Ranger version 1.7.2
	23:17:43,719 [ranger.core.main] |INFO| Running on Python 3.5.2 (default, Jun 28 2016, 08:46:01) [GCC 6.1.1 20160602]
	23:17:43,719 [ranger.core.main] |INFO| Process ID is 1515
	23:17:43,720 [ranger.core.main] |DEBUG| config dir: '/home/groucho/.config/ranger'
	23:17:43,720 [ranger.core.main] |DEBUG| cache dir: '/home/groucho/.cache/ranger'
	23:17:43,738 [ranger.core.actions] |DEBUG| Sourcing config file '/path/to/ranger/config/rc.conf'
	```

### Advantages
The main advantages of the new logging approach:

 - clean and standard API that can be used internally as well as in the custom command and plugins
 - support for [multilevel logging](https://docs.python.org/3/library/logging.html#logging-levels)
 - the infrastructure of loggers, handlers and filters allow to easily implement custom behaviour,
	that will be necessary in the feature.

### Logging in commands
All the subclass of the Command class can now use the
the class object `Command.log` for logging pourposes.
This is a standard `logging.Logger` instance, thus
the standard logging api must be used.

Example:

```
class dummy_cmd(Command):
    def execute(self):
        self.log.info("the dummy command has been invoked")
```




### Curses log viewer
You can open it with the `:display_log` command

Now shows the logs in descending order such that the last entry will correspond to the most recent log entry.
On every new open the pager will be positioned on the end of the log showing the most recents log entries.
