### PR TITLE
Solve map conflict for `gt`.

### DIFF
--- a/ranger/config/rc.conf
+++ b/ranger/config/rc.conf
@@ -387,7 +387,7 @@ map gv cd /var
 map gm cd /media
 map gM cd /mnt
 map gs cd /srv
-map gt cd /tmp
+map gp cd /tmp
 map gr cd /
 map gR eval fm.cd(ranger.RANGERDIR)
 map g/ cd /


### PR DESCRIPTION
For consistency with vim `gt` still means _go to the next tab_ the map
for _go to /tmp_ is now `gp` (first available letter in `/tmp`).

Fix #1040

<!-- Provide a descriptive summary of the changes in the title above -->

#### ISSUE TYPE
<!-- Pick relevant types and delete the rest -->
- Improvement/feature implementation

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [x] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [x] All changes follow the code style **[REQUIRED]**
- [x] All new and existing tests pass **[REQUIRED]**
- [x] Changes require config files to be updated
    - [x] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### MOTIVATION AND CONTEXT
<!-- Why are these changes required? -->
<!-- What problems do these changes solve? -->
<!-- Link to relevant issues -->
The map for `/tmp` was useless, now it's not.
The map for `/run/media/$USER` was missing and fit in well with both `/media` and `/mnt`.
Maybe the map for `/media` should also include `$USER`?
Possibly we should handle the case where `$USER` is `root` specially, dropping the `$USER` part.
Since these "hardcoded" maps are getting somewhat cluttered, maybe we should consider having a new bookmarks namespace with system directories.

#### TESTING
<!-- What tests have been run? -->
<!-- How does the changes affect other areas of the codebase? -->
Tested both maps.