### PR TITLE
ext.rifle: Additional Check for mime type with mimetype command

### DIFF
--- a/ranger/ext/rifle.py
+++ b/ranger/ext/rifle.py
@@ -262,10 +262,13 @@ class Rifle(object):  # pylint: disable=too-many-instance-attributes
             mimetype, _ = process.communicate()
             self._mimetype = mimetype.decode(ENCODING).strip()
             if self._mimetype == 'application/octet-stream':
-                process = Popen(["mimetype", "--output-format", "%m", fname],
-                        stdout=PIPE, stderr=PIPE)
-                mimetype, _ = process.communicate()
-                self._mimetype = mimetype.decode(ENCODING).strip()
+                try:
+                    process = Popen(["mimetype", "--output-format", "%m", fname],
+                                    stdout=PIPE, stderr=PIPE)
+                    mimetype, _ = process.communicate()
+                    self._mimetype = mimetype.decode(ENCODING).strip()
+                except:
+                    pass
         return self._mimetype
 
     def _build_command(self, files, action, flags):

--- a/ranger/ext/rifle.py
+++ b/ranger/ext/rifle.py
@@ -267,7 +267,7 @@ class Rifle(object):  # pylint: disable=too-many-instance-attributes
                                     stdout=PIPE, stderr=PIPE)
                     mimetype, _ = process.communicate()
                     self._mimetype = mimetype.decode(ENCODING).strip()
-                except:
+                except OSError:
                     pass
         return self._mimetype
 

--- a/ranger/ext/rifle.py
+++ b/ranger/ext/rifle.py
@@ -261,6 +261,11 @@ class Rifle(object):  # pylint: disable=too-many-instance-attributes
             process = Popen(["file", "--mime-type", "-Lb", fname], stdout=PIPE, stderr=PIPE)
             mimetype, _ = process.communicate()
             self._mimetype = mimetype.decode(ENCODING).strip()
+            if self._mimetype == 'application/octet-stream':
+                process = Popen(["mimetype", "--output-format", "%m", fname],
+                        stdout=PIPE, stderr=PIPE)
+                mimetype, _ = process.communicate()
+                self._mimetype = mimetype.decode(ENCODING).strip()
         return self._mimetype
 
     def _build_command(self, files, action, flags):


### PR DESCRIPTION
#### ISSUE TYPE
- Breaking changes
Some MIME types are not found by rifle. With an additional test with the mimetype command after the file command returns 'application/octet-stream' rifle should now be able to recognize all known mime types in the system.