### PR TITLE
Rotate the image previews according to the EXIF data

### DIFF
--- a/ranger/data/scope.sh
+++ b/ranger/data/scope.sh
@@ -95,6 +95,15 @@ handle_image() {
 
         # Image
         image/*)
+            local orientation
+            orientation="$( identify -format '%[EXIF:Orientation]\n' -- "${FILE_PATH}" )"
+            # If orientation data is present and the image actually
+            # needs rotating ("1" means no rotation)...
+            if [[ -n "$orientation" && "$orientation" != 1 ]]; then
+                # ...auto-rotate the image according to the EXIF data.
+                convert -- "${FILE_PATH}" -auto-orient "${IMAGE_CACHE_PATH}" && exit 6
+            fi
+
             # `w3mimgdisplay` will be called for all images (unless overriden as above),
             # but might fail for unsupported types.
             exit 7;;


### PR DESCRIPTION
It may cause a small overhead of checking the EXIF data for each file. Possible alternatives:

- Running `convert -auto-orient` for each and every image without doing this check. The preview will get cached but then each and every image will get copied to the cache directory usually with no such need.
- Commenting out this code by default, so it's easily available but still opt-in.

Fixes #927.