### PR TITLE
Yank command

### DIFF
--- a/ranger/config/commands.py
+++ b/ranger/config/commands.py
@@ -1688,6 +1688,7 @@ class yank(Command):
 
     def execute(self):
         import subprocess
+
         def clipboards():
             from ranger.ext.get_executables import get_executables
             clipboard_managers = {

--- a/ranger/config/commands.py
+++ b/ranger/config/commands.py
@@ -1721,7 +1721,7 @@ class yank(Command):
             process.communicate(input=input_argument)
 
     def get_selection_attr(self, attr):
-        return [getattr(file, attr) for file in
+        return [getattr(item, attr) for item in
                 self.fm.thistab.get_selection()]
 
     def tab(self, tabnum):

--- a/ranger/config/commands.py
+++ b/ranger/config/commands.py
@@ -88,7 +88,6 @@ from __future__ import (absolute_import, division, print_function)
 from collections import deque
 import os
 import re
-import subprocess
 
 from ranger.api.commands import Command
 
@@ -1676,7 +1675,7 @@ class linemode(default_linemode):
 class yank(Command):
     """:yank [name|dir|path]
 
-    Copies the file's name(default), directory or path into both the primary X
+    Copies the file's name (default), directory or path into both the primary X
     selection and the clipboard.
     """
 
@@ -1688,6 +1687,7 @@ class yank(Command):
     }
 
     def execute(self):
+        import subprocess
         def clipboards():
             from ranger.ext.get_executables import get_executables
             clipboard_managers = {
@@ -1708,17 +1708,16 @@ class yank(Command):
             for manager in ordered_managers:
                 if manager in executables:
                     return clipboard_managers[manager]
-
             return []
 
         clipboard_commands = clipboards()
 
         selection = self.get_selection_attr(self.modes[self.arg(1)])
-        input_argument = "\n".join(selection)
+        new_clipboard_contents = "\n".join(selection)
         for command in clipboard_commands:
             process = subprocess.Popen(command, universal_newlines=True,
                                        stdin=subprocess.PIPE)
-            process.communicate(input=input_argument)
+            process.communicate(input=new_clipboard_contents)
 
     def get_selection_attr(self, attr):
         return [getattr(item, attr) for item in

--- a/ranger/config/rc.conf
+++ b/ranger/config/rc.conf
@@ -375,10 +375,10 @@ map g? cd /usr/share/doc/ranger
 map E  edit
 map du shell -p du --max-depth=1 -h --apparent-size
 map dU shell -p du --max-depth=1 -h --apparent-size | sort -rh
-map yp shell -f echo -n %d/%f     | xsel -i && xsel -o | xsel -i -b
-map yd shell -f echo -n %d        | xsel -i && xsel -o | xsel -i -b
-map yn shell -f echo -n %f        | xsel -i && xsel -o | xsel -i -b
-map ys shell -f printf '%%s\n' %s | xsel -i && xsel -o | xsel -i -b
+map yp yank path
+map yd yank dir
+map yn yank name
+map ys yank name
 
 # Filesystem Operations
 map =  chmod


### PR DESCRIPTION
Implement a yank command instead of the long mappings for yn, yd, yp and ys.

#### ISSUE TYPE
- Improvement/feature implementation

#### CHECKLIST
- [x] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [x] All changes follow the code style **[REQUIRED]**
- [x] All new and existing tests pass **[REQUIRED]**
- [x] Changes require config files to be updated
    - [x] Config files have been updated
- [x] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
The command can use any of pbcopy, xclip or xsel, depending on what's available.
Behaviour for yn, yd and yp has changed. Instead of the highlighted file they operate on the selection, defaulting to the highlighted file if nothing's selected.


#### MOTIVATION AND CONTEXT
The yank command makes it easier to use multiple clipboard managers, xclip instead of xsel for example. It also groups the behaviour of several long mappings.


#### TESTING
Manually tested the command in all it's incantations.
