### PR TITLE
Add reference to x-terminal-emulator in man page

### DIFF
--- a/doc/ranger.1
+++ b/doc/ranger.1
@@ -129,7 +129,7 @@
 .\" ========================================================================
 .\"
 .IX Title "RANGER 1"
-.TH RANGER 1 "ranger-1.9.0b5" "07/16/2017" "ranger manual"
+.TH RANGER 1 "ranger-1.9.0b5" "12/09/17" "ranger manual"
 .\" For nroff, turn off justification.  Always turn off hyphenation; it makes
 .\" way too many mistakes in technical documents.
 .if n .ad l
@@ -1451,7 +1451,8 @@ the \*(L"S\*(R" key.  Defaults to \*(L"/bin/sh\*(R".
 .IP "\s-1TERMCMD\s0" 8
 .IX Item "TERMCMD"
 Defines the terminal emulator command that ranger is going to use with the
-:terminal command and the \*(L"t\*(R" run flag.  Defaults to \*(L"xterm\*(R".
+:terminal command and the \*(L"t\*(R" run flag.  Defaults to \*(L"x\-terminal-emulator\*(R"
+or \*(L"xterm\*(R".
 .IP "\s-1XDG_CONFIG_HOME\s0" 8
 .IX Item "XDG_CONFIG_HOME"
 Specifies the directory for configuration files. Defaults to \fI\f(CI$HOME\fI/.config\fR.

--- a/doc/ranger.pod
+++ b/doc/ranger.pod
@@ -1562,7 +1562,8 @@ the "S" key.  Defaults to "/bin/sh".
 =item TERMCMD
 
 Defines the terminal emulator command that ranger is going to use with the
-:terminal command and the "t" run flag.  Defaults to "xterm".
+:terminal command and the "t" run flag.  Defaults to "x-terminal-emulator"
+or "xterm".
 
 
 =item XDG_CONFIG_HOME


### PR DESCRIPTION
:terminal first defaults to x-terminal-emulator and then failbacks to xterm

Fix #940 

First time editing man pages, hope it's ok.

BTW, it seems that `make man` on my machine decided to change the date format, I don't know it that's okay, I could change it back manually if needed.