### PR TITLE
Add config options for iTerm2 font size (related to issue #499)

### DIFF
--- a/doc/ranger.1
+++ b/doc/ranger.1
@@ -129,7 +129,7 @@
 .\" ========================================================================
 .\"
 .IX Title "RANGER 1"
-.TH RANGER 1 "ranger-1.9.0b5" "10/01/2017" "ranger manual"
+.TH RANGER 1 "ranger-1.9.0b5" "10/22/2017" "ranger manual"
 .\" For nroff, turn off justification.  Always turn off hyphenation; it makes
 .\" way too many mistakes in technical documents.
 .if n .ad l
@@ -295,6 +295,10 @@ This only works in iTerm2 compiled with image preview support, but works over
 ssh.
 .PP
 To enable this feature, set the option \f(CW\*(C`preview_images_method\*(C'\fR to iterm2.
+.PP
+This feature relies on the dimensions of the terminal's font.  By default, a
+width of 8 and height of 11 are used.  To use other values, set the options
+\&\f(CW\*(C`iterm2_font_width\*(C'\fR and \f(CW\*(C`iterm2_font_height\*(C'\fR to the desired values.
 .PP
 \fIurxvt\fR
 .IX Subsection "urxvt"

--- a/doc/ranger.pod
+++ b/doc/ranger.pod
@@ -201,6 +201,10 @@ ssh.
 
 To enable this feature, set the option C<preview_images_method> to iterm2.
 
+This feature relies on the dimensions of the terminal's font.  By default, a
+width of 8 and height of 11 are used.  To use other values, set the options
+C<iterm2_font_width> and C<iterm2_font_height> to the desired values.
+
 =head3 urxvt
 
 This only works in urxvt compiled with pixbuf support. Does not work over ssh.

--- a/doc/rifle.1
+++ b/doc/rifle.1
@@ -129,7 +129,7 @@
 .\" ========================================================================
 .\"
 .IX Title "RIFLE 1"
-.TH RIFLE 1 "rifle-1.9.0b5" "10/01/2017" "rifle manual"
+.TH RIFLE 1 "rifle-1.9.0b5" "10/22/2017" "rifle manual"
 .\" For nroff, turn off justification.  Always turn off hyphenation; it makes
 .\" way too many mistakes in technical documents.
 .if n .ad l

--- a/ranger/config/rc.conf
+++ b/ranger/config/rc.conf
@@ -80,6 +80,10 @@ set preview_images false
 #   (http://iterm2.com/images.html). This requires using iTerm2 compiled
 #   with image preview support.
 #
+#   This feature relies on the dimensions of the terminal's font.  By default, a
+#   width of 8 and height of 11 are used.  To use other values, set the options
+#   iterm2_font_width and iterm2_font_height to the desired values.
+#
 # * urxvt:
 #   Preview images in full color using urxvt image backgrounds. This
 #   requires using urxvt compiled with pixbuf support.
@@ -88,6 +92,10 @@ set preview_images false
 #   The same as urxvt but utilizing not only the preview pane but the
 #   whole terminal window.
 set preview_images_method w3m
+
+# Default iTerm2 font size (see: preview_images_method: iterm2)
+set iterm2_font_width 8
+set iterm2_font_height 11
 
 # Use a unicode "..." character to mark cut-off filenames?
 set unicode_ellipsis false

--- a/ranger/container/settings.py
+++ b/ranger/container/settings.py
@@ -47,6 +47,8 @@ ALLOWED_SETTINGS = {
     'hidden_filter': str,
     'hostname_in_titlebar': bool,
     'idle_delay': int,
+    'iterm2_font_width': int,
+    'iterm2_font_height': int,
     'line_numbers': str,
     'max_console_history_size': (int, type(None)),
     'max_history_size': (int, type(None)),

--- a/ranger/ext/img_display.py
+++ b/ranger/ext/img_display.py
@@ -205,8 +205,6 @@ class ITerm2ImageDisplayer(ImageDisplayer, FileManagerAware):
 
     Ranger must be running in iTerm2 for this to work.
     """
-    _minimum_font_width = 8
-    _minimum_font_height = 11
 
     def draw(self, path, start_x, start_y, width, height):
         curses.putp(curses.tigetstr("sc"))
@@ -246,8 +244,8 @@ class ITerm2ImageDisplayer(ImageDisplayer, FileManagerAware):
         return text
 
     def _fit_width(self, width, height, max_cols, max_rows):
-        max_width = self._minimum_font_width * max_cols
-        max_height = self._minimum_font_height * max_rows
+        max_width = self.fm.settings.iterm2_font_width * max_cols
+        max_height = self.fm.settings.iterm2_font_height * max_rows
         if height > max_height:
             if width > max_width:
                 width_scale = max_width / width


### PR DESCRIPTION
Add two config options "iterm2_font_width" and "iterm2_font_height" that
override the default values of _minimum_font_width and
_minimum_font_height in ITerm2ImageDisplayer.  The default values may
cause preview distortion if set too high (Issue #499) or result in the
preview being smaller than necessary if set too low.

#### ISSUE TYPE
- Bug fix
- Improvement/feature implementation

#### RUNTIME ENVIRONMENT
- Operating system and version: OSX
- Terminal emulator and version: iTerm2 3.1.3
- Python version: 2.7.10
- Ranger version/commit: ranger-master 1.9.0b5
- Locale: None.None

#### CHECKLIST
- [X] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [X] All changes follow the code style **[REQUIRED]**
- [X] All new and existing tests pass **[REQUIRED]**
- [X] Changes require config files to be updated
    - [X] Config files have been updated
- [X] Changes require documentation to be updated
    - [X] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
Add config options: "iterm2_font_width" and "iterm2_font_height" to replace the hardcoded default font dimensions in ITerm2ImageDisplayer:
```
 _minimum_font_width = 8
 _minimum_font_height = 11
```


#### MOTIVATION AND CONTEXT
Issue #499 
A default font width that's too high can cause preview image distortion.  Default values that are too small will cause the preview to be smaller than required.


#### TESTING
The change seems straightforward.  I ran without changes to my personal rc.conf and it functioned as before.  Then I added to my rc.conf:
```
set iterm2_font_width 7
set iterm2_font_height 15
```
and previews of large images were no longer distorted.


#### IMAGES / VIDEOS
Before:
![screen shot 2017-10-22 at 2 38 52 pm](https://user-images.githubusercontent.com/41033/31866594-ef53ca34-b736-11e7-90d3-b071f253ca84.png)
After:
![screen shot 2017-10-22 at 2 39 29 pm](https://user-images.githubusercontent.com/41033/31866598-f9012428-b736-11e7-9414-ed2230908e7e.png)
