### PR TITLE
If the user config is not available, always load the global one

### DIFF
--- a/ranger/core/main.py
+++ b/ranger/core/main.py
@@ -396,9 +396,11 @@ def load_settings(  # pylint: disable=too-many-locals,too-many-branches,too-many
         custom_conf = fm.confpath('rc.conf')
         default_conf = fm.relpath('config', 'rc.conf')
 
-        if os.environ.get('RANGER_LOAD_DEFAULT_RC', 'TRUE').upper() != 'FALSE':
+        custom_conf_is_readable = os.access(custom_conf, os.R_OK)
+        if (os.environ.get('RANGER_LOAD_DEFAULT_RC', 'TRUE').upper() != 'FALSE' or
+                not custom_conf_is_readable):
             fm.source(default_conf)
-        if os.access(custom_conf, os.R_OK):
+        if custom_conf_is_readable:
             fm.source(custom_conf)
 
     else:


### PR DESCRIPTION
Ignore the RANGER_LOAD_DEFAULT_RC environmental variable if the user config doesn't exist or is unreadable because not loading any config would result in an unusable ranger instance.