### PR TITLE
Use 'file' as a fallback file preview method

### DIFF
--- a/ranger/data/scope.sh
+++ b/ranger/data/scope.sh
@@ -118,4 +118,4 @@ case "$mimetype" in
         try mediainfo "$path" && { dump | trim | sed 's/  \+:/: /;';  exit 5; } || exit 1;;
 esac
 
-exit 1
+try file --brief "$path" && { dump | tr ',' '\n'; exit 0; } || exit 1;


### PR DESCRIPTION
Ranger displays useful previews for many types of files, but sometimes there is no preview available for the type. In this case we could use `file` as the fallback command for providing information about the file type. This feature is implemented in this pull request.

`file` supports a huge number of file types and often provides helpful information. For example, an executable binary:
```
ELF 64-bit LSB executable
 x86-64
 version 1 (SYSV)
 dynamically linked
 interpreter /lib64/ld-linux-x86-64.so.2
 for GNU/Linux 2.6.32
 BuildID[sha1]=12becb41c4c38114d1df17d25fed36f907998faa
 stripped
```

Or an unknown `mapping.db` file that is now identified to be an SQLite database:
```
SQLite 3.x database
 last written using SQLite version 3011001
```