### PR TITLE
Switch the order of experimental plugin loading and rc.conf sourcing

### DIFF
--- a/ranger/core/main.py
+++ b/ranger/core/main.py
@@ -350,19 +350,6 @@ def load_settings(  # pylint: disable=too-many-locals,too-many-branches,too-many
                 LOG.debug("Loaded custom commands from '%s'", custom_comm_path)
             sys.dont_write_bytecode = old_bytecode_setting
 
-        allow_access_to_confdir(ranger.args.confdir, False)
-
-        # Load rc.conf
-        custom_conf = fm.confpath('rc.conf')
-        default_conf = fm.relpath('config', 'rc.conf')
-
-        if os.environ.get('RANGER_LOAD_DEFAULT_RC', 'TRUE').upper() != 'FALSE':
-            fm.source(default_conf)
-        if os.access(custom_conf, os.R_OK):
-            fm.source(custom_conf)
-
-        allow_access_to_confdir(ranger.args.confdir, True)
-
         # XXX Load plugins (experimental)
         plugindir = fm.confpath('plugins')
         try:
@@ -399,6 +386,15 @@ def load_settings(  # pylint: disable=too-many-locals,too-many-branches,too-many
             ranger.fm = None
 
         allow_access_to_confdir(ranger.args.confdir, False)
+        # Load rc.conf
+        custom_conf = fm.confpath('rc.conf')
+        default_conf = fm.relpath('config', 'rc.conf')
+
+        if os.environ.get('RANGER_LOAD_DEFAULT_RC', 'TRUE').upper() != 'FALSE':
+            fm.source(default_conf)
+        if os.access(custom_conf, os.R_OK):
+            fm.source(custom_conf)
+
     else:
         fm.source(fm.relpath('config', 'rc.conf'))
 


### PR DESCRIPTION
#### ISSUE TYPE
- Bug fix

#### RUNTIME ENVIRONMENT
- Operating system and version: Mac OS X El Captain
- Terminal emulator and version: iTerm2
- Python version: Python 2.7.13
- Ranger version/commit: ranger-master 1.9.0b5
- Locale: None.None

#### CHECKLIST
- [X] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [X] All changes follow the code style **[REQUIRED]**
- [X] All new and existing tests pass **[REQUIRED]**
- [ ] Changes require config files to be updated
    - [ ] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
Simply move the rc.conf loading chunk after plugin so that default_linemode plugin can be load propoerly


#### MOTIVATION AND CONTEXT
To make the default_linemode plugins other plugins, that rc.conf might relies on, work properly.

<!-- Why are these changes required? -->
<!-- What problems do these changes solve? -->
If you run without --debug it roughly work but pop this annoying message in terminal:
```.bash
Invalid linemode: devicons; should be metatitle/sizemtime/filename/mtime/fileinfo/permissions
```
[Issue #3](https://github.com/alexanderjeurissen/ranger_devicons/issues/3)
If run with --debug, you get error message:
```.bash
ranger version: ranger-master 1.9.0b5
Python version: 2.7.13 (default, Dec 17 2016, 23:03:43) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.42.1)]
Locale: None.None

Traceback (most recent call last):
  File "/usr/local/lib/python2.7/site-packages/ranger/core/main.py", line 120, in main
    load_settings(fm, args.clean)
  File "/usr/local/lib/python2.7/site-packages/ranger/core/main.py", line 362, in load_settings
    fm.source(custom_conf)
  File "/usr/local/lib/python2.7/site-packages/ranger/core/actions.py", line 385, in source
    self.execute_console(line)
  File "/usr/local/lib/python2.7/site-packages/ranger/core/actions.py", line 249, in execute_console
    cmd.execute()
  File "/usr/local/lib/python2.7/site-packages/ranger/config/commands.py", line 535, in execute
    bad=True,
  File "/usr/local/lib/python2.7/site-packages/ranger/core/actions.py", line 168, in notify
    raise Exception(str(obj))
Exception: Invalid linemode: devicons; should be metatitle/sizemtime/filename/mtime/fileinfo/permissions

ranger crashed. Please report this traceback at:
https://github.com/ranger/ranger/issues
```


#### TESTING
load devicons plugin and the error message no longer appears
rc.conf now source after experimental plugin loading, might impact the code that assume this order.

