### PR TITLE
Fixed crushing ranger when file stats inaccessible

### DIFF
--- a/ranger/core/linemode.py
+++ b/ranger/core/linemode.py
@@ -128,4 +128,4 @@ class SizeMtimeLinemode(LinemodeBase):
 
     def infostring(self, file, metadata):
         return "%s %s" % (human_readable(file.size),
-                          datetime.fromtimestamp(file.stat.st_mtime).strftime("%Y-%m-%d %H:%M"))
+                          datetime.fromtimestamp(file.stat.st_mtime).strftime("%Y-%m-%d %H:%M") if file.stat is not None else "")


### PR DESCRIPTION
Simple fix from crashing ranger when file stats is inaccessible

#### ISSUE TYPE
- Bug fix

#### RUNTIME ENVIRONMENT
```
Linux domst 4.8.0-53-generic #56~16.04.1-Ubuntu SMP Tue May 16 01:18:56 UTC 2017 x86_64 x86_64 x86_64 GNU/Linux
GNU bash, version 4.3.48(1)-release (x86_64-pc-linux-gnu)
Python 2.7.12
ranger-stable 1.8.1
```

  #### CHECKLIST
<!-- Replace [ ] with [X] when fulfilled -->
- [X] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [X] All changes follow the code style **[REQUIRED]**
- [X] All new and existing tests pass **[REQUIRED]**
- [ ] Changes require config files to be updated (new options using by default)
    - [ ] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
<!-- Describe the changes in detail -->
The crashing can happened when file that stat (properties) need to take can't be resolved by system library (sys/stat.h). There are number of errors that can happened when you try to access to the file: search permission is denied, not valid file descriptor, out of memory, etc.
You can get it in the reference manual by stat - http://man7.org/linux/man-pages/man2/stat.2.html in the "Errors" paragraph (EACCES, EBADF, EOVERFLOW, etc).
To fix this, we just don't display parameters that we can't take.