### PR TITLE
Implement the terminology-based image previews

### DIFF
--- a/ranger/core/fm.py
+++ b/ranger/core/fm.py
@@ -23,6 +23,7 @@ from ranger.gui.ui import UI
 from ranger.container.bookmarks import Bookmarks
 from ranger.core.runner import Runner
 from ranger.ext.img_display import (W3MImageDisplayer, ITerm2ImageDisplayer,
+                                    TerminologyImageDisplayer,
                                     URXVTImageDisplayer, URXVTImageFSDisplayer, ImageDisplayer)
 from ranger.core.metadata import MetadataManager
 from ranger.ext.rifle import Rifle
@@ -216,6 +217,8 @@ class FM(Actions,  # pylint: disable=too-many-instance-attributes
             return W3MImageDisplayer()
         elif self.settings.preview_images_method == "iterm2":
             return ITerm2ImageDisplayer()
+        elif self.settings.preview_images_method == "terminology":
+            return TerminologyImageDisplayer()
         elif self.settings.preview_images_method == "urxvt":
             return URXVTImageDisplayer()
         elif self.settings.preview_images_method == "urxvt-full":

--- a/ranger/ext/img_display.py
+++ b/ranger/ext/img_display.py
@@ -312,6 +312,61 @@ class ITerm2ImageDisplayer(ImageDisplayer, FileManagerAware):
         file_handle.close()
         return width, height
 
+class TerminologyImageDisplayer(ImageDisplayer, FileManagerAware):
+    """Implementation of ImageDisplayer using terminology image display support
+    (https://github.com/billiob/terminology).
+
+    Ranger must be running in terminology for this to work.
+    Doesn't work with TMUX :/
+    """
+
+    def __init__(self):
+        self.display_protocol = "\033"
+        self.close_protocol = "\000"
+
+    def draw(self, path, start_x, start_y, width, height):
+        # Save cursor
+        curses.putp(curses.tigetstr("sc"))
+
+        y = start_y
+        # Move to drawing zone
+        self._move_to(start_x, y)
+
+        # Write intent
+        sys.stdout.write("%s}ic#%d;%d;%s%s" % (
+            self.display_protocol,
+            width, height,
+            path,
+            self.close_protocol))
+
+        # Write Replacement commands ('#')
+        for x in range(0, height):
+            sys.stdout.write("%s}ib%s%s%s}ie%s" % (
+                self.display_protocol,
+                self.close_protocol,
+                "#" * width,
+                self.display_protocol,
+                self.close_protocol))
+            y = y + 1
+            self._move_to(start_x, y)
+
+        # Restore cursor
+        curses.putp(curses.tigetstr("rc"))
+
+        sys.stdout.flush()
+
+    def _move_to(self, x, y):
+        #  curses.move(y, x)
+        tparm = curses.tparm(curses.tigetstr("cup"), y, x)
+        if sys.version_info[0] < 3:
+            sys.stdout.write(tparm)
+        else:
+            sys.stdout.buffer.write(tparm)  # pylint: disable=no-member
+
+    def clear(self, start_x, start_y, width, height):
+        self.fm.ui.win.redrawwin()
+        self.fm.ui.win.refresh()
+
 
 class URXVTImageDisplayer(ImageDisplayer, FileManagerAware):
     """Implementation of ImageDisplayer working by setting the urxvt


### PR DESCRIPTION
Adds support for image previews for terminology (https://www.enlightenment.org/about-terminology)

#### ISSUE TYPE
- Improvement/feature implementation

#### DESCRIPTION
Adds `TerminologyImageDisplayer` class

#### TESTING
Works well (Terminology Version: 1.0.99).
Even for animated gifs ! It could probably work with videos too.
I couldn't make it work with TMUX.

