### PR TITLE
Add geeqie image viewer support

### DIFF
--- a/ranger/config/rifle.conf
+++ b/ranger/config/rifle.conf
@@ -182,6 +182,7 @@ mime ^image, has ristretto, X, flag f = ristretto "$@"
 mime ^image, has eog,       X, flag f = eog -- "$@"
 mime ^image, has eom,       X, flag f = eom -- "$@"
 mime ^image, has nomacs,    X, flag f = nomacs -- "$@"
+mime ^image, has geeqie,    X, flag f = geeqie -- "$@"
 mime ^image, has gimp,      X, flag f = gimp -- "$@"
 ext xcf,                    X, flag f = gimp -- "$@"
 


### PR DESCRIPTION
Add geeqie image viewer to the default list of image viewers.

#### ISSUE TYPE
- Improvement/feature implementation

#### RUNTIME ENVIRONMENT
- Operating system and version: Arch Linux with testing repositories
- Terminal emulator and version: termite 13-1
- Python version: 3.6.4
- Ranger version/commit: 1.9.0
- Locale: en_US.UTF-8

#### CHECKLIST
- [X] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [X] All changes follow the code style **[REQUIRED]**
- [X] All new and existing tests pass **[REQUIRED]**
- [ ] Changes require config files to be updated
    - [ ] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
Adds [geeqie](https://github.com/BestImageViewer/geeqie) to the default list of supported image viewers to open files with.


#### MOTIVATION AND CONTEXT
Geeqie is a lightweight, well-maintained image viewer. Having this included in the default rifle.sh eliminates the need for me to use a custom config.


#### TESTING
Tested that geeqie opens images.