### PR TITLE
Prevent unconditional symlink resolution

### DIFF
--- a/ranger/core/actions.py
+++ b/ranger/core/actions.py
@@ -8,7 +8,7 @@ from __future__ import (absolute_import, division, print_function)
 import codecs
 import os
 from os import link, symlink, getcwd, listdir, stat
-from os.path import join, isdir, realpath, exists
+from os.path import join, isdir, realpath, exists, abspath
 import re
 import shlex
 import shutil
@@ -823,7 +823,7 @@ class Actions(  # pylint: disable=too-many-instance-attributes,too-many-public-m
         if paths is None:
             tags = tuple(x.realpath for x in self.thistab.get_selection())
         else:
-            tags = [realpath(path) for path in paths]
+            tags = [abspath(path) for path in paths]
         if value is True:
             self.tags.add(*tags, tag=tag or self.tags.default_tag)
         elif value is False:


### PR DESCRIPTION
<!-- Provide a descriptive summary of the changes in the title above -->

#### ISSUE TYPE
<!-- Pick relevant types and delete the rest -->
- Bug fix

#### RUNTIME ENVIRONMENT
<!-- Details of your runtime environment -->
<!-- Retrieve Python/ranger version and locale with `ranger -\-version` -->
- Operating system and version: Linux 4.14.15-1-ARCH #1 SMP PREEMPT Tue Jan 23 21:49:25 UTC 2018 x86_64 GNU/Linux
- Terminal emulator and version: XTerm(330)
- Python version: Python 3.6.4
- Ranger version/commit: bfe1dbafaec8d79cb77fca93d4daa5a98e2cbf29
- Locale: ja_JP.utf8

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [X] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [X] All changes follow the code style **[REQUIRED]**
- [X] All new and existing tests pass **[REQUIRED]**

#### DESCRIPTION
<!-- Describe the changes in detail -->
Passing paths to `tag_toggle` now leaves symlinks unresolved, matching behavior when no paths are passed.


#### MOTIVATION AND CONTEXT
<!-- Why are these changes required? -->
<!-- What problems do these changes solve? -->
<!-- Link to relevant issues -->
Previously, calling `tag_toggle(['/path/to/link'])` would result in ranger tagging `/path/to/original`, whereas highlighting `/path/to/link` and calling `tag_toggle` with no arguments would correctly link `/path/to/link`.


#### TESTING
<!-- What tests have been run? -->
<!-- How does the changes affect other areas of the codebase? -->
All tests passed!

