### PR TITLE
Support cygwin UNC paths

### DIFF
--- a/ranger/core/tab.py
+++ b/ranger/core/tab.py
@@ -144,7 +144,14 @@ class Tab(FileManagerAware, SettingsAware):  # pylint: disable=too-many-instance
         else:
             pathway = []
             currentpath = '/'
-            for comp in path.split('/'):
+            spath = path.split('/')
+
+            # support cygwin UNC paths
+            if path[:2] == '//':
+                currentpath = '//'
+                spath = spath[2:]
+
+            for comp in spath:
                 currentpath = join(currentpath, comp)
                 pathway.append(self.fm.get_directory(currentpath))
             self.pathway = tuple(pathway)


### PR DESCRIPTION
Allows users on Wndows/cygwin to browse UNC paths (network shares) in the form of `//server/path`.

#### ISSUE TYPE
- Improvement/feature implementation

#### RUNTIME ENVIRONMENT
ranger version: ranger-master 1.9.0
Python version: 3.6.3 (default, Oct 31 2017, 19:00:36) [GCC 6.4.0]
Locale: en_US.UTF-8
Windows 10/cygwin

#### CHECKLIST
- [x] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [x] All changes follow the code style **[REQUIRED]**
- [x] All new and existing tests pass **[REQUIRED]**

#### DESCRIPTION
`ranger/core/tab.py` is modified to allow paths starting with `//` (they were reduced to `/` by the old code).

#### MOTIVATION AND CONTEXT
Allows users to browse network shares on Windows/cygwin.
