### PR TITLE
Fix column_ratios tab completion

### DIFF
--- a/ranger/config/commands.py
+++ b/ranger/config/commands.py
@@ -445,13 +445,18 @@ class set_(Command):
             return sorted(self.firstpart + setting for setting in settings
                           if setting.startswith(name))
         if not value:
-            # Cycle through colorschemes when name, but no value is specified
-            if name == "colorscheme":
-                return sorted(self.firstpart + colorscheme for colorscheme
-                              in get_all_colorschemes(self.fm))
-            if name == "column_ratios":
-                return self.firstpart + ",".join(map(str, settings[name]))
-            return self.firstpart + str(settings[name])
+            value_completers = {
+                "colorscheme": lambda:
+                # Cycle through colorschemes when name, but no value is specified
+                sorted(self.firstpart + colorscheme for colorscheme
+                       in get_all_colorschemes(self.fm)),
+
+                "column_ratios": lambda:
+                self.firstpart + ",".join(map(str, settings[name])),
+            }
+            def default_value_completer():
+                return self.firstpart + str(settings[name])
+            return value_completers.get(name, default_value_completer)()
         if bool in settings.types_of(name):
             if 'true'.startswith(value.lower()):
                 return self.firstpart + 'True'

--- a/ranger/config/commands.py
+++ b/ranger/config/commands.py
@@ -446,16 +446,18 @@ class set_(Command):
                           if setting.startswith(name))
         if not value:
             value_completers = {
-                "colorscheme": lambda:
+                "colorscheme":
                 # Cycle through colorschemes when name, but no value is specified
-                sorted(self.firstpart + colorscheme for colorscheme
-                       in get_all_colorschemes(self.fm)),
+                lambda: sorted(self.firstpart + colorscheme for colorscheme
+                               in get_all_colorschemes(self.fm)),
 
-                "column_ratios": lambda:
-                self.firstpart + ",".join(map(str, settings[name])),
+                "column_ratios":
+                lambda: self.firstpart + ",".join(map(str, settings[name])),
             }
+
             def default_value_completer():
                 return self.firstpart + str(settings[name])
+
             return value_completers.get(name, default_value_completer)()
         if bool in settings.types_of(name):
             if 'true'.startswith(value.lower()):

--- a/ranger/config/commands.py
+++ b/ranger/config/commands.py
@@ -449,6 +449,8 @@ class set_(Command):
             if name == "colorscheme":
                 return sorted(self.firstpart + colorscheme for colorscheme
                               in get_all_colorschemes(self.fm))
+            if name == "column_ratios":
+                return self.firstpart + ",".join(map(str, settings[name]))
             return self.firstpart + str(settings[name])
         if bool in settings.types_of(name):
             if 'true'.startswith(value.lower()):


### PR DESCRIPTION
The tab completion for `:set column_ratios <TAB>` previously used the literal list representation of this setting (e.g. `[1, 3, 4]`) which cannot be used in this syntax. Now this list is joined into a single comma-separated string that is actually usable (e.g. `1,3,4`).
  