### PR TITLE
Revamped context section of the colorscheme doc

### DIFF
--- a/doc/colorschemes.md
+++ b/doc/colorschemes.md
@@ -21,7 +21,7 @@ import ranger.gui.context
 # Add your key names
 ranger.gui.context.CONTEXT_KEYS.append('my_key')
 
-# Set it to false (the default value)
+# Set it to False (the default value)
 ranger.gui.context.Context.my_key = False
 
 # Or use an array for multiple names


### PR DESCRIPTION
Added basic instructions on how to add a context key with a working
example. This includes adding it to the `CONTEXT_KEYS` constant and
letting ranger know what it means.

#### ISSUE TYPE
- Improvement/feature implementation

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [X] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [X] All changes follow the code style **[REQUIRED]**
- [X] All new and existing tests pass **[REQUIRED]**
- [ ] Changes require config files to be updated
    - [ ] Config files have been updated
- [X] Changes require documentation to be updated
    - [X] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
Added a more comprehensive `Context` section in the colorschemes.md doc

#### MOTIVATION AND CONTEXT
It makes it easier to learn how to create a more dynamic colorscheme