### PR TITLE
Add nomacs image viewer support

### DIFF
--- a/ranger/config/rifle.conf
+++ b/ranger/config/rifle.conf
@@ -175,6 +175,7 @@ mime ^image, has mirage,    X, flag f = mirage -- "$@"
 mime ^image, has ristretto, X, flag f = ristretto "$@"
 mime ^image, has eog,       X, flag f = eog -- "$@"
 mime ^image, has eom,       X, flag f = eom -- "$@"
+mime ^image, has nomacs,    X, flag f = nomacs -- "$@"
 mime ^image, has gimp,      X, flag f = gimp -- "$@"
 ext xcf,                    X, flag f = gimp -- "$@"
 


### PR DESCRIPTION
Add nomacs image viewer to the default list of image viewers.

#### ISSUE TYPE
- Improvement/feature implementation

#### RUNTIME ENVIRONMENT
- Operating system and version: Arch Linux with testing repositories
- Terminal emulator and version: rxvt-unicode 9.22
- Python version: 3.6.1
- Ranger version/commit: 1.8.1
- Locale: en_US.UTF-8

#### CHECKLIST
- [X] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [X] All changes follow the code style **[REQUIRED]**
- [X] All new and existing tests pass **[REQUIRED]**
- [ ] Changes require config files to be updated
    - [ ] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
Adds [nomacs](https://nomacs.org/) to the default list of supported image viewers to open files with.

#### MOTIVATION AND CONTEXT
I was previously a user of mirage, but development has ceased on that. [nomacs](https://nomacs.org/) seems like a solid replacement as it's light weight, been around for a while, and still in development. It is also [available in the default repositories](https://nomacs.org/download/) of a number of distributions.

This change eliminates the need for me to have a custom rifle.conf. 

#### TESTING
Tested by running ranger without custom configuration.