### PR TITLE
Added the w3mimgdisplay path for OpenBSD systems to W3MIMGDISPLAY_PATHS

### DIFF
--- a/ranger/ext/img_display.py
+++ b/ranger/ext/img_display.py
@@ -32,6 +32,7 @@ W3MIMGDISPLAY_PATHS = [
     '/usr/libexec/w3m/w3mimgdisplay',
     '/usr/lib64/w3m/w3mimgdisplay',
     '/usr/libexec64/w3m/w3mimgdisplay',
+    '/usr/local/libexec/w3m/w3mimgdisplay',
 ]
 
 


### PR DESCRIPTION
<!-- Provide a descriptive summary of the changes in the title above -->
Additional path to check for W3MIMGDISPLAY_PATHS, to fix w3m image previewing on OpenBSD.

#### ISSUE TYPE
<!-- Pick relevant types and delete the rest -->
- Bug fix

#### RUNTIME ENVIRONMENT
<!-- Details of your runtime environment -->
<!-- Retrieve Python/ranger version and locale with `ranger -\-version` -->
- Operating system and version: OpenBSD 6.1 amd64
- Terminal emulator and version: rxvt-unicode 9.22
- Python version: 3.6.0/2.7.13
- Ranger version/commit: 1.7.2
- Locale: en_US.UTF-8

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [X] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [X] All changes follow the code style **[REQUIRED]**
- [X] All new and existing tests pass **[REQUIRED]**
- [ ] Changes require config files to be updated
    - [ ] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
<!-- Describe the changes in detail -->
Added the correct path to check for w3imgdisplay on OpenBSD systems

#### MOTIVATION AND CONTEXT
<!-- Why are these changes required? -->
<!-- What problems do these changes solve? -->
<!-- Link to relevant issues -->
Image previewing does not currently work on OpenBSD (though it has since been fixed in the OpenBSD port).  I'd like to get this change in upstream so there are fewer patches for the port.

#### TESTING
<!-- What tests have been run? -->
<!-- How does the changes affect other areas of the codebase? -->
All tests.  Shouldn't affect anything else in the codebase.

#### IMAGES / VIDEOS<!-- Only if relevant -->
<!-- Link or embed images and videos of screenshots, sketches etc. -->
