### PR TITLE
Custom config file option for rifle

### DIFF
--- a/doc/rifle.1
+++ b/doc/rifle.1
@@ -139,7 +139,7 @@ rifle \- ranger's file opener
 .SH "SYNOPSIS"
 .IX Header "SYNOPSIS"
 \&\fBrifle\fR [\fB\-\-help\fR] [\fB\-f\fR \fI\s-1FLAGS\s0\fR] [\fB\-l\fR] [\fB\-p\fR \fI\s-1KEYWORD\s0\fR]
-[\fB\-w\fR \fI\s-1PROGRAM\s0\fR] \fIfiles\fR
+[\fB\-w\fR \fI\s-1PROGRAM\s0\fR] [\fB\-c\fR \fI\s-1CONFIG_FILE\s0\fR] \fIfiles\fR
 .SH "DESCRIPTION"
 .IX Header "DESCRIPTION"
 rifle is a powerful file executor that allows for complex file type checking,
@@ -170,14 +170,18 @@ Pick a method to open the files.
 .IP "\fB\-w\fR \fI\s-1PROGRAM\s0\fR" 14
 .IX Item "-w PROGRAM"
 Open the files with the program \fI\s-1PROGRAM\s0\fR
+.IP "\fB\-c\fR \fI\s-1CONFIG_FILE\s0\fR" 14
+.IX Item "-c CONFIG_FILE"
+Read configuration from \fI\s-1CONFIG_FILE\s0\fR, instead of the default.
 .IP "\fB\-h\fR, \fB\-\-help\fR" 14
 .IX Item "-h, --help"
 Print a list of options and exit.
 .SH "FILES"
 .IX Header "FILES"
 rifle shares configuration files with ranger, though ranger is not required in
-order to use rifle.  The configuration file \fIrifle.conf\fR is expected to be at
-\&\fI~/.config/ranger/rifle.conf\fR.
+order to use rifle. The default configuration file \fIrifle.conf\fR is expected
+to be at \fI~/.config/ranger/rifle.conf\fR. However, this can be overridden with
+the \fB\-c\fR option.
 .PP
 This file specifies patterns for determining the commands to open files with.
 The syntax is described in the comments of the default \fIrifle.conf\fR that ships

--- a/doc/rifle.pod
+++ b/doc/rifle.pod
@@ -8,7 +8,7 @@ rifle - ranger's file opener
 =head1 SYNOPSIS
 
 B<rifle> [B<--help>] [B<-f> I<FLAGS>] [B<-l>] [B<-p> I<KEYWORD>]
-[B<-w> I<PROGRAM>] I<files>
+[B<-w> I<PROGRAM>] [B<-c> I<CONFIG_FILE>] I<files>
 
 
 
@@ -53,6 +53,10 @@ I<KEYWORD> is either the ID number listed by C<rifle -l> or a string that matche
 
 Open the files with the program I<PROGRAM>
 
+=item B<-c> I<CONFIG_FILE>
+
+Read configuration from I<CONFIG_FILE>, instead of the default.
+
 =item B<-h>, B<--help>
 
 Print a list of options and exit.
@@ -65,8 +69,9 @@ Print a list of options and exit.
 =head1 FILES
 
 rifle shares configuration files with ranger, though ranger is not required in
-order to use rifle.  The configuration file F<rifle.conf> is expected to be at
-F<~/.config/ranger/rifle.conf>.
+order to use rifle. The default configuration file F<rifle.conf> is expected
+to be at F<~/.config/ranger/rifle.conf>. However, this can be overridden with
+the B<-c> option.
 
 This file specifies patterns for determining the commands to open files with.
 The syntax is described in the comments of the default F<rifle.conf> that ships


### PR DESCRIPTION
This change adds a command line option to the `rifle` standalone script to allow specifying a custom configuration file instead of the default.

#### ISSUE TYPE

- Improvement/feature implementation


#### CHECKLIST

- [X] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [X] All changes follow the code style **[REQUIRED]**
- [x] All new and existing tests pass **[REQUIRED]**
- [X] Changes require documentation to be updated
    - [X] Documentation has been updated

#### DESCRIPTION

- new `-c CONFIG_FILE` option added to `rifle.py` arg parsing
- move `conf_path` logic to after arg parsing to allow the `-c` option to affect the process (if `-c` is set, that file will be used with no questions asked and without attempting to fallback to another default config file)
- rifle man page updated to suite.

#### MOTIVATION AND CONTEXT

I use rifle all the time, both with ranger and from the shell as an `xdg-open` replacement. However I find there are generally 2 contexts I want to use it in - from the shell where preference is for opening in text applications (eg. vim, atool for viewing archives), and the other is from gui applications where I need it to open a graphical application (eg. gvim, ark for archives). Currently there doesn't seem to be a way to split between the two. This cli option would allow tuning multiple `rifle.conf` files to different contexts. (Although, if there could be a better way, please suggest one. 😃 )


#### TESTING

This only affects running `rifle` as the standalone script. I couldn't find any automated tests set up relating to rifle. Please advise if any tests are required for this.

Also it seems like it fails pylint, which I failed to notice before... If maintainers are interested in merging this feature, I'd be interested to hear your opinion on the tests it failed on (too many branching - likely because if the extra nested if/else blocks) and how much refactoring you'd like to see.

UPDATE: refactored so the code is cleaner as well as passes pylint.