### PR TITLE
allow spaces again at the end of lines in rc.conf

### DIFF
--- a/ranger/core/actions.py
+++ b/ranger/core/actions.py
@@ -350,7 +350,7 @@ class Actions(FileManagerAware, SettingsAware):
         log.debug("Sourcing config file '{0}'".format(filename))
         with open(filename, 'r') as f:
             for line in f:
-                line = line.strip(" \r\n")
+                line = line.lstrip().rstrip('\r\n')
                 if line.startswith("#") or not line.strip():
                     continue
                 try:


### PR DESCRIPTION
If you have lines such as:
```
map cw console rename
map /  console search_inc
```

then being able to have a trailing space that isn't stripped is pretty useful. Otherwise, you have to press space after pressing the bound key, before typing the arguments in the console.

