### PR TITLE
Show only directories when using --choosedir

### DIFF
--- a/ranger/config/commands.py
+++ b/ranger/config/commands.py
@@ -1480,22 +1480,12 @@ class filter_inode_type(Command):
         f display files
         l display links
     """
-    # pylint: disable=bad-whitespace
-    FILTER_DIRS  = 'd'
-    FILTER_FILES = 'f'
-    FILTER_LINKS = 'l'
-    # pylint: enable=bad-whitespace
 
     def execute(self):
         if not self.arg(1):
-            self.fm.thisdir.inode_type_filter = None
+            self.fm.thisdir.inode_type_filter = ""
         else:
-            self.fm.thisdir.inode_type_filter = lambda file: (
-                True if (
-                    (self.FILTER_DIRS in self.arg(1) and file.is_directory) or
-                    (self.FILTER_FILES in self.arg(1) and file.is_file and not file.is_link) or
-                    (self.FILTER_LINKS in self.arg(1) and file.is_link)
-                ) else False)
+            self.fm.thisdir.inode_type_filter = self.arg(1)
         self.fm.thisdir.refilter()
 
 

--- a/ranger/container/directory.py
+++ b/ranger/container/directory.py
@@ -92,15 +92,15 @@ def mtimelevel(path, level):
         mtime = max(mtime, max([-1] + [os.stat(d).st_mtime for d in dirlist]))
     return mtime
 
-class InodeFilterConstants(object):
+
+class InodeFilterConstants(object):  # pylint: disable=too-few-public-methods
     DIRS = 'd'
     FILES = 'f'
     LINKS = 'l'
 
+
 class Directory(  # pylint: disable=too-many-instance-attributes,too-many-public-methods
         FileSystemObject, Accumulator, Loadable):
-
-
     is_directory = True
     enterable = False
     load_generator = None
@@ -260,14 +260,17 @@ class Directory(  # pylint: disable=too-many-instance-attributes,too-many-public
             filters.append(hidden_filter_func)
         if self.settings.global_inode_type_filter or self.inode_type_filter:
             def inode_filter_func(obj):
-                # Use local inode_type_filter is present, global otherwise
+                # Use local inode_type_filter if present, global otherwise
                 inode_filter = self.inode_type_filter or self.settings.global_inode_type_filter
                 # Apply filter
-                if InodeFilterConstants.DIRS in inode_filter and obj.is_directory:
+                if InodeFilterConstants.DIRS in inode_filter and \
+                        obj.is_directory:
                     return True
-                elif InodeFilterConstants.FILES in inode_filter and obj.is_file and not obj.is_link:
+                elif InodeFilterConstants.FILES in inode_filter and \
+                        obj.is_file and not obj.is_link:
                     return True
-                elif InodeFilterConstants.LINKS in inode_filter and obj.is_link:
+                elif InodeFilterConstants.LINKS in inode_filter and \
+                        obj.is_link:
                     return True
                 return False
             filters.append(inode_filter_func)

--- a/ranger/container/directory.py
+++ b/ranger/container/directory.py
@@ -92,13 +92,14 @@ def mtimelevel(path, level):
         mtime = max(mtime, max([-1] + [os.stat(d).st_mtime for d in dirlist]))
     return mtime
 
+class InodeFilterConstants(object):
+    DIRS = 'd'
+    FILES = 'f'
+    LINKS = 'l'
 
 class Directory(  # pylint: disable=too-many-instance-attributes,too-many-public-methods
         FileSystemObject, Accumulator, Loadable):
 
-    FILTER_DIRS = 'd'
-    FILTER_FILES = 'f'
-    FILTER_LINKS = 'l'
 
     is_directory = True
     enterable = False
@@ -262,11 +263,11 @@ class Directory(  # pylint: disable=too-many-instance-attributes,too-many-public
                 # Use local inode_type_filter is present, global otherwise
                 inode_filter = self.inode_type_filter or self.settings.global_inode_type_filter
                 # Apply filter
-                if self.FILTER_DIRS in inode_filter and obj.is_directory:
+                if InodeFilterConstants.DIRS in inode_filter and obj.is_directory:
                     return True
-                elif self.FILTER_FILES in inode_filter and obj.is_file and not obj.is_link:
+                elif InodeFilterConstants.FILES in inode_filter and obj.is_file and not obj.is_link:
                     return True
-                elif self.FILTER_LINKS in inode_filter and obj.is_link:
+                elif InodeFilterConstants.LINKS in inode_filter and obj.is_link:
                     return True
                 return False
             filters.append(inode_filter_func)

--- a/ranger/container/directory.py
+++ b/ranger/container/directory.py
@@ -258,12 +258,9 @@ class Directory(  # pylint: disable=too-many-instance-attributes,too-many-public
                 return True
             filters.append(hidden_filter_func)
         if self.settings.global_inode_type_filter or self.inode_type_filter:
-            def hidden_inode_filter_func(obj):
+            def inode_filter_func(obj):
                 # Use local inode_type_filter is present, global otherwise
-                if self.inode_type_filter:
-                    inode_filter = self.inode_type_filter
-                else:
-                    inode_filter = self.settings.global_inode_type_filter
+                inode_filter = self.inode_type_filter or self.settings.global_inode_type_filter
                 # Apply filter
                 if self.FILTER_DIRS in inode_filter and obj.is_directory:
                     return True
@@ -272,7 +269,7 @@ class Directory(  # pylint: disable=too-many-instance-attributes,too-many-public
                 elif self.FILTER_LINKS in inode_filter and obj.is_link:
                     return True
                 return False
-            filters.append(hidden_inode_filter_func)
+            filters.append(inode_filter_func)
         if self.filter:
             filter_search = self.filter.search
             filters.append(lambda fobj: filter_search(fobj.basename))

--- a/ranger/container/settings.py
+++ b/ranger/container/settings.py
@@ -41,6 +41,7 @@ ALLOWED_SETTINGS = {
     'draw_borders': bool,
     'draw_progress_bar_in_status_bar': bool,
     'flushinput': bool,
+    'global_inode_type_filter': str,
     'hidden_filter': str,
     'idle_delay': int,
     'line_numbers': str,

--- a/ranger/core/main.py
+++ b/ranger/core/main.py
@@ -119,6 +119,9 @@ def main(
         FileManagerAware.fm_set(fm)
         load_settings(fm, args.clean)
 
+        if args.choosedir:
+            SettingsAware.settings.global_inode_type_filter = 'd'
+
         if args.list_unused_keys:
             from ranger.ext.keybinding_parser import (special_keys,
                                                       reversed_special_keys)

--- a/ranger/core/main.py
+++ b/ranger/core/main.py
@@ -120,7 +120,7 @@ def main(
         load_settings(fm, args.clean)
 
         if args.choosedir:
-            SettingsAware.settings.global_inode_type_filter = 'd'
+            fm.settings.global_inode_type_filter = 'd'
 
         if args.list_unused_keys:
             from ranger.ext.keybinding_parser import (special_keys,

--- a/ranger/core/main.py
+++ b/ranger/core/main.py
@@ -120,7 +120,8 @@ def main(
         load_settings(fm, args.clean)
 
         if args.choosedir:
-            fm.settings.global_inode_type_filter = 'd'
+            from ranger.container.directory import InodeFilterConstants
+            fm.settings.global_inode_type_filter = InodeFilterConstants.DIRS
 
         if args.list_unused_keys:
             from ranger.ext.keybinding_parser import (special_keys,


### PR DESCRIPTION
#### ISSUE TYPE
- Improvement/feature implementation

#### CHECKLIST
- [X] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [X] All changes follow the code style **[REQUIRED]**
- [X] All new and existing tests pass **[REQUIRED]**
- [ ] Changes require config files to be updated
    - [ ] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
Added global_inode_filter_type setting for global filtering of file types. Uses same logic as the filter_inode_type command.

Sets the `global_inode_filter_type` to `'d'` (for directory) when --choosedir flag is used

#### MOTIVATION AND CONTEXT
Addresses request for global filtering of files when using --choosedir= in issue #821 

#### TESTING
Have done basic testing by hand to ensure functionality