### PR TITLE
Deprecate :bulkrename

### DIFF
--- a/ranger/config/commands.py
+++ b/ranger/config/commands.py
@@ -1048,81 +1048,25 @@ class chmod(Command):
 class bulkrename(Command):
     """:bulkrename
 
-    This command opens a list of selected files in an external editor.
-    After you edit and save the file, it will generate a shell script
-    which does bulk renaming according to the changes you did in the file.
+    Use vidir(1) to rename the selected files. Please refer to
+    vidir(1) documentation for details.
 
-    This shell script is opened in an editor for you to review.
-    After you close it, it will be executed.
     """
 
-    def execute(self):  # pylint: disable=too-many-locals,too-many-statements
-        import sys
-        import tempfile
-        from ranger.container.file import File
-        from ranger.ext.shell_escape import shell_escape as esc
-        py3 = sys.version_info[0] >= 3
-
-        # Create and edit the file list
+    def execute(self):
+        import subprocess
         filenames = [f.relative_path for f in self.fm.thistab.get_selection()]
-        listfile = tempfile.NamedTemporaryFile(delete=False)
-        listpath = listfile.name
-
-        if py3:
-            listfile.write("\n".join(filenames).encode("utf-8"))
-        else:
-            listfile.write("\n".join(filenames))
-        listfile.close()
-        self.fm.execute_file([File(listpath)], app='editor')
-        listfile = open(listpath, 'r')
-        new_filenames = listfile.read().split("\n")
-        listfile.close()
-        os.unlink(listpath)
-        if all(a == b for a, b in zip(filenames, new_filenames)):
-            self.fm.notify("No renaming to be done!")
-            return
-
-        # Generate script
-        cmdfile = tempfile.NamedTemporaryFile()
-        script_lines = []
-        script_lines.append("# This file will be executed when you close the editor.\n")
-        script_lines.append("# Please double-check everything, clear the file to abort.\n")
-        script_lines.extend("mv -vi -- %s %s\n" % (esc(old), esc(new))
-                            for old, new in zip(filenames, new_filenames) if old != new)
-        script_content = "".join(script_lines)
-        if py3:
-            cmdfile.write(script_content.encode("utf-8"))
-        else:
-            cmdfile.write(script_content)
-        cmdfile.flush()
-
-        # Open the script and let the user review it, then check if the script
-        # was modified by the user
-        self.fm.execute_file([File(cmdfile.name)], app='editor')
-        cmdfile.seek(0)
-        script_was_edited = (script_content != cmdfile.read())
-
-        # Do the renaming
-        self.fm.run(['/bin/sh', cmdfile.name], flags='w')
-        cmdfile.close()
-
-        # Retag the files, but only if the script wasn't changed during review,
-        # because only then we know which are the source and destination files.
-        if not script_was_edited:
-            tags_changed = False
-            for old, new in zip(filenames, new_filenames):
-                if old != new:
-                    oldpath = self.fm.thisdir.path + '/' + old
-                    newpath = self.fm.thisdir.path + '/' + new
-                    if oldpath in self.fm.tags:
-                        old_tag = self.fm.tags.tags[oldpath]
-                        self.fm.tags.remove(oldpath)
-                        self.fm.tags.tags[newpath] = old_tag
-                        tags_changed = True
-            if tags_changed:
-                self.fm.tags.dump()
-        else:
-            fm.notify("files have not been retagged")
+        try:
+            vidir = subprocess.Popen(
+                ["vidir", "-"],
+                stdin=subprocess.PIPE,
+                universal_newlines=True,
+            )
+            vidir.communicate("\n".join(filenames).encode('utf-8'))
+            if vidir.returncode != 0:
+                fm.notify("vidir encountered an error", bad=True)
+        except OSError:
+            fm.notify("vidir(1) is needed to use :bulkrename", bad=True)
 
 
 class relink(Command):


### PR DESCRIPTION
:bulkrename is now an alias to vidir(1).

Advantages of vidir:
- proper resolution of rename cycles, whereas a cycle in :bulkrename would cause a data loss
- fewer other subtle bugs like this
- less code to maintain
- uses $VISUAL/$EDITOR instead of calling rifle (fixes #880)

Disadvantages of vidir:
- it's a new soft dependency
- it doesn't track the ranger tags of the renamed files, unlike :bulkrename
- it's no longer possible to replace "mv" with another command before executing the scenario (doubtful whether anyone actually would do this)