### PR TITLE
Show current date and time in status bar

### DIFF
--- a/ranger/gui/context.py
+++ b/ranger/gui/context.py
@@ -16,7 +16,7 @@ CONTEXT_KEYS = [
     'good', 'bad',
     'space', 'permissions', 'owner', 'group', 'mtime', 'nlink',
     'scroll', 'all', 'bot', 'top', 'percentage', 'filter',
-    'flat', 'marked', 'tagged', 'tag_marker', 'cut', 'copied', 'frozen',
+    'flat', 'marked', 'tagged', 'tag_marker', 'cut', 'copied', 'frozen', 'currenttime',
     'help_markup',  # COMPAT
     'seperator', 'key', 'special', 'border',  # COMPAT
     'title', 'text', 'highlight', 'bars', 'quotes', 'tab', 'loaded',

--- a/ranger/gui/widgets/statusbar.py
+++ b/ranger/gui/widgets/statusbar.py
@@ -35,6 +35,7 @@ class StatusBar(Widget):  # pylint: disable=too-many-instance-attributes
     old_ctime = None
     old_du = None
     old_hint = None
+    old_currenttime = None
     result = None
 
     def __init__(self, win, column=None):
@@ -83,6 +84,8 @@ class StatusBar(Widget):  # pylint: disable=too-many-instance-attributes
         else:
             ctime = -1
 
+        currenttime = strftime('%M', localtime())
+
         if not self.result:
             self.need_redraw = True
 
@@ -92,6 +95,10 @@ class StatusBar(Widget):  # pylint: disable=too-many-instance-attributes
 
         if self.old_thisfile != self.fm.thisfile:
             self.old_thisfile = self.fm.thisfile
+            self.need_redraw = True
+
+        if self.old_currenttime != currenttime:
+            self.old_currenttime = currenttime
             self.need_redraw = True
 
         if self.old_ctime != ctime:
@@ -301,6 +308,9 @@ class StatusBar(Widget):  # pylint: disable=too-many-instance-attributes
                           base, 'percentage')
         else:
             right.add('0/0  All', base, 'all')
+        right.add("  ", "space")
+
+        right.add(strftime(self.timeformat, localtime()), 'currenttime')
 
         if self.settings.freeze_files:
             # Indicate that files are frozen and will not be loaded


### PR DESCRIPTION
#### ISSUE TYPE
- Improvement/feature implementation

#### RUNTIME ENVIRONMENT
- Operating system and version: macOS High Sierra (10.13)
- Terminal emulator and version: macOS Terminal.app 2.8 (400)
- Python version: 2.7.10
- Ranger version/commit: ranger-master 1.9.0b5
- Locale: None.None

#### CHECKLIST
- [x] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [x] All changes follow the code style **[REQUIRED]**
- [x] All new and existing tests pass **[REQUIRED]**
- [ ] Changes require config files to be updated
    - [ ] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
A date and time indicator has been added to the right of the status bar. It displays in the same format as the date and time indicator already used for the _ctime_ and _vcs commit_ displays. It updates every minute.


#### MOTIVATION AND CONTEXT
The addition was motivated by the lack of a current date and time display in ranger. I often work with the terminal fullscreen and, having come across ranger recently and having integrated it into my workflow, could do with seeing the current date and time from within ranger.


#### TESTING
The supplied tests have been performed and passed. The changes are very self-contained therefore the changes do not have far-reaching effects.


#### IMAGES / VIDEOS
![screen shot 2017-10-23 at 19 41 54](https://user-images.githubusercontent.com/7461694/31906937-4f85bb26-b82a-11e7-83df-b5edfe7ab6ab.png)
