### PR TITLE
Added: shift tabs right/left

### DIFF
--- a/ranger/config/rc.conf
+++ b/ranger/config/rc.conf
@@ -478,8 +478,8 @@ map <a-6>     tab_open 6
 map <a-7>     tab_open 7
 map <a-8>     tab_open 8
 map <a-9>     tab_open 9
-map <a-p>     tab_shift 1
-map <a-o>     tab_shift -1
+map <a-r>     tab_shift 1
+map <a-l>     tab_shift -1
 
 # Sorting
 map or set sort_reverse!

--- a/ranger/config/rc.conf
+++ b/ranger/config/rc.conf
@@ -478,6 +478,8 @@ map <a-6>     tab_open 6
 map <a-7>     tab_open 7
 map <a-8>     tab_open 8
 map <a-9>     tab_open 9
+map <a-p>     tab_shift 1
+map <a-o>     tab_shift -1
 
 # Sorting
 map or set sort_reverse!

--- a/ranger/core/actions.py
+++ b/ranger/core/actions.py
@@ -1191,59 +1191,6 @@ class Actions(  # pylint: disable=too-many-instance-attributes,too-many-public-m
                 return self.tab_open(i, path)
         return None
 
-    def tab_shift(self, offset=0, pos=None):
-        """Shift the tab left/right
-
-        Shift the current tab to the left or right by either:
-        offset - changes the tab number by offset
-        pos - shifts the tab to the specified tab number
-        """
-
-        oldtab_index = self.current_tab
-        if pos is None:
-            assert isinstance(offset, int)
-            # enumerated index (1 to 9)
-            newtab_index = oldtab_index + offset
-            if newtab_index < 1:
-                newtab_index = 1
-            if newtab_index > 9:
-                newtab_index = 9
-        else:
-            assert isinstance(pos, int)
-            if pos < 1 or pos > 9:
-                return None
-            newtab_index = pos
-        # shift tabs without enumerating, preserve tab numbers when can
-        if newtab_index != oldtab_index:
-            # the other tabs shift in the opposite direction
-            if (newtab_index - oldtab_index) > 0:
-                direction = -1
-            else:
-                direction = 1
-
-            def tabshiftreorder(source_index):
-                # shift the tabs to make source_index empty
-                if source_index in self.tabs:
-                    target_index = source_index + direction
-                    # make the target_index empty recursively
-                    tabshiftreorder(target_index)
-                    # shift the source to target
-                    source_tab = self.tabs[source_index]
-                    self.tabs[target_index] = source_tab
-                    del self.tabs[source_index]
-
-            # first remove the current tab from the dict
-            oldtab = self.tabs[oldtab_index]
-            del self.tabs[oldtab_index]
-            # make newtab_index empty by shifting
-            tabshiftreorder(newtab_index)
-            self.tabs[newtab_index] = oldtab
-            self.current_tab = newtab_index
-            self.thistab = oldtab
-            self.ui.titlebar.request_redraw()
-            self.signal_emit('tab.layoutchange')
-        return None
-
     def tab_shift(self, offset=0, to=None):  # pylint: disable=invalid-name
         """Shift the tab left/right
 

--- a/ranger/core/actions.py
+++ b/ranger/core/actions.py
@@ -1244,6 +1244,34 @@ class Actions(  # pylint: disable=too-many-instance-attributes,too-many-public-m
             self.signal_emit('tab.layoutchange')
         return None
 
+    def tab_shift(self, offset):
+        """Shift the tab left/right
+
+        Shift the current tab to the left or right
+        """
+        assert isinstance(offset, int)
+        tablist = self.get_tab_list()
+        oldtab_index = self.current_tab
+        old_index = tablist.index(oldtab_index)
+        new_index = (old_index + offset)
+        if new_index < 0:
+            return None
+        if new_index > (len(tablist)-1):
+            return None
+        newtab_index = tablist[new_index]
+        if newtab_index != oldtab_index:
+            oldtab = self.tabs[oldtab_index]
+            newtab = self.tabs[newtab_index]
+            self.tabs[oldtab_index] = newtab
+            self.tabs[newtab_index] = oldtab
+            self.current_tab = newtab_index
+            self.thistab = oldtab
+            self.change_mode('normal')
+            self.signal_emit('tab.change', old=oldtab, new=newtab)
+            self.signal_emit('tab.change', old=newtab, new=oldtab)
+            self.signal_emit('tab.layoutchange')
+        return None
+
     def tab_switch(self, path, create_directory=False):
         """Switches to tab of given path, opening a new tab as necessary.
 

--- a/ranger/core/actions.py
+++ b/ranger/core/actions.py
@@ -1244,28 +1244,22 @@ class Actions(  # pylint: disable=too-many-instance-attributes,too-many-public-m
             self.signal_emit('tab.layoutchange')
         return None
 
-    def tab_shift(self, offset=0, pos=None):
+    def tab_shift(self, offset=0, to=None):  # pylint: disable=invalid-name
         """Shift the tab left/right
 
         Shift the current tab to the left or right by either:
         offset - changes the tab number by offset
-        pos - shifts the tab to the specified tab number
+        to - shifts the tab to the specified tab number
         """
 
         oldtab_index = self.current_tab
-        if pos is None:
+        if to is None:
             assert isinstance(offset, int)
             # enumerated index (1 to 9)
             newtab_index = oldtab_index + offset
-            if newtab_index < 1:
-                newtab_index = 1
-            if newtab_index > 9:
-                newtab_index = 9
         else:
-            assert isinstance(pos, int)
-            if pos < 1 or pos > 9:
-                return None
-            newtab_index = pos
+            assert isinstance(to, int)
+            newtab_index = to
         # shift tabs without enumerating, preserve tab numbers when can
         if newtab_index != oldtab_index:
             # the other tabs shift in the opposite direction

--- a/ranger/core/actions.py
+++ b/ranger/core/actions.py
@@ -1191,6 +1191,34 @@ class Actions(  # pylint: disable=too-many-instance-attributes,too-many-public-m
                 return self.tab_open(i, path)
         return None
 
+    def tab_shift(self, offset):
+        """Shift the tab left/right
+
+        Shift the current tab to the left or right
+        """
+        assert isinstance(offset, int)
+        tablist = self.get_tab_list()
+        oldtab_index = self.current_tab
+        old_index = tablist.index(oldtab_index)
+        new_index = (old_index + offset)
+        if new_index < 0:
+            return None
+        if new_index > (len(tablist)-1):
+            return None
+        newtab_index = tablist[new_index]
+        if newtab_index != oldtab_index:
+            oldtab = self.tabs[oldtab_index]
+            newtab = self.tabs[newtab_index]
+            self.tabs[oldtab_index] = newtab
+            self.tabs[newtab_index] = oldtab
+            self.current_tab = newtab_index
+            self.thistab = oldtab
+            self.change_mode('normal')
+            self.signal_emit('tab.change', old=oldtab, new=newtab)
+            self.signal_emit('tab.change', old=newtab, new=oldtab)
+            self.signal_emit('tab.layoutchange')
+        return None
+
     def tab_switch(self, path, create_directory=False):
         """Switches to tab of given path, opening a new tab as necessary.
 

--- a/ranger/core/actions.py
+++ b/ranger/core/actions.py
@@ -1244,31 +1244,56 @@ class Actions(  # pylint: disable=too-many-instance-attributes,too-many-public-m
             self.signal_emit('tab.layoutchange')
         return None
 
-    def tab_shift(self, offset):
+    def tab_shift(self, offset=0, pos=None):
         """Shift the tab left/right
 
-        Shift the current tab to the left or right
+        Shift the current tab to the left or right by either:
+        offset - changes the tab number by offset
+        pos - shifts the tab to the specified tab number
         """
-        assert isinstance(offset, int)
-        tablist = self.get_tab_list()
+
         oldtab_index = self.current_tab
-        old_index = tablist.index(oldtab_index)
-        new_index = (old_index + offset)
-        if new_index < 0:
-            return None
-        if new_index > (len(tablist)-1):
-            return None
-        newtab_index = tablist[new_index]
+        if pos is None:
+            assert isinstance(offset, int)
+            # enumerated index (1 to 9)
+            newtab_index = oldtab_index + offset
+            if newtab_index < 1:
+                newtab_index = 1
+            if newtab_index > 9:
+                newtab_index = 9
+        else:
+            assert isinstance(pos, int)
+            if pos < 1 or pos > 9:
+                return None
+            newtab_index = pos
+        # shift tabs without enumerating, preserve tab numbers when can
         if newtab_index != oldtab_index:
+            # the other tabs shift in the opposite direction
+            if (newtab_index - oldtab_index) > 0:
+                direction = -1
+            else:
+                direction = 1
+
+            def tabshiftreorder(source_index):
+                # shift the tabs to make source_index empty
+                if source_index in self.tabs:
+                    target_index = source_index + direction
+                    # make the target_index empty recursively
+                    tabshiftreorder(target_index)
+                    # shift the source to target
+                    source_tab = self.tabs[source_index]
+                    self.tabs[target_index] = source_tab
+                    del self.tabs[source_index]
+
+            # first remove the current tab from the dict
             oldtab = self.tabs[oldtab_index]
-            newtab = self.tabs[newtab_index]
-            self.tabs[oldtab_index] = newtab
+            del self.tabs[oldtab_index]
+            # make newtab_index empty by shifting
+            tabshiftreorder(newtab_index)
             self.tabs[newtab_index] = oldtab
             self.current_tab = newtab_index
             self.thistab = oldtab
-            self.change_mode('normal')
-            self.signal_emit('tab.change', old=oldtab, new=newtab)
-            self.signal_emit('tab.change', old=newtab, new=oldtab)
+            self.ui.titlebar.request_redraw()
             self.signal_emit('tab.layoutchange')
         return None
 


### PR DESCRIPTION
 to shift tabs, use new shortcuts ALT-p and ALT-o

<!-- Provide a descriptive summary of the changes in the title above -->

#### ISSUE TYPE
<!-- Pick relevant types and delete the rest -->
- Improvement/feature implementation

#### RUNTIME ENVIRONMENT
<!-- Details of your runtime environment -->
<!-- Retrieve Python/ranger version and locale with `ranger -\-version` -->
- Operating system and version: Ubuntu 16
- Terminal emulator and version: GNOME Terminal 3.18.3
- Python version: Python version: 2.7.12 (default, Dec  4 2017, 14:50:18) [GCC 5.4.0 20160609]
- Ranger version/commit: ranger-master 1.9.1 / f855979587bd918f0d32c0caba79ab4b4aa531cf
- Locale: None.None

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [X] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [X] All changes follow the code style **[REQUIRED]**
- [] All new and existing tests pass **[REQUIRED]**
- [ ] Changes require config files to be updated
    - [X] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
<!-- Describe the changes in detail -->
Shift the selected tab left or right.
Uses shortcuts added to rc.conf: ALT-p to shift tab right, ALT-o to shift tab left.

#### MOTIVATION AND CONTEXT
<!-- Why are these changes required? -->
<!-- What problems do these changes solve? -->
Let's you organize the tabs so you can place them in the order you want.
<!-- Link to relevant issues -->



#### TESTING
<!-- What tests have been run? -->
Tested ok with different numbers of tabs open  (1 tab, 2 tabs  ... 9 tabs).
Tested ok with close tab/restore tab.
Tested ok with save_tabs_on_exit.
<!-- How does the changes affect other areas of the codebase? -->
None.
Running the base/make test compared to this fork/make test: 0.00 difference in score

#### IMAGES / VIDEOS<!-- Only if relevant -->
<!-- Link or embed images and videos of screenshots, sketches etc. -->
