### PR TITLE
Added Zenburn color scheme

### DIFF
--- a/doc/config/colorschemes/zenburn.py
+++ b/doc/config/colorschemes/zenburn.py
@@ -1,0 +1,1 @@
+../../../ranger/colorschemes/zenburn.py

--- a/ranger/colorschemes/zenburn.py
+++ b/ranger/colorschemes/zenburn.py
@@ -1,0 +1,163 @@
+# Ivaylo Kuzev <ivkuzev@gmail.com>, 2014
+# Zenburn like colorscheme for https://github.com/hut/ranger .
+
+# default colorscheme.
+# Copyright (C) 2009-2013  Roman Zimbelmann <hut@lepus.uberspace.de>
+# This software is distributed under the terms of the GNU GPL version 3.
+
+from ranger.gui.colorscheme import ColorScheme
+from ranger.gui.color import *
+
+class Zenburn(ColorScheme):
+    progress_bar_color = 108
+
+    def use(self, context):
+        fg, bg, attr = default_colors
+
+        if context.reset:
+            return default_colors
+
+        elif context.in_browser:
+            if context.selected:
+                attr = reverse
+            else:
+                attr = normal
+            if context.empty or context.error:
+                fg = 174
+                bg = 235
+            if context.border:
+                fg = 248
+            if context.image:
+                fg = 109
+            if context.video:
+                fg = 66
+            if context.audio:
+                fg = 116
+            if context.document:
+                fg = 151
+            if context.container:
+                attr |= bold
+                fg = 174
+            if context.directory:
+                attr |= bold
+                fg = 223
+            elif context.executable and not \
+                    any((context.media, context.container,
+                       context.fifo, context.socket)):
+                attr |= bold
+                fg = 108
+            if context.socket:
+                fg = 180
+                attr |= bold
+            if context.fifo or context.device:
+                fg = 144
+                if context.device:
+                    attr |= bold
+            if context.link:
+                fg = context.good and 223 or 116
+                bg = 234
+            if context.bad:
+                bg = 235
+            if context.tag_marker and not context.selected:
+                attr |= bold
+                if fg in (174, 95):
+                    fg = 248
+                else:
+                    fg = 174
+            if not context.selected and (context.cut or context.copied):
+                fg = 108
+                bg = 234
+            if context.main_column:
+                if context.selected:
+                    attr |= bold
+                if context.marked:
+                    attr |= bold
+                    fg = 223
+            if context.badinfo:
+                if attr & reverse:
+                    bg = 95
+                else:
+                    fg = 95
+
+        elif context.in_titlebar:
+            attr |= bold
+            if context.hostname:
+                fg = context.bad and 174 or 180
+            elif context.directory:
+                fg = 223
+            elif context.tab:
+                if context.good:
+                    bg = 180
+            elif context.link:
+                fg = 116
+
+        elif context.in_statusbar:
+            if context.permissions:
+                if context.good:
+                    fg = 108
+                elif context.bad:
+                    fg = 174
+            if context.marked:
+                attr |= bold | reverse
+                fg = 223
+            if context.message:
+                if context.bad:
+                    attr |= bold
+                    fg = 174
+            if context.loaded:
+                bg = self.progress_bar_color
+            if context.vcsinfo:
+                fg = 116
+                attr &= ~bold
+            if context.vcscommit:
+                fg = 144
+                attr &= ~bold
+
+
+        if context.text:
+            if context.highlight:
+                attr |= reverse
+
+        if context.in_taskview:
+            if context.title:
+                fg = 116
+
+            if context.selected:
+                attr |= reverse
+
+            if context.loaded:
+                if context.selected:
+                    fg = self.progress_bar_color
+                else:
+                    bg = self.progress_bar_color
+
+
+        if context.vcsfile and not context.selected:
+            attr &= ~bold
+            if context.vcsconflict:
+                fg = 95
+            elif context.vcschanged:
+                fg = 174
+            elif context.vcsunknown:
+                fg = 174
+            elif context.vcsstaged:
+                fg = 108
+            elif context.vcssync:
+                fg = 108
+            elif context.vcsignored:
+                fg = default
+
+        elif context.vcsremote and not context.selected:
+            attr &= ~bold
+            if context.vcssync:
+                fg = 108
+            elif context.vcsbehind:
+                fg = 174
+            elif context.vcsahead:
+                fg = 116
+            elif context.vcsdiverged:
+                fg = 95
+            elif context.vcsunknown:
+                fg = 174
+
+        return fg, bg, attr

--- a/ranger/colorschemes/zenburn.py
+++ b/ranger/colorschemes/zenburn.py
@@ -6,7 +6,8 @@
 # This software is distributed under the terms of the GNU GPL version 3.
 
 from ranger.gui.colorscheme import ColorScheme
-from ranger.gui.color import *
+from ranger.gui.color import default_colors, reverse, bold, normal, default
+# from ranger.gui.color import *
 
 class Zenburn(ColorScheme):
     progress_bar_color = 108
@@ -43,7 +44,7 @@ class Zenburn(ColorScheme):
                 fg = 223
             elif context.executable and not \
                     any((context.media, context.container,
-                       context.fifo, context.socket)):
+                         context.fifo, context.socket)):
                 attr |= bold
                 fg = 108
             if context.socket:
@@ -54,7 +55,7 @@ class Zenburn(ColorScheme):
                 if context.device:
                     attr |= bold
             if context.link:
-                fg = context.good and 223 or 116
+                fg = 223 if context.good else 116
                 bg = 234
             if context.bad:
                 bg = 235
@@ -82,7 +83,7 @@ class Zenburn(ColorScheme):
         elif context.in_titlebar:
             attr |= bold
             if context.hostname:
-                fg = context.bad and 174 or 180
+                fg = 174 if context.bad else 180
             elif context.directory:
                 fg = 223
             elif context.tab:

--- a/ranger/colorschemes/zenburn.py
+++ b/ranger/colorschemes/zenburn.py
@@ -7,8 +7,9 @@
 
 from ranger.gui.colorscheme import ColorScheme
 from ranger.gui.color import default_colors, reverse, bold, normal, default
-# from ranger.gui.color import *
 
+
+# pylint: disable=too-many-branches,too-many-statements
 class Zenburn(ColorScheme):
     progress_bar_color = 108
 
@@ -114,7 +115,6 @@ class Zenburn(ColorScheme):
                 fg = 144
                 attr &= ~bold
 
-
         if context.text:
             if context.highlight:
                 attr |= reverse
@@ -131,7 +131,6 @@ class Zenburn(ColorScheme):
                     fg = self.progress_bar_color
                 else:
                     bg = self.progress_bar_color
-
 
         if context.vcsfile and not context.selected:
             attr &= ~bold


### PR DESCRIPTION
See https://gist.github.com/ivoarch/8249238. Props to Ivaylo Kuzev.

#### ISSUE TYPE
- Improvement/feature implementation

#### RUNTIME ENVIRONMENT
- Operating system and version: 
Arch LInux
- Terminal emulator and version: 
termite v13  
- Python version: 
Python version: 3.6.5 (default, May 11 2018, 04:00:52) [GCC 8.1.0]
- Ranger version/commit: 
ranger version: ranger-master 1.9.1
- Locale: 
Locale: en_GB.UTF-8

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [x] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [x] All changes follow the code style **[REQUIRED]**
- [x] All new and existing tests pass **[REQUIRED]**
- [?] Changes require config files to be updated
    - [ ] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
<!-- Describe the changes in detail -->
Zenburn color scheme.

#### MOTIVATION AND CONTEXT
<!-- Why are these changes required? -->
<!-- What problems do these changes solve? -->
<!-- Link to relevant issues -->


#### TESTING
<!-- What tests have been run? -->
<!-- How does the changes affect other areas of the codebase? -->
Running ranger with this color scheme.

