### PR TITLE
 Added: shift tabs right/left

### DIFF
--- a/ranger/config/rc.conf
+++ b/ranger/config/rc.conf
@@ -478,6 +478,8 @@ map <a-6>     tab_open 6
 map <a-7>     tab_open 7
 map <a-8>     tab_open 8
 map <a-9>     tab_open 9
+map <a-p>     tab_shift 1
+map <a-o>     tab_shift -1
 
 # Sorting
 map or set sort_reverse!

--- a/ranger/core/actions.py
+++ b/ranger/core/actions.py
@@ -1183,6 +1183,35 @@ class Actions(  # pylint: disable=too-many-instance-attributes,too-many-public-m
             self.tab_open(newtab)
         return None
 
+    def tab_shift(self, offset):
+        """Shift the tab left/right
+
+        If the tab shift is to before first tab or after last tab,
+              move to other side
+        """
+        assert isinstance(offset, int)
+        tablist = self.get_tab_list()
+        oldtab_index = self.current_tab
+        old_index = tablist.index(oldtab_index)
+        new_index = (old_index + offset)
+        if new_index < 0:
+            new_index = len(tablist)-1
+        if new_index > (len(tablist)-1):
+            new_index = 0
+        newtab_index = tablist[new_index]
+        if newtab_index != oldtab_index:
+            oldtab = self.tabs[oldtab_index]
+            newtab = self.tabs[newtab_index]
+            self.tabs[oldtab_index] = newtab
+            self.tabs[newtab_index] = oldtab
+            self.current_tab = newtab_index
+            self.thistab = oldtab
+            self.change_mode('normal')
+            self.signal_emit('tab.change', old=oldtab, new=newtab)
+            self.signal_emit('tab.change', old=newtab, new=oldtab)
+            self.signal_emit('tab.layoutchange')
+        return None
+
     def tab_new(self, path=None, narg=None):
         if narg:
             return self.tab_open(narg, path)


### PR DESCRIPTION
 to shift tabs, use new shortcuts ALT-p and ALT-o

<!-- Provide a descriptive summary of the changes in the title above -->

#### ISSUE TYPE
<!-- Pick relevant types and delete the rest -->
- Improvement/feature implementation

#### RUNTIME ENVIRONMENT
<!-- Details of your runtime environment -->
<!-- Retrieve Python/ranger version and locale with `ranger -\-version` -->
- Operating system and version: Ubuntu 16
- Terminal emulator and version: GNOME Terminal 3.18.3
- Python version: Python version: 2.7.12 (default, Dec  4 2017, 14:50:18) [GCC 5.4.0 20160609]
- Ranger version/commit: ranger-master 1.9.1 / f855979587bd918f0d32c0caba79ab4b4aa531cf
- Locale: None.None

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [X] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [X] All changes follow the code style **[REQUIRED]**
- [] All new and existing tests pass **[REQUIRED]**
- [ ] Changes require config files to be updated
    - [X] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
<!-- Describe the changes in detail -->
Shift the selected tab left or right.
Also wraps the tabs around when shifting (if first tab shifted left, shift to last; if last tab is shifted right, shift to first.)

#### MOTIVATION AND CONTEXT
<!-- Why are these changes required? -->
<!-- What problems do these changes solve? -->
Let's you organize the tabs so you can place them in the order you want.
<!-- Link to relevant issues -->


#### TESTING
<!-- What tests have been run? -->
Tested ok with different numbers of tabs open  (1 tab, 2 tabs  ... 9 tabs).
Tested ok with close tab/restore tab.
Tested ok with F10 and restore saved tabs from last session -- tabs showed up in same order as when quit. 
<!-- How does the changes affect other areas of the codebase? -->
None.
Running the base/make test compared to this fork/make test: 0.00 difference in score

#### IMAGES / VIDEOS<!-- Only if relevant -->
<!-- Link or embed images and videos of screenshots, sketches etc. -->
