### PR TITLE
don't quit if tasks are running

### DIFF
--- a/doc/ranger.1
+++ b/doc/ranger.1
@@ -129,7 +129,7 @@
 .\" ========================================================================
 .\"
 .IX Title "RANGER 1"
-.TH RANGER 1 "ranger-1.8.1" "2017-02-06" "ranger manual"
+.TH RANGER 1 "ranger-1.8.1" "2017-02-08" "ranger manual"
 .\" For nroff, turn off justification.  Always turn off hyphenation; it makes
 .\" way too many mistakes in technical documents.
 .if n .ad l
@@ -937,6 +937,7 @@ ranger.  For your convenience, this is a list of the \*(L"public\*(R" commands i
 \& punmap keys...
 \& quit
 \& quit!
+\& quitall
 \& relink newpath
 \& rename_append [\-FLAGS...]
 \& rename newname
@@ -1170,11 +1171,17 @@ a row.
 Removes key mappings of the pager. Works like the \f(CW\*(C`unmap\*(C'\fR command.
 .IP "quit" 2
 .IX Item "quit"
-Like quit!, but closes only this tab if multiple tabs are open.
+If only one tab is currently open and no tasks are running, quit ranger. If
+multiple tabs are open, only close this tab. The current directory will be
+bookmarked as ' so you can re-enter it by typing `` or '' the next time you
+start ranger.
 .IP "quit!" 2
 .IX Item "quit!"
-Quit ranger.  The current directory will be bookmarked as ' so you can re-enter
-it by typing `` or '' the next time you start ranger.
+Force quit ranger, even if tasks are running. The current directory will still
+be bookmarked similarly to \f(CW\*(C`quit\*(C'\fR.
+.IP "quitall" 2
+.IX Item "quitall"
+Like \f(CW\*(C`quit\*(C'\fR, will close ranger even if multiple tabs are open.
 .IP "relink \fInewpath\fR" 2
 .IX Item "relink newpath"
 Change the link destination of the current symlink file to <newpath>. First

--- a/doc/ranger.pod
+++ b/doc/ranger.pod
@@ -958,6 +958,7 @@ ranger.  For your convenience, this is a list of the "public" commands including
  punmap keys...
  quit
  quit!
+ quitall
  relink newpath
  rename_append [-FLAGS...]
  rename newname
@@ -1224,12 +1225,19 @@ Removes key mappings of the pager. Works like the C<unmap> command.
 
 =item quit
 
-Like quit!, but closes only this tab if multiple tabs are open.
+If only one tab is currently open and no tasks are running, quit ranger. If
+multiple tabs are open, only close this tab. The current directory will be
+bookmarked as ' so you can re-enter it by typing `` or '' the next time you
+start ranger.
 
 =item quit!
 
-Quit ranger.  The current directory will be bookmarked as ' so you can re-enter
-it by typing `` or '' the next time you start ranger.
+Force quit ranger, even if tasks are running. The current directory will still
+be bookmarked similarly to C<quit>.
+
+=item quitall
+
+Like C<quit>, will close ranger even if multiple tabs are open.
 
 =item relink I<newpath>
 

--- a/doc/rifle.1
+++ b/doc/rifle.1
@@ -129,7 +129,7 @@
 .\" ========================================================================
 .\"
 .IX Title "RIFLE 1"
-.TH RIFLE 1 "rifle-1.8.1" "2017-02-06" "rifle manual"
+.TH RIFLE 1 "rifle-1.8.1" "2017-02-08" "rifle manual"
 .\" For nroff, turn off justification.  Always turn off hyphenation; it makes
 .\" way too many mistakes in technical documents.
 .if n .ad l

--- a/ranger/config/commands.py
+++ b/ranger/config/commands.py
@@ -477,32 +477,42 @@ class default_linemode(Command):
 class quit(Command):  # pylint: disable=redefined-builtin
     """:quit
 
-    Closes the current tab.  If there is only one tab, quit the program.
+    Closes the current tab. If there is only one tab, quit the program.
     """
 
-    def execute(self):
-        if len(self.fm.tabs) <= 1:
+    def _exit_no_work(self):
+        if self.fm.loader.has_work():
+            self.fm.notify('Not quitting: Tasks in progress: Use `quit!` to force quit')
+        else:
             self.fm.exit()
-        self.fm.tab_close()
+
+    def execute(self):
+        if len(self.fm.tabs) >= 2:
+            self.fm.tab_close()
+        else:
+            self._exit_no_work()
 
 
-class quitall(Command):
+class quitall(quit):
     """:quitall
 
     Quits the program immediately.
     """
 
     def execute(self):
-        self.fm.exit()
+        self._exit_no_work()
 
 
-class quit_bang(quitall):
+class quit_bang(Command):
     """:quit!
 
     Quits the program immediately.
     """
     name = 'quit!'
     allow_abbrev = False
+
+    def execute(self):
+        self.fm.exit()
 
 
 class terminal(Command):

--- a/ranger/config/rc.conf
+++ b/ranger/config/rc.conf
@@ -233,7 +233,7 @@ set wrap_scroll false
 
 alias e    edit
 alias q    quit
-alias q!   quitall
+alias q!   quit!
 alias qa   quitall
 alias qall quitall
 alias setl setlocal


### PR DESCRIPTION

This PR modifies the behaviour of the quit commands to avoid accidently quitting ranger if tasks are running.


#### ISSUE TYPE

- Improvement/feature implementation

#### CHECKLIST
- [X] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [X] All changes follow the code style **[REQUIRED]**
- [X] All new and existing tests pass **[REQUIRED]**
- [X] Changes require documentation to be updated
    - [X] Documentation has been updated

#### DESCRIPTION

- `quit` and `quitall` will not exit ranger if tasks are running
- `quit!` will force-quit ranger (ie. quit even if tasks are running)


#### MOTIVATION AND CONTEXT

- useful when long tasks are running in the background and the user has the potential to forget about them, for example extracting archives or copying large files.
- similar feature requested in #739