### PR TITLE
Fix typo for pdf in rifle.conf

### DIFF
--- a/ranger/config/rifle.conf
+++ b/ranger/config/rifle.conf
@@ -151,7 +151,7 @@ ext pdf, has atril,    X, flag f = atril -- "$@"
 ext pdf, has okular,   X, flag f = okular -- "$@"
 ext pdf, has epdfview, X, flag f = epdfview -- "$@"
 ext pdf, has qpdfview, X, flag f = qpdfview "$@"
-ext pdf, has open,     X, flat f = open "$@"
+ext pdf, has open,     X, flag f = open "$@"
 
 ext docx?, has catdoc,       terminal = catdoc -- "$@" | "$PAGER"
 


### PR DESCRIPTION
Fixes #1128

Changed from `flat` to `flag` for final pdf match:
https://github.com/ranger/ranger/blob/f3d8c57b1fa24f0fa8b4c3d2e5f96bf6a2f9778e/ranger/config/rifle.conf#L154

#### ISSUE TYPE
- Bug fix

#### RUNTIME ENVIRONMENT
ranger version: ranger-master 1.9.1
Python version: 2.7.10 (default, Jul 15 2017, 17:16:57) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.31)]
Locale: None.None

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [X] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [X] All changes follow the code style **[REQUIRED]**
- [X] All new and existing tests pass **[REQUIRED]**
- [X] Changes require config files to be updated
    - [X] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
Changed from `flat` to `flag` for final pdf match:
https://github.com/ranger/ranger/blob/f3d8c57b1fa24f0fa8b4c3d2e5f96bf6a2f9778e/ranger/config/rifle.conf#L154


#### MOTIVATION AND CONTEXT
<!-- Why are these changes required? -->
It breaks the use of `open` with PDFs if using the default rifle config.
<!-- What problems do these changes solve? -->
If none of the listed PDF applications are installed (e.g. OS X), then PDFs won't open with the associated program and `open`.
<!-- Link to relevant issues --> #1128 


#### TESTING
<!-- What tests have been run? -->
`make test`
<!-- How does the changes affect other areas of the codebase? -->
They don't.
