### PR TITLE
Open epub files with ebook-viewer

### DIFF
--- a/ranger/config/rifle.conf
+++ b/ranger/config/rifle.conf
@@ -162,6 +162,8 @@ ext djvu, has zathura,X, flag f = zathura -- "$@"
 ext djvu, has evince, X, flag f = evince -- "$@"
 ext djvu, has atril,  X, flag f = atril -- "$@"
 
+ext epub, has ebook-viewer, X, flag f = ebook-viewer "$@"
+
 #-------------------------------------------
 # Image Viewing:
 #-------------------------------------------


### PR DESCRIPTION
Adds support for opening `epub` ebook files with ebook-viewer (included with Calibre).

#### ISSUE TYPE
- Improvement/feature implementation

#### RUNTIME ENVIRONMENT
- Operating system and version: Arch Linux w/ testing repos
- Terminal emulator and version: rxvt-unicode 9.22
- Python version: 3.6.1
- Ranger version/commit: ranger-stable 1.8.1
- Locale: en_US.UTF-8

#### CHECKLIST
- [X] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [X] All changes follow the code style **[REQUIRED]**
- [X] All new and existing tests pass **[REQUIRED]**
- [ ] Changes require config files to be updated
    - [ ] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
Adds a sane default for opening epub files. Calibre is a commonly used ebook management solution that includes an epub reader: ebook-viewer.


#### MOTIVATION AND CONTEXT
epub is a common ebook format. This adds support built-in support for opening such files from ranger.


#### TESTING
Manually - rifle.conf addition only.
