### PR TITLE
Catch the right errors in addstr

### DIFF
--- a/ranger/gui/curses_shortcuts.py
+++ b/ranger/gui/curses_shortcuts.py
@@ -36,7 +36,8 @@ class CursesShortcuts(SettingsAware):
         try:
             self.win.addstr(*args)
         except (curses.error, TypeError, ValueError):
-            # a TE changed to VE from 3.5 (github.com/python/cpython/pull/2302)
+            # a TypeError changed to ValueError from version 3.5 onwards
+            # https://bugs.python.org/issue22215
             if len(args) > 1:
                 self.win.move(y, x)
 

--- a/ranger/gui/curses_shortcuts.py
+++ b/ranger/gui/curses_shortcuts.py
@@ -35,7 +35,8 @@ class CursesShortcuts(SettingsAware):
 
         try:
             self.win.addstr(*args)
-        except (curses.error, TypeError):
+        except (curses.error, TypeError, ValueError):
+            # a TE changed to VE from 3.5 (github.com/python/cpython/pull/2302)
             if len(args) > 1:
                 self.win.move(y, x)
 


### PR DESCRIPTION
Python changed an error from `TypeError` to `ValueError` in version 3.5
now we catch both for backwards compatibility.
Relevant issue: https://bugs.python.org/issue22215

Fixes #990
Fixes #1045
Fixes #1079
Fixes #1082
Fixes #1086