### PR TITLE
Save all the tabs, including the active tab.

### DIFF
--- a/ranger/core/actions.py
+++ b/ranger/core/actions.py
@@ -1237,7 +1237,18 @@ class Actions(  # pylint: disable=too-many-instance-attributes,too-many-public-m
 
     def get_tab_list(self):
         assert self.tabs, "There must be at least 1 tab at all times"
-        return sorted(self.tabs)
+
+        class NaturalOrder(object):  # pylint: disable=too-few-public-methods
+            def __init__(self, obj):
+                self.obj = obj
+
+            def __lt__(self, other):
+                try:
+                    return self.obj < other.obj
+                except TypeError:
+                    return str(self.obj) < str(other.obj)
+
+        return sorted(self.tabs, key=NaturalOrder)
 
     # --------------------------
     # -- Overview of internals

--- a/ranger/core/actions.py
+++ b/ranger/core/actions.py
@@ -1186,10 +1186,10 @@ class Actions(  # pylint: disable=too-many-instance-attributes,too-many-public-m
     def tab_new(self, path=None, narg=None):
         if narg:
             return self.tab_open(narg, path)
-        for i in range(1, 10):
-            if i not in self.tabs:
-                return self.tab_open(i, path)
-        return None
+        i = 1
+        while i in self.tabs:
+            i += 1
+        return self.tab_open(i, path)
 
     def tab_switch(self, path, create_directory=False):
         """Switches to tab of given path, opening a new tab as necessary.

--- a/ranger/core/fm.py
+++ b/ranger/core/fm.py
@@ -424,5 +424,5 @@ class FM(Actions,  # pylint: disable=too-many-instance-attributes
             if not ranger.args.clean and self.settings.save_tabs_on_exit and len(self.tabs) > 1:
                 with open(self.datapath('tabs'), 'a') as fobj:
                     # Don't save active tab since launching ranger changes the active tab
-                    fobj.write('\0'.join(v.path for t, v in self.tabs.items()
-                                         if t != self.current_tab) + '\0\0')
+                    fobj.write('\0'.join(v.path for t, v in self.tabs.items()) +
+                               '\0\0')


### PR DESCRIPTION
Remove the check preventing the active tab from being saved.

Fixes #883

The limit on the number of tabs is removed because it's weird that you can get more tabs except using the most obvious way `tab_new`.

The code only implicitly assumed tab indices have to be numbers in one spot so I patched that, tabs are now ordered lexically unless they're both numbers, this resembles ranger's natural ordering.