### PR TITLE
Update colorscheme docs path in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -111,7 +111,7 @@ def main():
                 'doc/rifle.1',
             ]),
             ('share/doc/ranger', [
-                'doc/colorschemes.txt',
+                'doc/colorschemes.md',
                 'CHANGELOG.md',
                 'HACKING.md',
                 'README.md',


### PR DESCRIPTION
`colorschemes.txt` markup was improved and the file got a `.md`
extension to match.

Fixes #1221