### PR TITLE
Fixed yank name without extension in multiple files

### DIFF
--- a/ranger/config/commands.py
+++ b/ranger/config/commands.py
@@ -1762,7 +1762,8 @@ class yank(Command):
 
         mode = self.modes[self.arg(1)]
         if mode == "splitext":
-            selection = [os.path.splitext(self.get_selection_attr('basename')[0])[0]]
+            selection = [os.path.splitext(item)[0] for item in
+                         self.get_selection_attr('basename')]
         else:
             selection = self.get_selection_attr(mode)
 

--- a/ranger/config/commands.py
+++ b/ranger/config/commands.py
@@ -1727,7 +1727,7 @@ class yank(Command):
 
     modes = {
         '': 'basename',
-        'name_without_extension': 'splitext',
+        'name_without_extension': 'basename_without_extension',
         'name': 'basename',
         'dir': 'dirname',
         'path': 'path',
@@ -1761,11 +1761,7 @@ class yank(Command):
         clipboard_commands = clipboards()
 
         mode = self.modes[self.arg(1)]
-        if mode == "splitext":
-            selection = [os.path.splitext(item)[0] for item in
-                         self.get_selection_attr('basename')]
-        else:
-            selection = self.get_selection_attr(mode)
+        selection = self.get_selection_attr(mode)
 
         new_clipboard_contents = "\n".join(selection)
         for command in clipboard_commands:

--- a/ranger/config/rc.conf
+++ b/ranger/config/rc.conf
@@ -413,7 +413,7 @@ map dU shell -p du --max-depth=1 -h --apparent-size | sort -rh
 map yp yank path
 map yd yank dir
 map yn yank name
-map yw yank name_without_extension
+map y. yank name_without_extension
 
 # Filesystem Operations
 map =  chmod

--- a/ranger/container/fsobject.py
+++ b/ranger/container/fsobject.py
@@ -6,7 +6,7 @@ from __future__ import (absolute_import, division, print_function)
 import re
 from grp import getgrgid
 from os import lstat, stat
-from os.path import abspath, basename, dirname, realpath, relpath
+from os.path import abspath, basename, dirname, realpath, relpath, splitext
 from pwd import getpwuid
 from time import time
 
@@ -169,6 +169,10 @@ class FileSystemObject(  # pylint: disable=too-many-instance-attributes,too-many
             except ValueError:
                 basename_list += [(string, 0)]
         return basename_list
+
+    @lazy_property
+    def basename_without_extension(self):
+        return splitext(self.basename)[0]
 
     @lazy_property
     def safe_basename(self):


### PR DESCRIPTION
fixed yank file name without extension with multiple files selected.
and changed map `yw` to `y.` ref. pr #1174

<!-- Provide a descriptive summary of the changes in the title above -->
fixed yank file name without extension with multiple files selected.

#### ISSUE TYPE
<!-- Pick relevant types and delete the rest -->
- Bug fix
- Improvement/feature implementation

#### RUNTIME ENVIRONMENT
<!-- Details of your runtime environment -->
<!-- Retrieve Python/ranger version and locale with `ranger -\-version` -->
- Operating system and version: 
- Terminal emulator and version: 
- Python version: 
- Ranger version/commit: 
- Locale: 

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [x] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [x] All changes follow the code style **[REQUIRED]**
- [x] All new and existing tests pass **[REQUIRED]**
- [x] Changes require config files to be updated
    - [x] Config files have been updated
- [x] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
<!-- Describe the changes in detail -->
fixed yank file name without extension with multiple files selected.


#### MOTIVATION AND CONTEXT
<!-- Why are these changes required? -->
<!-- What problems do these changes solve? -->
<!-- Link to relevant issues -->
fixed yank file name without extension with multiple files selected.
and changed map `yw` to `y.` PR #1174

#### TESTING
<!-- What tests have been run? -->
<!-- How does the changes affect other areas of the codebase? -->

Tested with multiple files selected, all working


