### PR TITLE
Improve error messages when calling commands without args

### DIFF
--- a/ranger/config/commands.py
+++ b/ranger/config/commands.py
@@ -208,6 +208,9 @@ class chain(Command):
     """
 
     def execute(self):
+        if not self.rest(1).strip():
+            self.fm.notify('Syntax: chain <command1>; <command2>; ...', bad=True)
+            return
         for command in [s.strip() for s in self.rest(1).split(";")]:
             self.fm.execute_console(command)
 
@@ -927,6 +930,9 @@ class chmod(Command):
     def execute(self):
         mode_str = self.rest(1)
         if not mode_str:
+            if not self.quantifier:
+                self.fm.notify("Syntax: chmod <octal number>", bad=True)
+                return
             mode_str = str(self.quantifier)
 
         try:
@@ -1180,7 +1186,8 @@ class map_(Command):
 
     def execute(self):
         if not self.arg(1) or not self.arg(2):
-            return self.fm.notify("Not enough arguments", bad=True)
+            self.fm.notify("Syntax: {0} <keysequence> <command>".format(self.get_name()), bad=True)
+            return
 
         self.fm.ui.keymaps.bind(self.context, self.arg(1), self.rest(2))
 
@@ -1455,6 +1462,9 @@ class flat(Command):
             level = int(level_str)
         except ValueError:
             level = self.quantifier
+        if level is None:
+            self.fm.notify("Syntax: flat <level>", bad=True)
+            return
         if level < -1:
             self.fm.notify("Need an integer number (-1, 0, 1, ...)", bad=True)
         self.fm.thisdir.unload()
@@ -1479,8 +1489,8 @@ class stage(Command):
             filelist = [f.path for f in self.fm.thistab.get_selection()]
             try:
                 self.fm.thisdir.vcs.action_add(filelist)
-            except VcsError as error:
-                self.fm.notify('Unable to stage files: {0:s}'.format(str(error)))
+            except VcsError as ex:
+                self.fm.notify('Unable to stage files: {0}'.format(ex))
             self.fm.ui.vcsthread.process(self.fm.thisdir)
         else:
             self.fm.notify('Unable to stage files: Not in repository')
@@ -1500,8 +1510,8 @@ class unstage(Command):
             filelist = [f.path for f in self.fm.thistab.get_selection()]
             try:
                 self.fm.thisdir.vcs.action_reset(filelist)
-            except VcsError as error:
-                self.fm.notify('Unable to unstage files: {0:s}'.format(str(error)))
+            except VcsError as ex:
+                self.fm.notify('Unable to unstage files: {0}'.format(ex))
             self.fm.ui.vcsthread.process(self.fm.thisdir)
         else:
             self.fm.notify('Unable to unstage files: Not in repository')

--- a/ranger/core/actions.py
+++ b/ranger/core/actions.py
@@ -74,11 +74,14 @@ class Actions(  # pylint: disable=too-many-instance-attributes,too-many-public-m
         if self.metadata:
             self.metadata.reset()
 
-    def change_mode(self, mode):
+    def change_mode(self, mode=None):
         """:change_mode <mode>
 
         Change mode to "visual" (selection) or "normal" mode.
         """
+        if mode is None:
+            self.fm.notify('Syntax: change_mode <mode>', bad=True)
+            return
         if mode == self.mode:  # pylint: disable=access-member-before-definition
             return
         if mode == 'visual':


### PR DESCRIPTION
<!-- Provide a descriptive summary of the changes in the title above -->

#### ISSUE TYPE
- Bug fix
- Improvement/feature implementation

#### CHECKLIST
- [X] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [X] All changes follow the code style **[REQUIRED]**
- [X] All new and existing tests pass **[REQUIRED]**

#### DESCRIPTION

Some commands crash with unhelpful error messages. For example with flat - calling `:flat` currently results in:

```
'<' not supported between instances of 'NoneType' and 'int'
```

This PR improves the error messages shown when calling the following commands with no arguments:

- flat
- chain
- map (including cmap, tmap, pmap)
- change_mode
