### PR TITLE
Change bulkrename to execute a fixed command

### DIFF
--- a/ranger/config/commands.py
+++ b/ranger/config/commands.py
@@ -1056,6 +1056,8 @@ class bulkrename(Command):
     After you close it, it will be executed.
     """
 
+    RENAME_CMD = 'vim "$@"'
+
     def execute(self):  # pylint: disable=too-many-locals,too-many-statements
         import sys
         import tempfile
@@ -1073,7 +1075,8 @@ class bulkrename(Command):
         else:
             listfile.write("\n".join(filenames))
         listfile.close()
-        self.fm.execute_file([File(listpath)], app='editor')
+        rename_command = "set -- '%s'; %s" % (File(listpath).path, self.RENAME_CMD)
+        self.fm.rifle.execute_command(rename_command)
         listfile = open(listpath, 'r')
         new_filenames = listfile.read().split("\n")
         listfile.close()
@@ -1098,7 +1101,8 @@ class bulkrename(Command):
 
         # Open the script and let the user review it, then check if the script
         # was modified by the user
-        self.fm.execute_file([File(cmdfile.name)], app='editor')
+        review_command = "set -- '%s'; %s" % (File(cmdfile.name).path, self.RENAME_CMD)
+        self.fm.rifle.execute_command(review_command)
         cmdfile.seek(0)
         script_was_edited = (script_content != cmdfile.read())
 

--- a/ranger/ext/get_executables.py
+++ b/ranger/ext/get_executables.py
@@ -56,8 +56,14 @@ def get_term():
     Either $TERMCMD, $TERM, "x-terminal-emulator" or "xterm", in this order.
     """
     command = environ.get('TERMCMD', environ.get('TERM'))
-    if shlex.split(command)[0] not in get_executables():
+    command = shlex.split(command)[0]
+    if command.startswith('rxvt-'):
+        if 'rxvt' in get_executables():
+            command = 'rxvt'
+        else:
+            command = 'urxvt'
+    if command not in get_executables():
         command = 'x-terminal-emulator'
         if command not in get_executables():
-            command = 'xterm'
+            raise EnvironmentError('Could not detect executable terminal emulator')
     return command


### PR DESCRIPTION
Do not attempt to resolve mimetypes and labels to determine the right
call for the bulkrename command. We always need the same behaviour.

Fixes #880

#### ISSUE TYPE
- Bug fix

#### RUNTIME ENVIRONMENT
- Operating system and version: 4.14.15-1-ARCH
- Terminal emulator and version: rxvt-unicode (urxvt) v9.22 - released: 2016-01-23
- Python version: 3.6.4 (default, Jan  5 2018, 02:35:40) [GCC 7.2.1 20171224]
- Ranger version/commit: ranger-master 1.9.0 (afdd6aafcc0654424f8901e8aa83948382ef7bd2)
- Locale: en_US.UTF-8

#### CHECKLIST
- [X] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [X] All changes follow the code style **[REQUIRED]**
- [X] All new and existing tests pass **[REQUIRED]**
- [ ] Changes require config files to be updated
    - [ ] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
bulkrename command now uses a fixed command instead of using rifle to determine it. The command is simply `vim "$@"`, which may not be the best choice.
In `rifle.py` `execute` function was refactored to allow execution of a predetermined command.


#### MOTIVATION AND CONTEXT
#880