### PR TITLE
Added aid window for displaying miscellaneous information

### DIFF
--- a/ranger/core/actions.py
+++ b/ranger/core/actions.py
@@ -874,6 +874,20 @@ class Actions(  # pylint: disable=too-many-instance-attributes,too-many-public-m
     def hide_bookmarks(self):
         self.ui.browser.draw_bookmarks = False
 
+    def draw_aidwin(self):
+        """:draw_aidwin
+
+            Show aid window (see :set_aidwin).
+        """
+        self.ui.browser.draw_aidwin = True
+
+    def hide_aidwin(self):
+        """:hide_aidwin
+
+            Hide aid window (see :set_aidwin).
+        """
+        self.ui.browser.draw_aidwin = False
+
     def draw_possible_programs(self):
         try:
             target = self.thistab.get_selection()[0]
@@ -1459,3 +1473,11 @@ class Actions(  # pylint: disable=too-many-instance-attributes,too-many-public-m
             self.notify(err)
             return False
         return True
+
+    def set_aidwin(self, header="", *lines):
+        """:set_aidwin [<header> [<lines>]]
+
+            Set contents of aid window (for displaying see :draw_aidwin).
+        """
+        self.fm.aidwin["header"] = header
+        self.fm.aidwin["lines"] = lines

--- a/ranger/core/fm.py
+++ b/ranger/core/fm.py
@@ -67,6 +67,7 @@ class FM(Actions,  # pylint: disable=too-many-instance-attributes
         self.run = None
         self.rifle = None
         self.thistab = None
+        self.aidwin = {"header": "", "lines": []}
 
         try:
             self.username = pwd.getpwuid(os.geteuid()).pw_name

--- a/ranger/gui/widgets/view_base.py
+++ b/ranger/gui/widgets/view_base.py
@@ -13,6 +13,7 @@ from ..displayable import DisplayableContainer
 
 class ViewBase(Widget, DisplayableContainer):  # pylint: disable=too-many-instance-attributes
     draw_bookmarks = False
+    draw_aidwin = False
     need_clear = False
     draw_hints = False
     draw_info = False
@@ -43,6 +44,8 @@ class ViewBase(Widget, DisplayableContainer):  # pylint: disable=too-many-instan
         DisplayableContainer.draw(self)
         if self.draw_bookmarks:
             self._draw_bookmarks()
+        elif self.draw_aidwin:
+            self._draw_aidwin()
         elif self.draw_hints:
             self._draw_hints()
         elif self.draw_info:
@@ -85,9 +88,29 @@ class ViewBase(Widget, DisplayableContainer):  # pylint: disable=too-many-instan
         self.addnstr(ystart - 1, 0, "mark  path".ljust(self.wid), self.wid)
 
         whitespace = " " * maxlen
+
         for line, items in zip(range(self.hei - 1), sorted_bookmarks):
             key, mark = items
             string = " " + key + "   " + mark.path
+            self.addstr(ystart + line, 0, whitespace)
+            self.addnstr(ystart + line, 0, string, self.wid)
+
+        self.win.chgat(ystart - 1, 0, curses.A_UNDERLINE)
+
+    def _draw_aidwin(self):
+        self.columns[-1].clear_image(force=True)
+        self.color_reset()
+        self.need_clear = True
+
+        hei = min(self.hei - 1, len(self.fm.aidwin["lines"]))
+        ystart = self.hei - hei
+
+        maxlen = self.wid
+        self.addnstr(ystart - 1, 0, self.fm.aidwin["header"].ljust(self.wid), self.wid)
+
+        whitespace = " " * maxlen
+        for line, item in zip(range(self.hei - 1), self.fm.aidwin["lines"]):
+            string = " " + item
             self.addstr(ystart + line, 0, whitespace)
             self.addnstr(ystart + line, 0, string, self.wid)
 

--- a/ranger/gui/widgets/view_miller.py
+++ b/ranger/gui/widgets/view_miller.py
@@ -102,6 +102,8 @@ class ViewMiller(ViewBase):  # pylint: disable=too-many-ancestors,too-many-insta
             self._draw_borders()
         if self.draw_bookmarks:
             self._draw_bookmarks()
+        elif self.draw_aidwin:
+            self._draw_aidwin()
         elif self.draw_hints:
             self._draw_hints()
         elif self.draw_info:


### PR DESCRIPTION
<!-- Provide a descriptive summary of the changes in the title above -->
Added an implementaiton of an aid window, which looks the same as bookmarks, but allows to display any contents.
#### ISSUE TYPE
<!-- Pick relevant types and delete the rest -->
- Improvement/feature implementation

#### RUNTIME ENVIRONMENT
<!-- Details of your runtime environment -->
<!-- Retrieve Python/ranger version and locale with `ranger -\-version` -->
- Operating system and version: Arch Linux, x86
- Terminal emulator and version: xterm 327
- Python version: 3.6.0
- Ranger version/commit: 1.9.0b5
- Locale: cs_CZ.UTF-8

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [x ] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [ x] All changes follow the code style **[REQUIRED]**
- [ x] All new and existing tests pass **[REQUIRED]**
- [ ] Changes require config files to be updated
    - [ ] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
<!-- Describe the changes in detail -->
 Set contents by `:set_aidwin <header> <lines>` and show/hide by `:draw/hide_aidwin`

#### MOTIVATION AND CONTEXT
<!-- Why are these changes required? -->
<!-- What problems do these changes solve? -->
<!-- Link to relevant issues -->

This is extremely useful when using fasd. It can be used for any type of suggestions, options. The main advantage is that the user themselves can set it (even in `rc.conf`). My first big commit, so please take it into account when inspecting the code ;).

Command for running fasd:
```
class fasd(Command):
    """
    :fasd

    Jump to directory using fasd
    """
    def tab(self):
        #TODO

    def execute(self):
        self.fm.set_aidwin()
        self.fm.hide_aidwin()
        arg = self.rest(1)
        if arg:
            directory = subprocess.check_output(["fasd", "-d"]+arg.split(), universal_newlines=True).strip()
            self.fm.cd(directory)

    def cancel(self):
        self.fm.set_aidwin()
        self.fm.hide_aidwin()

    def quick(self):
        arg = self.rest(1)
        if arg:
            directory = subprocess.check_output(["fasd", "-l"]+arg.split(), universal_newlines=True).strip().split("\n")
            directory.reverse()
            self.fm.set_aidwin('Change to directory:', *directory)
            self.fm.draw_aidwin()
```


#### TESTING
<!-- What tests have been run? -->
<!-- How does the changes affect other areas of the codebase? -->


#### IMAGES / VIDEOS<!-- Only if relevant -->
<!-- Link or embed images and videos of screenshots, sketches etc. -->
