### PR TITLE
Help function need to pass temporary_file.name to the default pager

### DIFF
--- a/ranger/core/actions.py
+++ b/ranger/core/actions.py
@@ -1236,7 +1236,7 @@ class Actions(  # pylint: disable=too-many-instance-attributes,too-many-public-m
             write("\n")
 
         temporary_file.flush()
-        self._run_pager(temporary_file)
+        self._run_pager(temporary_file.name)
 
     def dump_commands(self):
         temporary_file = tempfile.NamedTemporaryFile()
@@ -1261,7 +1261,7 @@ class Actions(  # pylint: disable=too-many-instance-attributes,too-many-public-m
                 write("    :%s\n" % cmd.get_name())
 
         temporary_file.flush()
-        self._run_pager(temporary_file)
+        self._run_pager(temporary_file.name)
 
     def dump_settings(self):
         temporary_file = tempfile.NamedTemporaryFile()
@@ -1273,7 +1273,7 @@ class Actions(  # pylint: disable=too-many-instance-attributes,too-many-public-m
             write("%30s = %s\n" % (setting, getattr(self.settings, setting)))
 
         temporary_file.flush()
-        self._run_pager(temporary_file)
+        self._run_pager(temporary_file.name)
 
     # --------------------------
     # -- File System Operations


### PR DESCRIPTION
Help functions fail to display keybindings, commands or settings because the temporary_file object is passed to the pager instead of the temporary_file name.

#### ISSUE TYPE
- Bug fix

#### RUNTIME ENVIRONMENT
- Operating system and version:  Ubuntu 14.04 x64
- Terminal emulator and version:  Mac Terminal
- Python version: 2.7
- Ranger version/commit: 7255a02

#### CHECKLIST
- [X] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [X] All changes follow the code style **[REQUIRED]**
- [X] All new and existing tests pass **[REQUIRED]**
- [ ] Changes require config files to be updated
    - [ ] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
Where the help menu presents three options (keybindings, commands configuration) the information is written to a file and displayed via the default pager (less).

The calling function incorrectly passes the "tempfile" object to the pager, instead of a usable filename.

#### MOTIVATION AND CONTEXT
These changes are required to actually see the help

#### TESTING
Existing Tests do not pick this up.  _run_pager() should detect if the passes "path" parameter is in fact a stirng containing a valid existing filename.  (not done)

#### IMAGES / VIDEOS<!-- Only if relevant -->
N/A
