### PR TITLE
rc.conf: use the correct confpath for scope.sh

### DIFF
--- a/examples/rc_emacs.conf
+++ b/examples/rc_emacs.conf
@@ -37,7 +37,7 @@ set confirm_on_delete multiple
 # Which script is used to generate file previews?
 # ranger ships with scope.sh, a script that calls external programs (see
 # README.md for dependencies) to preview images, archives, etc.
-set preview_script ~/.config/ranger/scope.sh
+eval cmd("set preview_script " + fm.confpath("scope.sh"))
 
 # Use the external preview script or display simple plain text or image previews?
 set use_preview_script true

--- a/ranger/config/rc.conf
+++ b/ranger/config/rc.conf
@@ -43,7 +43,7 @@ set confirm_on_delete multiple
 # Which script is used to generate file previews?
 # ranger ships with scope.sh, a script that calls external programs (see
 # README.md for dependencies) to preview images, archives, etc.
-set preview_script ~/.config/ranger/scope.sh
+eval cmd("set preview_script " + fm.confpath("scope.sh"))
 
 # Use the external preview script or display simple plain text or image previews?
 set use_preview_script true


### PR DESCRIPTION
Change the default rc.conf to look inside $XDG_CONFIG_HOME rather than ~/.config, as required by the XDG Base Directory specification.

#### ISSUE TYPE
- Bug fix

#### CHECKLIST
- [X] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [X] All changes follow the code style **[REQUIRED]**
- [X] All new and existing tests pass **[REQUIRED]**
- [X] Changes require config files to be updated
    - [X] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION

The change is implemented with the line ```eval cmd("set preview_script " + fm.confpath("scope.sh"))```. This re-uses the fm.confpath function to guarantee that we’re using the same path as `ranger --copy-config`, which is the desired behavior.

#### MOTIVATION AND CONTEXT

This fixes #849; see the issue for details.