### PR TITLE
Open PDFs with Preview in macOS

### DIFF
--- a/ranger/config/rifle.conf
+++ b/ranger/config/rifle.conf
@@ -149,6 +149,7 @@ ext pdf, has atril,    X, flag f = atril -- "$@"
 ext pdf, has okular,   X, flag f = okular -- "$@"
 ext pdf, has epdfview, X, flag f = epdfview -- "$@"
 ext pdf, has qpdfview, X, flag f = qpdfview "$@"
+ext pdf, has open,     X, flat f = open "$@"
 
 ext docx?, has catdoc,       terminal = catdoc -- "$@" | "$PAGER"
 


### PR DESCRIPTION
<!-- Provide a descriptive summary of the changes in the title above -->

#### ISSUE TYPE
<!-- Pick relevant types and delete the rest -->
- Improvement/feature implementation

#### RUNTIME ENVIRONMENT
<!-- Details of your runtime environment -->
<!-- Retrieve Python/ranger version and locale with `ranger -\-version` -->
- Operating system and version: macOS Sierra
- Terminal emulator and version: iTerm2 3.1.5
- Python version: Python 3.6.2
- Ranger version/commit: 1.9.0b5
- Locale: ??? What is it?

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [x ] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [ x] All changes follow the code style **[REQUIRED]**
- [ ] All new and existing tests pass **[REQUIRED]**
- [ x] Changes require config files to be updated
    - [x ] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
<!-- Describe the changes in detail -->
You can open PDFs with Preview in macOS with just an enter.

#### MOTIVATION AND CONTEXT
<!-- Why are these changes required? -->
Eases your life.
<!-- What problems do these changes solve? -->
Easily open PDFs in Mac
<!-- Link to relevant issues -->


#### TESTING
<!-- What tests have been run? -->
Test wouldn't be necessary for this minor change. I tried to run tests but ran into:
```
AttributeError: 'TreeRebuilder3k' object has no attribute 'visit_joinedstr'
```
<!-- How does the changes affect other areas of the codebase? -->
Nothing

#### IMAGES / VIDEOS<!-- Only if relevant -->
<!-- Link or embed images and videos of screenshots, sketches etc. -->