### PR TITLE
Change DIRSTATUSES order.

### DIFF
--- a/ranger/ext/vcs/vcs.py
+++ b/ranger/ext/vcs/vcs.py
@@ -58,10 +58,10 @@ class Vcs(object):  # pylint: disable=too-many-instance-attributes
     # statuses that should not be inherited from subpaths are disabled
     DIRSTATUSES = (
         'conflict',
-        'untracked',
-        'deleted',
-        'changed',
         'staged',
+        'changed',
+        'deleted',
+        'untracked',
         # 'ignored',
         'sync',
         # 'none',


### PR DESCRIPTION
- Untracked files should be less important than changes to tracked
  files.

- When there are both changed and deleted files, 'changed' seems to be a
  better summary of the situation than 'deleted', so prioritize changed
  over deleted.

- Staged files should be more important than non-staged files, since
  that indicates there's a commit being formed, but not yet committed.
