### PR TITLE
Update bindings for media directories

### DIFF
--- a/ranger/config/rc.conf
+++ b/ranger/config/rc.conf
@@ -384,7 +384,7 @@ map gl cd -r .
 map gL cd -r %f
 map go cd /opt
 map gv cd /var
-map gm eval fm.cd('/media/' + os.getenv('USER'))
+map gm cd /media
 map gi eval fm.cd('/run/media/' + os.getenv('USER'))
 map gM cd /mnt
 map gs cd /srv

--- a/ranger/config/rc.conf
+++ b/ranger/config/rc.conf
@@ -384,7 +384,8 @@ map gl cd -r .
 map gL cd -r %f
 map go cd /opt
 map gv cd /var
-map gm cd /media
+map gm eval fm.cd('/media/' + os.getenv('USER'))
+map gi eval fm.cd('/run/media/' + os.getenv('USER'))
 map gM cd /mnt
 map gs cd /srv
 map gt cd /tmp


### PR DESCRIPTION
Because of `udisks2` `/run/media/$USER` is becoming a common directory
for automounting, this adds a keybinding to go there (using the first
available letter in the path).

Similarly the binding for `/media` now points to `/media/$USER`, because
for example ubuntu adopted this new location.
I believe the `$USER` parts have to do with security, giving only the
user that mounted a filesystem access to it.

<!-- Provide a descriptive summary of the changes in the title above -->

#### ISSUE TYPE
<!-- Pick relevant types and delete the rest -->
- Improvement/feature implementation

These locations are already common but as I understand it not definite yet. We could wait until the new FHS spec is finalized.