### PR TITLE
Don't use bold on selected items for better readability

### DIFF
--- a/ranger/colorschemes/default.py
+++ b/ranger/colorschemes/default.py
@@ -63,11 +63,11 @@ class Default(ColorScheme):
                 fg = black
                 attr |= bold
             if context.main_column:
-                if context.selected:
-                    attr |= bold
                 if context.marked:
                     attr |= bold
                     fg = yellow
+            if context.selected:
+                attr &= ~bold
             if context.badinfo:
                 if attr & reverse:
                     bg = magenta

--- a/ranger/colorschemes/snow.py
+++ b/ranger/colorschemes/snow.py
@@ -18,7 +18,7 @@ class Snow(ColorScheme):
         elif context.in_browser:
             if context.selected:
                 attr = reverse
-            if context.directory:
+            elif context.directory:
                 attr |= bold
 
         elif context.highlight:

--- a/ranger/colorschemes/solarized.py
+++ b/ranger/colorschemes/solarized.py
@@ -76,11 +76,11 @@ class Solarized(ColorScheme):
                 fg = 234
                 attr |= bold
             if context.main_column:
-                if context.selected:
-                    attr |= bold
                 if context.marked:
                     attr |= bold
                     bg = 237
+            if context.selected:
+                attr &= ~bold
             if context.badinfo:
                 if attr & reverse:
                     bg = magenta


### PR DESCRIPTION
When inverting a selected item's colour and setting the attributes to bold, the text becomes gray on a coloured background. This makes it quite hard to read even with a big font. I propose to just use black instead.