### PR TITLE
Faster mercurial vcs

### DIFF
--- a/ranger/ext/vcs/vcs.py
+++ b/ranger/ext/vcs/vcs.py
@@ -112,7 +112,11 @@ class Vcs(object):  # pylint: disable=too-many-instance-attributes
     def _run(self, args, path=None,  # pylint: disable=too-many-arguments
              catchout=True, retbytes=False, rstrip_newline=True):
         """Run a command"""
-        cmd = [self.repotype] + args
+        if self.repotype == 'hg':
+            # use "chg", a faster built-in client
+            cmd = ['chg'] + args
+        else:
+            cmd = [self.repotype] + args
         if path is None:
             path = self.path
 


### PR DESCRIPTION
Use "chg", a faster client to mercurial shipped with mercurial itself. This fixes the unrecoverable hang I get when entering a folder with many hg repos.

<!-- Provide a descriptive summary of the changes in the title above -->

#### ISSUE TYPE
<!-- Pick relevant types and delete the rest -->
- Bug fix

#### RUNTIME ENVIRONMENT
<!-- Details of your runtime environment -->
<!-- Retrieve Python/ranger version and locale with `ranger -\-version` -->
- Operating system and version: Arch Linux
- Terminal emulator and version: Gnome terminal
- Python version: 3.6
- Ranger version/commit:  5bd92b3
- Locale: en_US

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [x] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [x] All changes follow the code style **[REQUIRED]**
- [x] All new and existing tests pass **[REQUIRED]**
- [ ] Changes require config files to be updated
    - [ ] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION

Call chg instead than hg for much better performance

#### MOTIVATION AND CONTEXT

Necessary if we want to use vcs_enabled_hg inside folders containing many hg repos.

#### TESTING

Only empirical testing.
