### PR TITLE
fix crash when file.stat equals None

### DIFF
--- a/ranger/core/linemode.py
+++ b/ranger/core/linemode.py
@@ -119,7 +119,10 @@ class MtimeLinemode(LinemodeBase):
         return fobj.relative_path
 
     def infostring(self, fobj, metadata):
-        return datetime.fromtimestamp(fobj.stat.st_mtime).strftime("%Y-%m-%d %H:%M")
+        if fobj.stat is None:
+            return "               ?"
+        else:
+            return datetime.fromtimestamp(fobj.stat.st_mtime).strftime("%Y-%m-%d %H:%M")
 
 
 class SizeMtimeLinemode(LinemodeBase):
@@ -129,5 +132,9 @@ class SizeMtimeLinemode(LinemodeBase):
         return fobj.relative_path
 
     def infostring(self, fobj, metadata):
-        return "%s %s" % (human_readable(fobj.size),
-                          datetime.fromtimestamp(fobj.stat.st_mtime).strftime("%Y-%m-%d %H:%M"))
+        if fobj.stat is None:
+            time = "               ?"
+        else:
+            time = datetime.fromtimestamp(fobj.stat.st_mtime).strftime("%Y-%m-%d %H:%M")
+
+        return "%s %s" % (human_readable(fobj.size), time)


### PR DESCRIPTION
this can happen with bash on windows for files without permission (and sometimes on macOS when deleting files)
fixes #741 

#### ISSUE TYPE
- Bug fix

#### RUNTIME ENVIRONMENT
- Operating system and version: 
bash on windows 10
mac elcap
- Terminal emulator and version: 
terminal
- Python version: 
2.7.12
- Ranger version/commit: 

#### CHECKLIST
- [x] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [x] All changes follow the code style **[REQUIRED]**
- [x] All new and existing tests pass **[REQUIRED]**

#### DESCRIPTION

This fixes the following crash:

```
ranger version: 1.7.2, executed with python 2.7.12
Locale: en_US.UTF-8
Current file: /mnt/c
Traceback (most recent call last):
  File "/home/laktak/tools/ranger/core/main.py", line 157, in main
    fm.loop()
  File "/home/laktak/tools/ranger/core/fm.py", line 369, in loop
    ui.redraw()
  File "/home/laktak/tools/ranger/gui/ui.py", line 295, in redraw
    self.draw()
  File "/home/laktak/tools/ranger/gui/ui.py", line 322, in draw
    DisplayableContainer.draw(self)
  File "/home/laktak/tools/ranger/gui/displayable.py", line 248, in draw
    displayable.draw()
  File "/home/laktak/tools/ranger/gui/widgets/view_miller.py", line 99, in draw
    DisplayableContainer.draw(self)
  File "/home/laktak/tools/ranger/gui/displayable.py", line 248, in draw
    displayable.draw()
  File "/home/laktak/tools/ranger/gui/widgets/browsercolumn.py", line 168, in draw
    self._draw_directory()
  File "/home/laktak/tools/ranger/gui/widgets/browsercolumn.py", line 348, in _draw_directory
    infostringdata = current_linemode.infostring(drawn, metadata)
  File "/home/laktak/tools/ranger/core/linemode.py", line 131, in infostring
    datetime.fromtimestamp(file.stat.st_mtime).strftime("%Y-%m-%d %H:%M"))
AttributeError: 'NoneType' object has no attribute 'st_mtime'

ranger crashed.  Please report this traceback at:
https://github.com/hut/ranger/issues
```