### PR TITLE
Make new `rifle` behavior backwards compatible.

### DIFF
--- a/ranger/ext/rifle.py
+++ b/ranger/ext/rifle.py
@@ -343,15 +343,8 @@ class Rifle(object):  # pylint: disable=too-many-instance-attributes
         else:
             if 'PAGER' not in os.environ:
                 os.environ['PAGER'] = DEFAULT_PAGER
-            if 'VISUAL' not in os.environ:
-                if 'EDITOR' not in os.environ:
-                    os.environ['VISUAL'] = DEFAULT_EDITOR
-                    # necessary for compatibility with old rifle.conf
-                    os.environ['EDITOR'] = DEFAULT_EDITOR
-            else:
-                if 'EDITOR' not in os.environ:
-                    # similar to new behavior for old rifle.conf
-                    os.environ['EDITOR'] = os.environ['VISUAL']
+            if 'EDITOR' not in os.environ:
+                os.environ['EDITOR'] = os.environ.get('VISUAL', DEFAULT_EDITOR)
             command = self.hook_command_postprocessing(command)
             self.hook_before_executing(command, self._mimetype, self._app_flags)
             try:

--- a/ranger/ext/rifle.py
+++ b/ranger/ext/rifle.py
@@ -343,10 +343,15 @@ class Rifle(object):  # pylint: disable=too-many-instance-attributes
         else:
             if 'PAGER' not in os.environ:
                 os.environ['PAGER'] = DEFAULT_PAGER
-            if 'VISUAL' not in os.environ and 'EDITOR' not in os.environ:
-                os.environ['VISUAL'] = DEFAULT_EDITOR
-                # necessary for compatibility with old rifle.conf
-                os.environ['EDITOR'] = DEFAULT_EDITOR
+            if 'VISUAL' not in os.environ:
+                if 'EDITOR' not in os.environ:
+                    os.environ['VISUAL'] = DEFAULT_EDITOR
+                    # necessary for compatibility with old rifle.conf
+                    os.environ['EDITOR'] = DEFAULT_EDITOR
+            else:
+                if 'EDITOR' not in os.environ:
+                    # similar to new behavior for old rifle.conf
+                    os.environ['EDITOR'] = os.environ['VISUAL']
             command = self.hook_command_postprocessing(command)
             self.hook_before_executing(command, self._mimetype, self._app_flags)
             try:


### PR DESCRIPTION
There's 4 possible situation:

  1. `VISUAL` set, `EDITOR` set
  2. `VISUAL` set, `EDITOR` not set
  3. `VISUAL` not set, `EDITOR` set
  4. `VISUAL` not set, `EDITOR` not set

All but _No.2_ are already properly handled.
Behavior can differ depending on whether you have an old or a new `rifle.conf` in cases
_No.1_ (if the variables differ the new approach prefers `VISUAL` instead of `EDITOR`)
and _No.2_ (new approach will use `VISUAL` whereas the old approach would've fallen back to _vim_).
_No.3_ is likely the most common case and works almost identically with either approach.
_No.4_ still falls back to _vim_ as before.

Fix #1048