### PR TITLE
Boldisnotbright

### DIFF
--- a/ranger/colorschemes/default.py
+++ b/ranger/colorschemes/default.py
@@ -37,29 +37,35 @@ class Default(ColorScheme):
             if context.container:
                 fg = red
             if context.directory:
+                attr |= bold
                 fg = blue
                 fg += BRIGHT
             elif context.executable and not \
                     any((context.media, context.container,
                          context.fifo, context.socket)):
+                attr |= bold
                 fg = green
                 fg += BRIGHT
             if context.socket:
+                attr |= bold
                 fg = magenta
                 fg += BRIGHT
             if context.fifo or context.device:
                 fg = yellow
                 if context.device:
+                    attr |= bold
                     fg += BRIGHT
             if context.link:
                 fg = cyan if context.good else magenta
             if context.tag_marker and not context.selected:
+                attr |= bold
                 if fg in (red, magenta):
                     fg = white
                 else:
                     fg = red
                 fg += BRIGHT
             if not context.selected and (context.cut or context.copied):
+                attr |= bold
                 fg = black
                 fg += BRIGHT
                 # If the terminal doesn't support bright colors, use dim white
@@ -69,8 +75,10 @@ class Default(ColorScheme):
                     fg = white
             if context.main_column:
                 if context.selected:
+                    attr |= bold
                     fg += BRIGHT
                 if context.marked:
+                    attr |= bold
                     fg = yellow
                     fg += BRIGHT
             if context.badinfo:
@@ -92,6 +100,7 @@ class Default(ColorScheme):
                     bg = green
             elif context.link:
                 fg = cyan
+            attr |= bold
             fg += BRIGHT
 
         elif context.in_statusbar:
@@ -101,15 +110,16 @@ class Default(ColorScheme):
                 elif context.bad:
                     fg = magenta
             if context.marked:
-                attr |= reverse
+                attr |= bold | reverse
                 fg = yellow
                 fg += BRIGHT
             if context.frozen:
-                attr |= reverse
+                attr |= bold | reverse
                 fg = cyan
                 fg += BRIGHT
             if context.message:
                 if context.bad:
+                    attr |= bold
                     fg = red
                     fg += BRIGHT
             if context.loaded:

--- a/ranger/colorschemes/default.py
+++ b/ranger/colorschemes/default.py
@@ -6,7 +6,7 @@ from __future__ import (absolute_import, division, print_function)
 from ranger.gui.colorscheme import ColorScheme
 from ranger.gui.color import (
     black, blue, cyan, green, magenta, red, white, yellow, default,
-    normal, bold, reverse,
+    normal, bold, reverse, dim, BRIGHT,
     default_colors,
 )
 
@@ -37,37 +37,42 @@ class Default(ColorScheme):
             if context.container:
                 fg = red
             if context.directory:
-                attr |= bold
                 fg = blue
+                fg += BRIGHT
             elif context.executable and not \
                     any((context.media, context.container,
                          context.fifo, context.socket)):
-                attr |= bold
                 fg = green
+                fg += BRIGHT
             if context.socket:
                 fg = magenta
-                attr |= bold
+                fg += BRIGHT
             if context.fifo or context.device:
                 fg = yellow
                 if context.device:
-                    attr |= bold
+                    fg += BRIGHT
             if context.link:
                 fg = cyan if context.good else magenta
             if context.tag_marker and not context.selected:
-                attr |= bold
                 if fg in (red, magenta):
                     fg = white
                 else:
                     fg = red
+                fg += BRIGHT
             if not context.selected and (context.cut or context.copied):
                 fg = black
-                attr |= bold
+                fg += BRIGHT
+                # If the terminal doesn't support bright colors, use dim white
+                # instead of black.
+                if BRIGHT == 0:
+                    attr |= dim
+                    fg = white
             if context.main_column:
                 if context.selected:
-                    attr |= bold
+                    fg += BRIGHT
                 if context.marked:
-                    attr |= bold
                     fg = yellow
+                    fg += BRIGHT
             if context.badinfo:
                 if attr & reverse:
                     bg = magenta
@@ -78,7 +83,6 @@ class Default(ColorScheme):
                 fg = cyan
 
         elif context.in_titlebar:
-            attr |= bold
             if context.hostname:
                 fg = red if context.bad else green
             elif context.directory:
@@ -88,6 +92,7 @@ class Default(ColorScheme):
                     bg = green
             elif context.link:
                 fg = cyan
+            fg += BRIGHT
 
         elif context.in_statusbar:
             if context.permissions:
@@ -96,15 +101,17 @@ class Default(ColorScheme):
                 elif context.bad:
                     fg = magenta
             if context.marked:
-                attr |= bold | reverse
+                attr |= reverse
                 fg = yellow
+                fg += BRIGHT
             if context.frozen:
-                attr |= bold | reverse
+                attr |= reverse
                 fg = cyan
+                fg += BRIGHT
             if context.message:
                 if context.bad:
-                    attr |= bold
                     fg = red
+                    fg += BRIGHT
             if context.loaded:
                 bg = self.progress_bar_color
             if context.vcsinfo:

--- a/ranger/colorschemes/default.py
+++ b/ranger/colorschemes/default.py
@@ -74,13 +74,13 @@ class Default(ColorScheme):
                     attr |= dim
                     fg = white
             if context.main_column:
+                # Doubling up with BRIGHT here causes issues because it's
+                # additive not idempotent.
                 if context.selected:
                     attr |= bold
-                    fg += BRIGHT
                 if context.marked:
                     attr |= bold
                     fg = yellow
-                    fg += BRIGHT
             if context.badinfo:
                 if attr & reverse:
                     bg = magenta

--- a/ranger/colorschemes/snow.py
+++ b/ranger/colorschemes/snow.py
@@ -4,7 +4,7 @@
 from __future__ import (absolute_import, division, print_function)
 
 from ranger.gui.colorscheme import ColorScheme
-from ranger.gui.color import default_colors, reverse, BRIGHT
+from ranger.gui.color import default_colors, reverse, bold, BRIGHT
 
 
 class Snow(ColorScheme):
@@ -19,6 +19,7 @@ class Snow(ColorScheme):
             if context.selected:
                 attr = reverse
             if context.directory:
+                attr |= bold
                 fg += BRIGHT
 
         elif context.highlight:
@@ -35,6 +36,7 @@ class Snow(ColorScheme):
 
         elif context.in_taskview:
             if context.selected:
+                attr |= bold
                 fg += BRIGHT
             if context.loaded:
                 attr |= reverse

--- a/ranger/colorschemes/snow.py
+++ b/ranger/colorschemes/snow.py
@@ -4,7 +4,7 @@
 from __future__ import (absolute_import, division, print_function)
 
 from ranger.gui.colorscheme import ColorScheme
-from ranger.gui.color import default_colors, reverse, bold
+from ranger.gui.color import default_colors, reverse, BRIGHT
 
 
 class Snow(ColorScheme):
@@ -19,7 +19,7 @@ class Snow(ColorScheme):
             if context.selected:
                 attr = reverse
             if context.directory:
-                attr |= bold
+                fg += BRIGHT
 
         elif context.highlight:
             attr |= reverse
@@ -35,7 +35,7 @@ class Snow(ColorScheme):
 
         elif context.in_taskview:
             if context.selected:
-                attr |= bold
+                fg += BRIGHT
             if context.loaded:
                 attr |= reverse
 

--- a/ranger/gui/color.py
+++ b/ranger/gui/color.py
@@ -66,6 +66,11 @@ blink      = curses.A_BLINK
 reverse    = curses.A_REVERSE
 underline  = curses.A_UNDERLINE
 invisible  = curses.A_INVIS
+dim = curses.A_DIM
 
 default_colors = (default, default, normal)
 # pylint: enable=invalid-name,bad-whitespace
+
+curses.setupterm()
+# Adding BRIGHT to a color achieves what `bold` was used for.
+BRIGHT = 8 if curses.tigetnum('colors') >= 16 else 0


### PR DESCRIPTION
Stop lying and use bright instead of bold. Fall back to dim white instead of bright black in terminals that don't support bright colors.