### PR TITLE
config.commands.cd.tab: Now tab works fine with '-r'

### DIFF
--- a/ranger/config/commands.py
+++ b/ranger/config/commands.py
@@ -149,7 +149,13 @@ class cd(Command):
         from os.path import dirname, basename, expanduser, join
 
         cwd = self.fm.thisdir.path
-        rel_dest = self.rest(1)
+
+        if self.arg(1) == '-r':
+            start = self.start(2)
+            rel_dest = self.arg(2)
+        else:
+            start = self.start(1)
+            rel_dest = self.arg(1)
 
         bookmarks = [v.path for v in self.fm.bookmarks.dct.values()
                      if rel_dest in v.path]
@@ -188,11 +194,11 @@ class cd(Command):
 
             # one result. since it must be a directory, append a slash.
             if len(dirnames) == 1:
-                return self.start(1) + join(rel_dirname, dirnames[0]) + '/'
+                return start + join(rel_dirname, dirnames[0]) + '/'
 
             # more than one result. append no slash, so the user can
             # manually type in the slash to advance into that directory
-            return (self.start(1) + join(rel_dirname, dirname) for dirname in dirnames)
+            return (start + join(rel_dirname, dirname) for dirname in dirnames)
 
 
 class chain(Command):


### PR DESCRIPTION
cd tab completion didn't work in the presence of real path argument '-r'.
Fixed that.

<!-- Provide a descriptive summary of the changes in the title above -->

#### ISSUE TYPE
<!-- Pick relevant types and delete the rest -->
- Bug fix

#### RUNTIME ENVIRONMENT
<!-- Details of your runtime environment -->
<!-- Retrieve Python/ranger version and locale with `ranger -\-version` -->
- Operating system and version: Linux 4.4.45
- Terminal emulator and version: gnome-terminal 3.22.1
- Python version: 2.7.13 and 3.6.0
- Ranger version/commit: ranger-master 1.9.0b5
- Locale: en_US.UTF-8

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [x] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [x] All changes follow the code style **[REQUIRED]**
- [x] All new and existing tests pass **[REQUIRED]**
- [ ] Changes require config files to be updated
    - [ ] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
<!-- Describe the changes in detail -->
When '-r' argument is present, user given path must be self.arg(2) not self.arg(1).
That was the reason why tab completion didn't work with '-r'.

#### MOTIVATION AND CONTEXT
<!-- Why are these changes required? -->
<!-- What problems do these changes solve? -->
<!-- Link to relevant issues -->
The bug was a small glitch. Not much to say.

#### TESTING
<!-- What tests have been run? -->
<!-- How does the changes affect other areas of the codebase? -->
Tested manually input some directories and press tab by hand.