### PR TITLE
Show the full keybindings in the key hints

### DIFF
--- a/doc/ranger.1
+++ b/doc/ranger.1
@@ -129,7 +129,7 @@
 .\" ========================================================================
 .\"
 .IX Title "RANGER 1"
-.TH RANGER 1 "ranger-1.9.1" "02/22/2018" "ranger manual"
+.TH RANGER 1 "ranger-1.9.1" "03/04/2018" "ranger manual"
 .\" For nroff, turn off justification.  Always turn off hyphenation; it makes
 .\" way too many mistakes in technical documents.
 .if n .ad l
@@ -800,6 +800,10 @@ this pattern will hide all files that start with a dot or end with a tilde.
 .Vb 1
 \& set hidden_filter ^\e.|~$
 .Ve
+.IP "hint_collapse_threshold [int]" 4
+.IX Item "hint_collapse_threshold [int]"
+The key hint lists up to this size have their sublists expanded.
+Otherwise the submaps are replaced with \*(L"...\*(R".
 .IP "idle_delay [integer]" 4
 .IX Item "idle_delay [integer]"
 The delay that ranger idly waits for user input, in milliseconds, with a

--- a/doc/ranger.pod
+++ b/doc/ranger.pod
@@ -791,6 +791,11 @@ this pattern will hide all files that start with a dot or end with a tilde.
 
  set hidden_filter ^\.|~$
 
+=item hint_collapse_threshold [int]
+
+The key hint lists up to this size have their sublists expanded.
+Otherwise the submaps are replaced with "...".
+
 =item idle_delay [integer]
 
 The delay that ranger idly waits for user input, in milliseconds, with a

--- a/ranger/config/rc.conf
+++ b/ranger/config/rc.conf
@@ -216,6 +216,10 @@ set cd_tab_fuzzy false
 # disable this feature.
 set preview_max_size 0
 
+# The key hint lists up to this size have their sublists expanded.
+# Otherwise the submaps are replaced with "...".
+set hint_collapse_threshold 10
+
 # Add the highlighted file to the path in the titlebar
 set show_selection_in_titlebar true
 

--- a/ranger/container/settings.py
+++ b/ranger/container/settings.py
@@ -45,7 +45,7 @@ ALLOWED_SETTINGS = {
     'freeze_files': bool,
     'global_inode_type_filter': str,
     'hidden_filter': str,
-    'hint_collapse_threshold' : int,
+    'hint_collapse_threshold': int,
     'hostname_in_titlebar': bool,
     'idle_delay': int,
     'iterm2_font_width': int,

--- a/ranger/container/settings.py
+++ b/ranger/container/settings.py
@@ -45,6 +45,7 @@ ALLOWED_SETTINGS = {
     'freeze_files': bool,
     'global_inode_type_filter': str,
     'hidden_filter': str,
+    'hint_collapse_threshold' : int,
     'hostname_in_titlebar': bool,
     'idle_delay': int,
     'iterm2_font_width': int,

--- a/ranger/gui/widgets/view_base.py
+++ b/ranger/gui/widgets/view_base.py
@@ -154,10 +154,12 @@ class ViewBase(Widget, DisplayableContainer):  # pylint: disable=too-many-instan
             if len(hints) > self.fm.settings.hint_collapse_threshold:
                 def first_key_in_group(group):
                     return group[0][0][0]
-                grouped_hints = [[(first_key_in_group(hint_group), "...")]
-                               if len(hint_group) > 1
-                               else hint_group
-                               for hint_group in grouped_hints]
+                grouped_hints = [
+                    [(first_key_in_group(hint_group), "...")]
+                    if len(hint_group) > 1
+                    else hint_group
+                    for hint_group in grouped_hints
+                ]
 
             # Sort by the first action in group.
             grouped_hints = sorted(grouped_hints, key=lambda g: g[0][1])

--- a/ranger/gui/widgets/view_base.py
+++ b/ranger/gui/widgets/view_base.py
@@ -142,7 +142,7 @@ class ViewBase(Widget, DisplayableContainer):  # pylint: disable=too-many-instan
                 def action_string(hint):
                     return hint[1]
 
-                return (list(sorted(group, key=action_string))
+                return (sorted(group, key=action_string)
                         for _, group
                         in groupby(
                             hints,
@@ -154,12 +154,12 @@ class ViewBase(Widget, DisplayableContainer):  # pylint: disable=too-many-instan
             if len(hints) > self.fm.settings.hint_collapse_threshold:
                 def first_key_in_group(group):
                     return group[0][0][0]
-                grouped_hints = [
+                grouped_hints = (
                     [(first_key_in_group(hint_group), "...")]
                     if len(hint_group) > 1
                     else hint_group
                     for hint_group in grouped_hints
-                ]
+                )
 
             # Sort by the first action in group.
             grouped_hints = sorted(grouped_hints, key=lambda g: g[0][1])

--- a/ranger/gui/widgets/view_base.py
+++ b/ranger/gui/widgets/view_base.py
@@ -132,7 +132,7 @@ class ViewBase(Widget, DisplayableContainer):  # pylint: disable=too-many-instan
             """
             from itertools import groupby
 
-            # groupby needs the list to be sorted
+            # groupby needs the list to be sorted.
             hints.sort(key=lambda t: t[0])
 
             def group_hints(hints):
@@ -147,13 +147,24 @@ class ViewBase(Widget, DisplayableContainer):  # pylint: disable=too-many-instan
                         in groupby(
                             hints,
                             key=first_key))
-            hints = sorted(
-                group_hints(hints),
-                key=lambda g: g[0][1])  # sort by the first action in group
+
+            grouped_hints = group_hints(hints)
+
+            # If there are too many hints, collapse the sublists.
+            if len(hints) > self.fm.settings.hint_collapse_threshold:
+                def first_key_in_group(group):
+                    return group[0][0][0]
+                grouped_hints = [[(first_key_in_group(hint_group), "...")]
+                               if len(hint_group) > 1
+                               else hint_group
+                               for hint_group in grouped_hints]
+
+            # Sort by the first action in group.
+            grouped_hints = sorted(grouped_hints, key=lambda g: g[0][1])
 
             def flatten(nested_list):
                 return [item for inner_list in nested_list for item in inner_list]
-            return flatten(hints)
+            return flatten(grouped_hints)
         hints = sort_hints(hints)
 
         hei = min(self.hei - 1, len(hints))


### PR DESCRIPTION
Replace the "..." hints with the full contents of the subkeymaps. Might get troublesome with the bigger keymaps like the chmod one (<kbd>+</kbd> and <kbd>-</kbd>) but the "..." hints are just as uninformative in this case in my opinion.

The hints are grouped by the first key before sorting these groups, so the submaps should be easy to read.