### PR TITLE
Make scope.sh backwards compatible with bash v3

### DIFF
--- a/ranger/data/scope.sh
+++ b/ranger/data/scope.sh
@@ -31,7 +31,7 @@ IMAGE_CACHE_PATH="${4}"  # Full path that should be used to cache image preview
 PV_IMAGE_ENABLED="${5}"  # 'True' if image previews are enabled, 'False' otherwise.
 
 FILE_EXTENSION="${FILE_PATH##*.}"
-FILE_EXTENSION_LOWER="${FILE_EXTENSION,,}"
+FILE_EXTENSION_LOWER=$(echo ${FILE_EXTENSION} | tr '[:upper:]' '[:lower:]')
 
 # Settings
 HIGHLIGHT_SIZE_MAX=262143  # 256KiB


### PR DESCRIPTION
Bash v3 doesn't support the `,,` syntax for lowercasing. This is
relevant on Mac OS which still comes with bash v3.2.
Using `:upper:` and `:lower:` with `tr` takes into account the locale so
this allows letters with diacritical marks in extensions.
This behavior may not be desirable.

Fixes #1072

<!-- Provide a descriptive summary of the changes in the title above -->

#### ISSUE TYPE
<!-- Pick relevant types and delete the rest -->
- Bug fix