### PR TITLE
Add delay after opening (quickly_executed) a file

### DIFF
--- a/ranger/config/commands.py
+++ b/ranger/config/commands.py
@@ -1393,6 +1393,8 @@ class scout(Command):
                 self.fm.cd(pattern)
             else:
                 self.fm.move(right=1)
+                if self.quickly_executed:
+                    self.fm.block_input(0.5)
 
         if self.KEEP_OPEN in flags and thisdir != self.fm.thisdir:
             # reopen the console:


### PR DESCRIPTION
This is analogous to 6cae0ed but with files, not directories.

#### ISSUE TYPE
- Improvement/feature implementation

#### CHECKLIST
- [x] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [X] All changes follow the code style **[REQUIRED]**
- [X] All new and existing tests pass **[REQUIRED]**

#### MOTIVATION AND CONTEXT
Same as #181, but for files. I use `f` quite often, and it's common to open a file only to find that a command has been unintendedly executed. Let's add a delay. It shouldn't really affect anyone.