### PR TITLE
Add cd case-insensitive completion

### DIFF
--- a/doc/ranger.1
+++ b/doc/ranger.1
@@ -704,6 +704,15 @@ though by turning on this option.
 .IX Item "cd_bookmarks [bool]"
 Specify whether bookmarks should be included in the tab completion of the \*(L"cd\*(R"
 command.
+.IP "cd_tab_case [string]" 4
+.IX Item "cd_tab_case [string]"
+Changes case sensitivity for the \*(L"cd\*(R" command tab completion. Possible values are:
+.Sp
+.Vb 3
+\& sensitive
+\& insensitive
+\& smart
+.Ve
 .IP "collapse_preview [bool] <zc>" 4
 .IX Item "collapse_preview [bool] <zc>"
 When no preview is visible, should the last column be squeezed to make use of

--- a/doc/ranger.1
+++ b/doc/ranger.1
@@ -713,6 +713,9 @@ Changes case sensitivity for the \*(L"cd\*(R" command tab completion. Possible v
 \& insensitive
 \& smart
 .Ve
+.IP "clear_filters_on_dir_change [bool]" 4
+.IX Item "clear_filters_on_dir_change [bool]"
+If set to 'true', persistent filters would be cleared upon leaving the directory
 .IP "collapse_preview [bool] <zc>" 4
 .IX Item "collapse_preview [bool] <zc>"
 When no preview is visible, should the last column be squeezed to make use of
@@ -820,6 +823,11 @@ the content.
 .IX Item "save_console_history [bool]"
 Should the console history be saved on exit?  If disabled, the console history
 is reset when you restart ranger.
+.IP "save_tabs_on_exit [bool]" 4
+.IX Item "save_tabs_on_exit [bool]"
+Save all tabs, except the active, on exit? The last saved tabs are restored once
+when starting the next session. Multiple sessions are stored in a stack and the
+oldest saved tabs are restored first.
 .IP "scroll_offset [integer]" 4
 .IX Item "scroll_offset [integer]"
 Try to keep this much space between the top/bottom border when scrolling.
@@ -898,14 +906,6 @@ the top and vice versa.
 .IX Item "xterm_alt_key [bool]"
 Enable this if key combinations with the Alt Key don't work for you.
 (Especially on xterm)
-.IP "clear_filters_on_dir_change [bool]" 4
-.IX Item "clear_filters_on_dir_change [bool]"
-If set to 'true', persistent filters would be cleared upon leaving the directory
-.IP "save_tabs_on_exit [bool]" 4
-.IX Item "save_tabs_on_exit [bool]"
-Save all tabs, except the active, on exit? The last saved tabs are restored once
-when starting the next session. Multiple sessions are stored in a stack and the
-oldest saved tabs are restored first.
 .SH "COMMANDS"
 .IX Header "COMMANDS"
 You can enter the commands in the console which is opened by pressing \*(L":\*(R".

--- a/doc/ranger.pod
+++ b/doc/ranger.pod
@@ -682,6 +682,14 @@ though by turning on this option.
 Specify whether bookmarks should be included in the tab completion of the "cd"
 command.
 
+=item cd_tab_case [string]
+
+Changes case sensitivity for the "cd" command tab completion. Possible values are:
+
+ sensitive
+ insensitive
+ smart
+
 =item collapse_preview [bool] <zc>
 
 When no preview is visible, should the last column be squeezed to make use of

--- a/doc/ranger.pod
+++ b/doc/ranger.pod
@@ -690,6 +690,10 @@ Changes case sensitivity for the "cd" command tab completion. Possible values ar
  insensitive
  smart
 
+=item clear_filters_on_dir_change [bool]
+
+If set to 'true', persistent filters would be cleared upon leaving the directory
+
 =item collapse_preview [bool] <zc>
 
 When no preview is visible, should the last column be squeezed to make use of
@@ -818,6 +822,12 @@ the content.
 Should the console history be saved on exit?  If disabled, the console history
 is reset when you restart ranger.
 
+=item save_tabs_on_exit [bool]
+
+Save all tabs, except the active, on exit? The last saved tabs are restored once
+when starting the next session. Multiple sessions are stored in a stack and the
+oldest saved tabs are restored first.
+
 =item scroll_offset [integer]
 
 Try to keep this much space between the top/bottom border when scrolling.
@@ -914,16 +924,6 @@ the top and vice versa.
 
 Enable this if key combinations with the Alt Key don't work for you.
 (Especially on xterm)
-
-=item clear_filters_on_dir_change [bool]
-
-If set to 'true', persistent filters would be cleared upon leaving the directory
-
-=item save_tabs_on_exit [bool]
-
-Save all tabs, except the active, on exit? The last saved tabs are restored once
-when starting the next session. Multiple sessions are stored in a stack and the
-oldest saved tabs are restored first.
 
 =back
 

--- a/ranger/config/commands.py
+++ b/ranger/config/commands.py
@@ -178,8 +178,13 @@ class cd(Command):
             # are we in the middle of the filename?
             else:
                 _, dirnames, _ = next(os.walk(abs_dirname))
-                dirnames = [dn for dn in dirnames
-                            if dn.startswith(rel_basename)]
+                if self.fm.settings.cd_tab_case == 'insensitive' or (
+                        self.fm.settings.cd_tab_case == 'smart' and rel_basename.islower()):
+                    dirnames = [dn for dn in dirnames
+                                if dn.lower().startswith(rel_basename.lower())]
+                else:
+                    dirnames = [dn for dn in dirnames
+                                if dn.startswith(rel_basename)]
         except (OSError, StopIteration):
             # os.walk found nothing
             pass

--- a/ranger/config/rc.conf
+++ b/ranger/config/rc.conf
@@ -192,6 +192,9 @@ set xterm_alt_key false
 # Whether to include bookmarks in cd command
 set cd_bookmarks true
 
+# Changes case sensitivity for the cd command tab completion
+set cd_tab_case sensitive
+
 # Avoid previewing files larger than this size, in bytes.  Use a value of 0 to
 # disable this feature.
 set preview_max_size 0

--- a/ranger/container/settings.py
+++ b/ranger/container/settings.py
@@ -27,6 +27,7 @@ ALLOWED_SETTINGS = {
     'autosave_bookmarks': bool,
     'autoupdate_cumulative_size': bool,
     'cd_bookmarks': bool,
+    'cd_tab_case': str,
     'collapse_preview': bool,
     'colorscheme': str,
     'column_ratios': (tuple, list),
@@ -85,6 +86,7 @@ ALLOWED_SETTINGS = {
 }
 
 ALLOWED_VALUES = {
+    'cd_tab_case': ['sensitive', 'insensitive', 'smart'],
     'confirm_on_delete': ['multiple', 'always', 'never'],
     'line_numbers': ['false', 'absolute', 'relative'],
     'preview_images_method': ['w3m', 'iterm2', 'urxvt', 'urxvt-full'],


### PR DESCRIPTION
Now you can use case-insensitive completion in cd command.
`cd Me<tab press>` becomes `cd MEGA`
`cd do<tab press>` becomes `cd Downloads` with double tab becomes `cd downloads`
`cd r<tab press>` becomes `cd ReWrite`

#### ISSUE TYPE
- Improvement/feature implementation

#### RUNTIME ENVIRONMENT
<!-- Details of your runtime environment -->
<!-- Retrieve Python/ranger version and locale with `ranger -\-version` -->
- Operating system and version: Linux 4.9.11-1-ARCH
- Terminal emulator and version: xterm(327)
- Python version: 2.7.13 and 3.6.0
- Ranger version/commit: 1.9.0b5
- Locale: en_US.UTF-8

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [X] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [X] All changes follow the code style **[REQUIRED]**
- [X] All new and existing tests pass **[REQUIRED]**
- [X] Changes require config files to be updated
    - [X] Config files have been updated
- [x] Changes require documentation to be updated
    - [x] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
<!-- Describe the changes in detail -->


#### MOTIVATION AND CONTEXT
<!-- Why are these changes required? -->
<!-- What problems do these changes solve? -->
<!-- Link to relevant issues -->
To simplify completion.

#### TESTING
<!-- What tests have been run? -->
<!-- How does the changes affect other areas of the codebase? -->
I only ran `make test` and used it about two days.