### PR TITLE
fix automatically_count_files false

### DIFF
--- a/ranger/ext/human_readable.py
+++ b/ranger/ext/human_readable.py
@@ -15,6 +15,10 @@ def human_readable(byte, separator=' '):  # pylint: disable=too-many-return-stat
     '1023 M'
     """
 
+    # handle automatically_count_files false
+    if byte is None:
+        return ''
+
     # I know this can be written much shorter, but this long version
     # performs much better than what I had before.  If you attempt to
     # shorten this code, take performance into consideration.


### PR DESCRIPTION
ranger will fail if `automatically_count_files false` is set.

- Bug fix

```
ranger version: ranger-master 1.9.0
Python version: 3.6.4 (default, Jan  5 2018, 02:35:40) [GCC 7.2.1 20171224]
Locale: en_US.UTF-8
Current file: '/home/laktak'

Traceback (most recent call last):
  File "/home/laktak/ranger/ranger/core/main.py", line 196, in main
    fm.loop()
  File "/home/laktak/ranger/ranger/core/fm.py", line 390, in loop
    ui.redraw()
  File "/home/laktak/ranger/ranger/gui/ui.py", line 338, in redraw
    self.draw()
  File "/home/laktak/ranger/ranger/gui/ui.py", line 365, in draw
    DisplayableContainer.draw(self)
  File "/home/laktak/ranger/ranger/gui/displayable.py", line 256, in draw
    displayable.draw()
  File "/home/laktak/ranger/ranger/gui/widgets/view_miller.py", line 100, in draw
    DisplayableContainer.draw(self)
  File "/home/laktak/ranger/ranger/gui/displayable.py", line 256, in draw
    displayable.draw()
  File "/home/laktak/ranger/ranger/gui/widgets/browsercolumn.py", line 178, in draw
    self._draw_directory()
  File "/home/laktak/ranger/ranger/gui/widgets/browsercolumn.py", line 364, in _draw_directory
    infostringdata = current_linemode.infostring(drawn, metadata)
  File "/home/laktak/ranger/ranger/core/linemode.py", line 132, in infostring
    return "%s %s" % (human_readable(fobj.size),
  File "/home/laktak/ranger/ranger/ext/human_readable.py", line 21, in human_readable
    if byte <= 0:
TypeError: '<=' not supported between instances of 'NoneType' and 'int'
```

#### RUNTIME ENVIRONMENT
ranger version: ranger-master 1.9.0
Python version: 3.6.4 (default, Jan  5 2018, 02:35:40) [GCC 7.2.1 20171224]
Arch Linux
US

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [x] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [x] All changes follow the code style **[REQUIRED]**
- [x] All new and existing tests pass **[REQUIRED]**

#### DESCRIPTION
Return `''` for `None` in `human_readable`.


#### MOTIVATION AND CONTEXT
bugfix
