### PR TITLE
:touch and :mkdir focus their argument

### DIFF
--- a/ranger/config/commands.py
+++ b/ranger/config/commands.py
@@ -838,12 +838,17 @@ class mkdir(Command):
     def execute(self):
         from os.path import join, expanduser, lexists
         from os import makedirs
+        from ranger.container.file import File
 
         dirname = join(self.fm.thisdir.path, expanduser(self.rest(1)))
         if not lexists(dirname):
             makedirs(dirname)
+            dir_new = File(dirname)
+            self.fm.thisfile = dir_new
+            self.fm.thisdir.pointed_obj = dir_new
         else:
             self.fm.notify("file/directory exists!", bad=True)
+            self.fm.thisdir.move_to_obj(dirname)
 
     def tab(self, tabnum):
         return self._tab_directory_content()
@@ -857,12 +862,19 @@ class touch(Command):
 
     def execute(self):
         from os.path import join, expanduser, lexists
+        from os import utime
+        from ranger.container.file import File
 
         fname = join(self.fm.thisdir.path, expanduser(self.rest(1)))
         if not lexists(fname):
             open(fname, 'a').close()
+            file_new = File(fname)
+            self.fm.thisfile = file_new
+            self.fm.thisdir.pointed_obj = file_new
         else:
-            self.fm.notify("file/directory exists!", bad=True)
+            self.fm.notify("file/directory exists!")
+            utime(fname)
+            self.fm.thisdir.move_to_obj(fname)
 
     def tab(self, tabnum):
         return self._tab_directory_content()


### PR DESCRIPTION
:touch now behaves more like the unix command in case the file already
exists, the notification is now info-level instead of error.
Both :touch and :mkdir now focus the new/existing file/directory.

Fix #1028


#### ISSUE TYPE
- Improvement/feature implementation

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [x] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [x] All changes follow the code style **[REQUIRED]**
- [x] All new and existing tests pass **[REQUIRED]**
- [ ] Changes require config files to be updated
    - [ ] Config files have been updated
- [x] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
<!-- Describe the changes in detail -->
Not sure whether documentation should be updated.

#### MOTIVATION AND CONTEXT
<!-- Why are these changes required? -->
<!-- What problems do these changes solve? -->
<!-- Link to relevant issues -->
Make touch behave more like the unix command and since that could just as well be called mkfile, give mkdir the same behaviour.