### PR TITLE
Open .sql files with editor

### DIFF
--- a/ranger/config/rifle.conf
+++ b/ranger/config/rifle.conf
@@ -87,8 +87,8 @@ ext x?html?, has w3m,               terminal = w3m "$@"
 # Define the "editor" for text files as first action
 mime ^text,  label editor = ${VISUAL:-$EDITOR} -- "$@"
 mime ^text,  label pager  = "$PAGER" -- "$@"
-!mime ^text, label editor, ext xml|json|csv|tex|py|pl|rb|js|sh|php = ${VISUAL:-$EDITOR} -- "$@"
-!mime ^text, label pager,  ext xml|json|csv|tex|py|pl|rb|js|sh|php = "$PAGER" -- "$@"
+!mime ^text, label editor, ext xml|json|csv|tex|py|pl|rb|js|sh|php|sql = ${VISUAL:-$EDITOR} -- "$@"
+!mime ^text, label pager,  ext xml|json|csv|tex|py|pl|rb|js|sh|php|sql= "$PAGER" -- "$@"
 
 ext 1                         = man "$1"
 ext s[wmf]c, has zsnes, X     = zsnes "$1"
@@ -106,6 +106,7 @@ ext rb  = ruby -- "$1"
 ext js  = node -- "$1"
 ext sh  = sh -- "$1"
 ext php = php -- "$1"
+ext sql = sql -- "$1"
 
 #--------------------------------------------
 # Audio without X
@@ -218,9 +219,9 @@ label wallpaper, number 13, mime ^image, has feh, X = feh --bg-center "$1"
 label wallpaper, number 14, mime ^image, has feh, X = feh --bg-fill "$1"
 
 # Define the editor for non-text files + pager as last action
-              !mime ^text, !ext xml|json|csv|tex|py|pl|rb|js|sh|php  = ask
-label editor, !mime ^text, !ext xml|json|csv|tex|py|pl|rb|js|sh|php  = ${VISUAL:-$EDITOR} -- "$@"
-label pager,  !mime ^text, !ext xml|json|csv|tex|py|pl|rb|js|sh|php  = "$PAGER" -- "$@"
+              !mime ^text, !ext xml|json|csv|tex|py|pl|rb|js|sh|php|sql  = ask
+label editor, !mime ^text, !ext xml|json|csv|tex|py|pl|rb|js|sh|php|sql  = ${VISUAL:-$EDITOR} -- "$@"
+label pager,  !mime ^text, !ext xml|json|csv|tex|py|pl|rb|js|sh|php|sql  = "$PAGER" -- "$@"
 
 # The very last action, so that it's never triggered accidentally, is to execute a program:
 mime application/x-executable = "$1"


### PR DESCRIPTION
Add default support for opening sql files with text editor. 

Confirmed working:
``
ranger version: ranger-stable 1.9.0
Python version: 3.6.4 (default, Mar  9 2018, 23:15:12) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
Locale: en_US.UTF-8
``