### PR TITLE
Image displayer improvements

### DIFF
--- a/ranger/core/fm.py
+++ b/ranger/core/fm.py
@@ -21,7 +21,7 @@ from ranger.container.tags import Tags, TagsDummy
 from ranger.gui.ui import UI
 from ranger.container.bookmarks import Bookmarks
 from ranger.core.runner import Runner
-from ranger.ext.img_display import *
+from ranger.ext.img_display import image_displayers
 from ranger.core.metadata import MetadataManager
 from ranger.ext.rifle import Rifle
 from ranger.container.directory import Directory
@@ -213,16 +213,7 @@ class FM(Actions, SignalDispatcher):
                 yield line
 
     def _get_image_displayer(self):
-        if self.settings.preview_images_method == "w3m":
-            return W3MImageDisplayer()
-        elif self.settings.preview_images_method == "iterm2":
-            return ITerm2ImageDisplayer()
-        elif self.settings.preview_images_method == "urxvt":
-            return URXVTImageDisplayer()
-        elif self.settings.preview_images_method == "urxvt-full":
-            return URXVTImageFSDisplayer()
-        else:
-            return ImageDisplayer()
+        return image_displayers.get(self.settings.preview_images_method)()
 
     def _get_thisfile(self):
         return self.thistab.thisfile

--- a/ranger/ext/img_display.py
+++ b/ranger/ext/img_display.py
@@ -74,6 +74,37 @@ class ImageDisplayer(ImageDisplayerBase, metaclass=ImageDisplayerMeta):
 class ImgDisplayUnsupportedException(Exception):
     pass
 
+@register_image_displayer("auto")
+def AutoImageDisplayer():
+    """Automatically select a context-appropriate ImageDisplayer."""
+
+    from shutil import which
+
+    def is_term(term):
+        try:
+            import psutil
+        except ImportError:
+            return False
+        proc = psutil.Process()
+        while proc:
+            proc = proc.parent()
+            if proc.name() == term:
+                return True
+        return False
+
+    if is_term("iterm2"): # Is the name of the binary iterm or iterm2?
+        return ITerm2ImageDisplayer()
+    if which("w2mimgdisplay"):
+        return W3MImageDisplayer()
+    if which("mpv"):
+        return MPVImageDisplayer()
+    if is_term("urxvt"):
+        return URXVTImageDisplayer()
+
+    raise ImgDisplayUnsupportedException
+    #  return ImageDisplayer()
+    #  return ASCIIImageDisplayer()
+
 
 class W3MImageDisplayer(ImageDisplayer):
     """Implementation of ImageDisplayer using w3mimgdisplay, an utilitary


### PR DESCRIPTION
Added ImageDisplayer registry, automatic selection and a new ImageDisplayer.

#### ISSUE TYPE
- Improvement/feature implementation

#### RUNTIME ENVIRONMENT
- Operating system and version: Arch Linux
- Terminal emulator and version: st 0.7
- Python version: 3.6.1
- Ranger version/commit: 1.8.1/10d7174613e9865b065c52e57af8b0799cd106b0
- Locale: en_us

#### CHECKLIST
- [X] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [X] All changes follow the code style **[REQUIRED]**
- [X] All new and existing tests pass **[REQUIRED]**
- [ ] Changes require config files to be updated
    - [ ] Config files have been updated
- [X] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
- commit b7af7b6fcd32e60141e64cb1162e8d1de74a45c6
I've added a registry for ImageDisplayers, to manage a growing number of sub-classes and to allow users to add their own sub-classes. This commit provides a register function and a metaclass for ImageDisplayer. Each ImageDisplayer can simply set METHOD_NAME to the desired key.
- commit e4005d10ba28a6a27644dad325619364d089229a
The user can now choose "set preview_method auto" to choose an ImageDisplayer that will run in the given environment. Simple heuristics are used, such as searching the parent process tree (optionally with psutils) for the currently used terminal. An arbitrary test ordering was used: iterm2 > w3m > urxvt.
- commit b05c6858ae016d90e4004f6b766d08c8c0b2a856
The user can now "set preview_method mpv" to use mpv as their ImageDisplayer. This uses mpv 0.25's socket IPC mechanism. The new "auto" order is: iterm2 > w3m > mpv > urxvt. More work on this will need to be done to configure mpv to not resize the window on media change.



#### MOTIVATION AND CONTEXT
To ease the management of many ImageDisplayers and allow users to easily implement their own. Also, to utilize a popular media viewer (mpv) that behaves differently from current ImageDisplayers.

Link to relevant issues:
MPV provides an alternative that may act as a satisfactory workaround for these issues: #864 #820 #856 #467



#### TESTING
What tests have been run?
I have run the included tests and have been using the mpv method myself.

How does the changes affect other areas of the codebase?
I don't think it will.
