### PR TITLE
change PATH to OUTFILE to avoid confusion

### DIFF
--- a/ranger/core/main.py
+++ b/ranger/core/main.py
@@ -267,17 +267,17 @@ def parse_arguments():
     parser.add_option('--copy-config', type='string', metavar='which',
                       help="copy the default configs to the local config directory. "
                       "Possible values: all, rc, rifle, commands, commands_full, scope")
-    parser.add_option('--choosefile', type='string', metavar='PATH',
+    parser.add_option('--choosefile', type='string', metavar='OUTFILE',
                       help="Makes ranger act like a file chooser. When opening "
                       "a file, it will quit and write the name of the selected "
-                      "file to PATH.")
-    parser.add_option('--choosefiles', type='string', metavar='PATH',
+                      "file to OUTFILE.")
+    parser.add_option('--choosefiles', type='string', metavar='OUTFILE',
                       help="Makes ranger act like a file chooser for multiple files "
                       "at once. When opening a file, it will quit and write the name "
-                      "of all selected files to PATH.")
-    parser.add_option('--choosedir', type='string', metavar='PATH',
+                      "of all selected files to OUTFILE.")
+    parser.add_option('--choosedir', type='string', metavar='OUTFILE',
                       help="Makes ranger act like a directory chooser. When ranger quits"
-                      ", it will write the name of the last visited directory to PATH")
+                      ", it will write the name of the last visited directory to OUTFILE")
     parser.add_option('--selectfile', type='string', metavar='filepath',
                       help="Open ranger with supplied file selected.")
     parser.add_option('--show-only-dirs', action='store_true',


### PR DESCRIPTION
The metavar "PATH" is likely being confused with the environment
variable PATH. OUTFILE makes it clearer that the "PATH" in question is a
file.

<!-- Provide a descriptive summary of the changes in the title above -->

#### ISSUE TYPE

- Improvement/feature implementation

#### RUNTIME ENVIRONMENT
<!-- Details of your runtime environment -->
<!-- Retrieve Python/ranger version and locale with `ranger -\-version` -->
- Operating system and version: Arch Linux, Kernel 4.14.15-1-ARCH
- Terminal emulator and version: termite v13
- Python version: 3.6.4
- Ranger version/commit: 1.9.0
- Locale: en_GB.UTF-8

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [X] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [X] All changes follow the code style **[REQUIRED]**
- [X] All new and existing tests pass **[REQUIRED]**
- [ ] Changes require config files to be updated
    - [ ] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
<!-- Describe the changes in detail -->
The PATH metavar has been changed in the help text (`ranger --help`) to avoid confusion with the environmental variable of the same name.

#### MOTIVATION AND CONTEXT
<!-- Why are these changes required? -->
<!-- What problems do these changes solve? -->
<!-- Link to relevant issues -->
Avoid confusion (see above)

#### TESTING
<!-- What tests have been run? -->
<!-- How does the changes affect other areas of the codebase? -->
`make test` has been run. All tests passed.
