### PR TITLE
Fix scope.sh crashing on text ending with nullbyte

### DIFF
--- a/ranger/data/scope.sh
+++ b/ranger/data/scope.sh
@@ -130,6 +130,10 @@ handle_mime() {
     case "${mimetype}" in
         # Text
         text/* | */xml)
+            # Check for nullbyte in first 40 bytes
+            if head -n 3 "${FILE_PATH}" | od -t a | grep -q 'nul'; then
+                return
+            fi
             # Syntax highlight
             if [[ "$( stat --printf='%s' -- "${FILE_PATH}" )" -gt "${HIGHLIGHT_SIZE_MAX}" ]]; then
                 exit 2


### PR DESCRIPTION
#### ISSUE TYPE
- Bug fix

#### RUNTIME ENVIRONMENT
ranger version: ranger-master 1.9.1
Python version: 3.6.4 (default, Jan 5 2018, 02:35:40) [GCC 7.2.1 20171224]
Locale: en_US.UTF-8
Kernel: 4.15.3-2-ARCH x86_64

#### CHECKLIST
- [X] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [X] All changes follow the code style **[REQUIRED]**
- [x] All new and existing tests pass **[REQUIRED]**

#### DESCRIPTION / MOTIVATION AND CONTEXT
Currently, scope.sh doesn't differentiate between charsets.
So, if a file with the mimetype `text/plain` is encoded in
binary, and contains a trailing nullbyte within the first 40
bytes, it will crash with `embedded null charcater`. This is
due to using `file --dereference --brief --mime-type --` on
line 170, instead of using the POSIX-compatible `file -i`,
which does the same thing, but also lists the charset.

The main culprit is the `file` utility, which lists any files
with 40 or less bytes, even if they contain control characters,
as `ISO-8859 text` or `ASCII text`. If the last byte is a
nullbyte, it will be sent to Python and crash the draw()
function.

If the `MIMETYPE` variable was defined with the second version,
all you would need to do is add a `*binary)` case to
`handle_mime`, right before `text/* | */xml)`, and just let it
fall through to the regular `fallback_handler`. Instead, the
most inexpensive thing you can do is retrieve the first 40 bytes
of any file with mimetype `text/plain` with `head -n 3`. Then
do a hex dump in named-character format, `od -t a`, on the output
and pipe it to `grep -q 'nul'` which will determine if it
contains any nullbytes. If it does, call `return` and exit the
case statement to the `fallback_handler`.

This is also is a very minor security concern.

_After Edit:_ This isn't only relevant to the specific cases I listed. Going over past issues with scope.sh, it solves others:

Resolves: #1094 
Resolves: #1082 
Resolves: #1086

#### TESTING
Isolated, manual tests on `scope.sh` with bash `set -x` debugging. Multiple files were tested, including the problem ones, nothing pops out. Full tests on `ranger` with `scope.sh` switched out for the hotfix, and nothing pops out. All files, except the problem ones, still display the same way and the problem files display without issue anymore.

Affects should be minimal, and the state-less design is maintained. 