### PR TITLE
tests: Reenable indentation linting

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,3 @@
 [flake8]
 max-line-length = 99
-ignore = E221,E128
+ignore = E221

--- a/.pylintrc
+++ b/.pylintrc
@@ -8,7 +8,7 @@ max-branches=16
 
 [FORMAT]
 max-line-length = 99
-disable=locally-disabled,locally-enabled,missing-docstring,duplicate-code,fixme,cyclic-import,redefined-variable-type,bad-continuation
+disable=locally-disabled,locally-enabled,missing-docstring,duplicate-code,fixme,cyclic-import,redefined-variable-type
 
 [TYPECHECK]
 ignored-classes=ranger.core.actions.Actions

--- a/ranger/container/directory.py
+++ b/ranger/container/directory.py
@@ -172,9 +172,10 @@ class Directory(  # pylint: disable=too-many-instance-attributes,too-many-public
     @lazy_property
     def vcs(self):
         if not self._vcs_signal_handler_installed:
-            self.settings.signal_bind('setopt.vcs_aware',
-                    self.vcs__reset,  # pylint: disable=no-member
-                    weak=True, autosort=False)
+            self.settings.signal_bind(
+                'setopt.vcs_aware', self.vcs__reset,  # pylint: disable=no-member
+                weak=True, autosort=False,
+            )
             self._vcs_signal_handler_installed = True
         if self.settings.vcs_aware:
             return Vcs(self)


### PR DESCRIPTION
<!-- Provide a descriptive summary of the changes in the title above -->

#### ISSUE TYPE
<!-- Pick relevant types and delete the rest -->
- Improvement/feature implementation

#### RUNTIME ENVIRONMENT
<!-- Details of your runtime environment -->
<!-- Retrieve Python/ranger version and locale with `ranger -\-version` -->
- Operating system and version: Arch Linux
- Terminal emulator and version: urxvt 9.22 and tmux 2.3
- Python version: 3.6.2
- Ranger version/commit: a81b6ecf750aba0eb9efceea88f43ffbf3729700
- Locale: en_US.UTF-8

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [x] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [x] All changes follow the code style **[REQUIRED]**
- [x] All new and existing tests pass **[REQUIRED]**


#### DESCRIPTION
<!-- Describe the changes in detail -->
Reenable linting for indentation.


#### MOTIVATION AND CONTEXT
<!-- Why are these changes required? -->
<!-- What problems do these changes solve? -->
<!-- Link to relevant issues -->
Will make it much easier to parse and understand the codebase in the future. Not hard to make new code compliant.


#### TESTING
<!-- What tests have been run? -->
<!-- How does the changes affect other areas of the codebase? -->
`make test`
