### PR TITLE
Add new option to disable display of free disk space in statusbar

### DIFF
--- a/doc/ranger.1
+++ b/doc/ranger.1
@@ -766,6 +766,9 @@ Display the file size in the main column?
 Display the file size in the status bar?
 .IP "display_tags_in_all_columns [bool]" 4
 .IX Item "display_tags_in_all_columns [bool]"
+Display the free disk space in the status bar?
+.IP "display_free_space_in_status_bar [bool]" 4
+.IX Item "display_free_space_in_status_bar [bool]"
 Display tags in all columns?
 .IP "draw_borders [bool]" 4
 .IX Item "draw_borders [bool]"

--- a/doc/ranger.pod
+++ b/doc/ranger.pod
@@ -752,6 +752,10 @@ Display the file size in the main column?
 
 Display the file size in the status bar?
 
+=item display_free_space_in_status_bar [bool]
+
+Display the free disk space in the status bar?
+
 =item display_tags_in_all_columns [bool]
 
 Display tags in all columns?

--- a/examples/rc_emacs.conf
+++ b/examples/rc_emacs.conf
@@ -122,6 +122,9 @@ set mouse_enabled true
 set display_size_in_main_column true
 set display_size_in_status_bar true
 
+# Display the free disk space in the status bar?
+set display_free_space_in_status_bar true
+
 # Display files tags in all columns or only in main column?
 set display_tags_in_all_columns true
 

--- a/ranger/config/rc.conf
+++ b/ranger/config/rc.conf
@@ -137,6 +137,9 @@ set mouse_enabled true
 set display_size_in_main_column true
 set display_size_in_status_bar true
 
+# Display the free disk space in the status bar?
+set display_free_space_in_status_bar true
+
 # Display files tags in all columns or only in main column?
 set display_tags_in_all_columns true
 

--- a/ranger/container/settings.py
+++ b/ranger/container/settings.py
@@ -38,6 +38,7 @@ ALLOWED_SETTINGS = {
     'dirname_in_tabs': bool,
     'display_size_in_main_column': bool,
     'display_size_in_status_bar': bool,
+    "display_free_space_in_status_bar": bool,
     'display_tags_in_all_columns': bool,
     'draw_borders': bool,
     'draw_progress_bar_in_status_bar': bool,

--- a/ranger/gui/widgets/statusbar.py
+++ b/ranger/gui/widgets/statusbar.py
@@ -275,13 +275,14 @@ class StatusBar(Widget):  # pylint: disable=too-many-instance-attributes
             right.add("/" + str(len(target.marked_items)))
         else:
             right.add(human_readable(target.disk_usage, separator='') + " sum")
-            try:
-                free = get_free_space(target.mount_path)
-            except OSError:
-                pass
-            else:
-                right.add(", ", "space")
-                right.add(human_readable(free, separator='') + " free")
+            if self.settings.display_free_space_in_status_bar:
+                try:
+                    free = get_free_space(target.mount_path)
+                except OSError:
+                    pass
+                else:
+                    right.add(", ", "space")
+                    right.add(human_readable(free, separator='') + " free")
         right.add("  ", "space")
 
         if target.marked_items:


### PR DESCRIPTION
Fixes #1087
Useful on high-latency filesystems as it avoid calls to statvfs system
call which costs: (number of redraw) * latency.

<!-- Provide a descriptive summary of the changes in the title above -->

#### ISSUE TYPE
- Improvement/feature implementation

#### RUNTIME ENVIRONMENT
- Operating system and version: linux
- Python version: 3.6
- Ranger version/commit: c2b9dd31
- Locale: UTF-8

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [x] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [X] All changes follow the code style **[REQUIRED]**
- [X] All new and existing tests pass **[REQUIRED]**
- [X] Changes require config files to be updated
    - [X] Config files have been updated
- [X] Changes require documentation to be updated
    - [X] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
This patch adds a new option to hide the freespace from the status bar.


#### MOTIVATION AND CONTEXT
see issue #1087 
