### PR TITLE
Change the method of defining colorschemes

### DIFF
--- a/doc/colorschemes.md
+++ b/doc/colorschemes.md
@@ -88,24 +88,17 @@ others as `False`, and passes it to the colorscheme's `use(context)` method.
 The Color Scheme
 ----------------
 
-A colorscheme should be a subclass of `ranger.gui.ColorScheme` and define the
-method `use(context)`. By looking at the context, this use-method has to
-determine a 3-tuple of integers: `(foreground, background, attribute)` and return
-it.
+There are two main ways to create a colorscheme. Both require that you create a
+sub-class of `ranger.gui.ColorScheme`. The easy way to do it is to redefine the
+`colors` dictionary to your liking. Each low-level tag is a 3-tuple in the
+format `(foreground, background, attribute)`. This method leaves most of the
+work to the default `use(context)` method.
 
-`foreground` and `background` are integers representing colors, `attribute` is
-another integer with each bit representing one attribute. These integers are
-interpreted by the terminal emulator in use.
-
-Abbreviations for colors and attributes are defined in `ranger.gui.color`. Two
-attributes can be combined via bitwise OR: `bold | reverse`
-
-Once the color for a set of tags is determined, it will be cached by default. If
-you want more dynamic colorschemes (such as a different color for very large
-files), you will need to dig into the source code, perhaps add a custom tag and
-modify the draw-method of the widget to use that tag.
-
-Run `tc_colorscheme` to check if your colorschemes are valid.
+The hard way to define colorschemes is by redefining the `use(context)` method.
+The branches pan out the same way as the dictionary method, but it is harder to
+read. The benefit to some people is that it is very customizable. You can set
+different rules for which tags appear to be activated. The function returns a
+3-tuple in the format `(foreground, background, attribute)`.
 
 Specify a Colorscheme
 ---------------------

--- a/ranger/colorschemes/default.py
+++ b/ranger/colorschemes/default.py
@@ -1,167 +1,104 @@
-# This file is part of ranger, the console file manager.
-# License: GNU GPL version 3, see the file "AUTHORS" for details.
-
 from __future__ import (absolute_import, division, print_function)
 
 from ranger.gui.colorscheme import ColorScheme
 from ranger.gui.color import (
-    black, blue, cyan, green, magenta, red, white, yellow, default,
-    normal, bold, reverse,
-    default_colors,
+    black, blue, cyan, green, magenta, red, yellow,
+    bold, reverse
 )
 
 
 class Default(ColorScheme):
     progress_bar_color = blue
+    default_colors = (None, None, None)
 
-    def use(self, context):  # pylint: disable=too-many-branches,too-many-statements
-        fg, bg, attr = default_colors
-
-        if context.reset:
-            return default_colors
-
-        elif context.in_browser:
-            if context.selected:
-                attr = reverse
-            else:
-                attr = normal
-            if context.empty or context.error:
-                bg = red
-            if context.border:
-                fg = default
-            if context.media:
-                if context.image:
-                    fg = yellow
-                else:
-                    fg = magenta
-            if context.container:
-                fg = red
-            if context.directory:
-                attr |= bold
-                fg = blue
-            elif context.executable and not \
-                    any((context.media, context.container,
-                         context.fifo, context.socket)):
-                attr |= bold
-                fg = green
-            if context.socket:
-                fg = magenta
-                attr |= bold
-            if context.fifo or context.device:
-                fg = yellow
-                if context.device:
-                    attr |= bold
-            if context.link:
-                fg = cyan if context.good else magenta
-            if context.tag_marker and not context.selected:
-                attr |= bold
-                if fg in (red, magenta):
-                    fg = white
-                else:
-                    fg = red
-            if not context.selected and (context.cut or context.copied):
-                fg = black
-                attr |= bold
-            if context.main_column:
-                if context.selected:
-                    attr |= bold
-                if context.marked:
-                    attr |= bold
-                    fg = yellow
-            if context.badinfo:
-                if attr & reverse:
-                    bg = magenta
-                else:
-                    fg = magenta
-
-            if context.inactive_pane:
-                fg = cyan
-
-        elif context.in_titlebar:
-            attr |= bold
-            if context.hostname:
-                fg = red if context.bad else green
-            elif context.directory:
-                fg = blue
-            elif context.tab:
-                if context.good:
-                    bg = green
-            elif context.link:
-                fg = cyan
-
-        elif context.in_statusbar:
-            if context.permissions:
-                if context.good:
-                    fg = cyan
-                elif context.bad:
-                    fg = magenta
-            if context.marked:
-                attr |= bold | reverse
-                fg = yellow
-            if context.frozen:
-                attr |= bold | reverse
-                fg = cyan
-            if context.message:
-                if context.bad:
-                    attr |= bold
-                    fg = red
-            if context.loaded:
-                bg = self.progress_bar_color
-            if context.vcsinfo:
-                fg = blue
-                attr &= ~bold
-            if context.vcscommit:
-                fg = yellow
-                attr &= ~bold
-            if context.vcsdate:
-                fg = cyan
-                attr &= ~bold
-
-        if context.text:
-            if context.highlight:
-                attr |= reverse
-
-        if context.in_taskview:
-            if context.title:
-                fg = blue
-
-            if context.selected:
-                attr |= reverse
-
-            if context.loaded:
-                if context.selected:
-                    fg = self.progress_bar_color
-                else:
-                    bg = self.progress_bar_color
-
-        if context.vcsfile and not context.selected:
-            attr &= ~bold
-            if context.vcsconflict:
-                fg = magenta
-            elif context.vcsuntracked:
-                fg = cyan
-            elif context.vcschanged:
-                fg = red
-            elif context.vcsunknown:
-                fg = red
-            elif context.vcsstaged:
-                fg = green
-            elif context.vcssync:
-                fg = green
-            elif context.vcsignored:
-                fg = default
-
-        elif context.vcsremote and not context.selected:
-            attr &= ~bold
-            if context.vcssync or context.vcsnone:
-                fg = green
-            elif context.vcsbehind:
-                fg = red
-            elif context.vcsahead:
-                fg = blue
-            elif context.vcsdiverged:
-                fg = magenta
-            elif context.vcsunknown:
-                fg = red
-
-        return fg, bg, attr
+    colors = {
+        'in_browser': {
+            'default': default_colors,
+            'selected': (None, None, reverse),
+            'empty': (None, red, None,),
+            'border': default_colors,
+            'media': {
+                'default': (magenta, None, None),
+                'image': (yellow, None, None)
+            },
+            'container': (red, None, None),
+            'directory': (blue, None, bold),
+            'executable': (green, None, bold),
+            'socket': (magenta, None, bold),
+            'fifo': (yellow, None, None),
+            'device': (yellow, None, bold),
+            'link': {
+                'default': (magenta, None, None),
+                'good': (cyan, None, None)
+            },
+            'tag_marker': (red, None, bold),
+            'copied': (black, None, bold),
+            'main_column': {
+                'selected': (None, None, bold),
+                'marked': (yellow, None, bold)
+            },
+            'badinfo': (magenta, None, None),
+            'inactive_pane': (cyan, None, None)
+        },
+        'in_titlebar': {
+            'default': (None, None, bold),
+            'hostname': {
+                'default': (green, None, None),
+                'bad': (red, None, None)
+            },
+            'directory': (blue, None, None),
+            'tab': {
+                'default': default_colors,
+                'good': (None, green, None)
+            },
+            'link': (cyan, None, None)
+        },
+        'in_statusbar': {
+            'default': default_colors,
+            'permissions': {
+                'good': (cyan, None, None),
+                'bad': (magenta, None, None)
+            },
+            'marked': (yellow, None, bold | reverse),
+            'frozen': (cyan, None, bold | reverse),
+            'message': {
+                'default': default_colors,
+                'bad': (red, None, bold),
+            },
+            'loaded': (None, progress_bar_color, None),
+            'vcsinfo': (blue, None, ~bold),
+            'vcscommit': (yellow, None, ~bold),
+            'vcsdate': (cyan, None, ~bold)
+        },
+        'text': {
+            'default': default_colors,
+            'highlight': (None, None, reverse)
+        },
+        'in_taskview': {
+            'default': default_colors,
+            'title': (blue, None, None),
+            'selected': (None, None, reverse),
+            'loaded': {
+                'default': (None, progress_bar_color, None),
+                'selected': (progress_bar_color, None, None)
+            }
+        },
+        'vcsfile': {
+            'default': (None, None, ~bold),
+            'vcsconflict': (magenta, None, None),
+            'vcsuntracked': (cyan, None, None),
+            'vcschanged': (red, None, None),
+            'vcsunknown': (red, None, None),
+            'vcsstaged': (green, None, None),
+            'vcssync': (green, None, None),
+            'vcsignored': default_colors
+        },
+        'vcsremote': {
+            'default': (None, None, ~bold),
+            'vcssync': (green, None, None),
+            'vcsbehind': (red, None, None),
+            'vcsahead': (blue, None, None),
+            'vcsdiverged': (magenta, None, None),
+            'vcsunknown': (red, None, None)
+        }
+    }

--- a/ranger/colorschemes/jungle.py
+++ b/ranger/colorschemes/jungle.py
@@ -4,20 +4,12 @@
 from __future__ import (absolute_import, division, print_function)
 
 from ranger.colorschemes.default import Default
-from ranger.gui.color import green, red, blue
+from ranger.gui.color import green, red, blue, bold
 
 
 class Scheme(Default):
     progress_bar_color = green
 
-    def use(self, context):
-        fg, bg, attr = Default.use(self, context)
-
-        if context.directory and not context.marked and not context.link \
-                and not context.inactive_pane:
-            fg = green
-
-        if context.in_titlebar and context.hostname:
-            fg = red if context.bad else blue
-
-        return fg, bg, attr
+    Default.colors['in_browser']['directory'] = (green, None, bold)
+    Default.colors['in_titlebar']['hostname']['default'] = (blue, None, None)
+    Default.colors['in_titlebar']['hostname']['bad'] = (red, None, None)

--- a/ranger/gui/colorscheme.py
+++ b/ranger/gui/colorscheme.py
@@ -30,7 +30,7 @@ import os.path
 from curses import color_pair
 
 import ranger
-from ranger.gui.color import get_color
+from ranger.gui.color import get_color, normal, default_colors, default, reverse
 from ranger.gui.context import Context
 from ranger.core.main import allow_access_to_confdir
 from ranger.ext.cached_function import cached_function
@@ -47,6 +47,11 @@ class ColorScheme(object):
     it defines the get() method, which returns the color tuple
     which fits to the given keys.
     """
+    colors = {}
+
+    fg = default
+    bg = default
+    attr = normal
 
     @cached_function
     def get(self, *keys):
@@ -71,13 +76,180 @@ class ColorScheme(object):
         fg, bg, attr = self.get(*flatten(keys))
         return attr | color_pair(get_color(fg, bg))
 
-    @staticmethod
-    def use(_):
-        """Use the colorscheme to determine the (fg, bg, attr) tuple.
+    def color(self, tag, attr_and=False):
+        if tag[0]:
+            self.fg = tag[0]
+        if tag[1]:
+            self.bg = tag[1]
+        if tag[2]:
+            if attr_and:
+                self.attr &= tag[2]
+            else:
+                self.attr |= tag[2]
 
-        Override this method in your own colorscheme.
-        """
-        return (-1, -1, 0)
+    def use(self, context):  # pylint: disable=too-many-branches,too-many-statements
+        self.fg, self.bg, self.attr = default_colors
+
+        if context.reset:
+            return default_colors
+
+        elif context.in_browser:
+            tag = self.colors['in_browser']
+
+            self.color(tag['default'])
+
+            if context.selected:
+                self.color(tag['selected'])
+            else:
+                self.color(default_colors)
+            if context.empty or context.error:
+                self.color(tag['empty'])
+            if context.border:
+                self.color(tag['border'])
+            if context.media:
+                if context.image:
+                    self.color(tag['media']['image'])
+                else:
+                    self.color(tag['media']['default'])
+            if context.container:
+                self.color(tag['container'])
+            if context.directory:
+                self.color(tag['directory'])
+            elif context.executable and not \
+                    any((context.media, context.container,
+                         context.fifo, context.socket)):
+                self.color(tag['executable'])
+            if context.socket:
+                self.color(tag['socket'])
+            if context.fifo:
+                self.color(tag['fifo'])
+            if context.device:
+                self.color(tag['device'])
+            if context.link:
+                if context.good:
+                    self.color(tag['link']['good'])
+                else:
+                    self.color(tag['link']['default'])
+            if context.tag_marker and not context.selected:
+                self.color(tag['tag_marker'])
+            if (context.cut or context.copied) and not context.selected:
+                self.color(tag['copied'])
+            if context.main_column:
+                if context.selected:
+                    self.color(tag['main_column']['selected'])
+                if context.marked:
+                    self.color(tag['main_column']['marked'])
+            if context.badinfo:
+                self.color(tag['badinfo'])
+
+            if context.inactive_pane:
+                self.color(tag['inactive_pane'])
+
+        elif context.in_titlebar:
+            tag = self.colors['in_titlebar']
+
+            self.color(tag['default'])
+
+            if context.hostname:
+                if context.bad:
+                    self.color(tag['hostname']['bad'])
+                else:
+                    self.color(tag['hostname']['default'])
+            elif context.directory:
+                self.color(tag['directory'])
+            elif context.tab:
+                if context.good:
+                    self.color(tag['tab']['good'])
+                else:
+                    self.color(tag['tab']['default'])
+            elif context.link:
+                self.color(tag['link'])
+
+        elif context.in_statusbar:
+            tag = self.colors['in_statusbar']
+
+            self.color(tag['default'])
+
+            if context.permissions:
+                if context.good:
+                    self.color(tag['permissions']['good'])
+                elif context.bad:
+                    self.color(tag['permissions']['bad'])
+            if context.marked:
+                self.color(tag['marked'])
+            if context.frozen:
+                self.color(tag['frozen'])
+            if context.message:
+                if context.bad:
+                    self.color(tag['message']['bad'])
+                else:
+                    self.color(tag['message']['good'])
+            if context.loaded:
+                self.color(tag['loaded'])
+            if context.vcsinfo:
+                self.color(tag['vcsinfo'], attr_and=True)
+            if context.vcscommit:
+                self.color(tag['vcscommit'], attr_and=True)
+            if context.vcsdate:
+                self.color(tag['vcsdate'], attr_and=True)
+
+        if context.text:
+            tag = self.colors['text']
+            if context.highlight:
+                self.color(tag['highlight'])
+
+        if context.in_taskview:
+            tag = self.colors['in_taskview']
+            if context.title:
+                self.color(tag['title'])
+
+            if context.selected:
+                self.color(tag['selected'])
+
+            if context.loaded:
+                if context.selected:
+                    self.color(tag['loaded']['selected'])
+                else:
+                    self.color(tag['loaded']['default'])
+
+        if context.vcsfile and not context.selected:
+            tag = self.colors['vcsfile']
+
+            self.color(tag['default'])
+            if context.vcsconflict:
+                self.color(tag['vcsconflict'])
+            elif context.vcsuntracked:
+                self.color(tag['vcsuntracked'])
+            elif context.vcschanged:
+                self.color(tag['vcschanged'])
+            elif context.vcsunknown:
+                self.color(tag['vcsunknown'])
+            elif context.vcsstaged:
+                self.color(tag['vcsstaged'])
+            elif context.vcssync:
+                self.color(tag['vcssync'])
+            elif context.vcsignored:
+                self.color(tag['vcsignored'])
+
+        elif context.vcsremote and not context.selected:
+            tag = self.colors['vcsremote']
+
+            self.color(tag['default'])
+            if context.vcssync or context.vcsnone:
+                self.color(tag['vcssync'])
+            elif context.vcsbehind:
+                self.color(tag['vcsbehind'])
+            elif context.vcsahead:
+                self.color(tag['vcsahead'])
+            elif context.vcsdiverged:
+                self.color(tag['vcsdiverged'])
+            elif context.vcsunknown:
+                self.color(tag['vcsunknown'])
+
+        if self.attr == reverse:
+            self.attr = normal
+
+        return self.fg, self.bg, self.attr
 
 
 def _colorscheme_name_to_class(signal):  # pylint: disable=too-many-branches

--- a/setup.py
+++ b/setup.py
@@ -111,7 +111,7 @@ def main():
                 'doc/rifle.1',
             ]),
             ('share/doc/ranger', [
-                'doc/colorschemes.txt',
+                'doc/colorschemes.md',
                 'CHANGELOG.md',
                 'HACKING.md',
                 'README.md',


### PR DESCRIPTION
Use dictionaries instead of method redefinition.

#### ISSUE TYPE
- Improvement/feature implementation

#### RUNTIME ENVIRONMENT
- Operating system and version: `Arch Linux x86_64 4.14.51-1-lts`
- Terminal emulator and version: `termite v13`
- Python version: `3.6.5`
- Ranger version/commit: `ranger-master 1.9.1`
- Locale: `en_US.UTF-8`

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [X] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [X] All changes follow the code style **[REQUIRED]**
- [X] All new and existing tests pass **[REQUIRED]**
- [ ] Changes require config files to be updated
    - [ ] Config files have been updated
- [X] Changes require documentation to be updated
    - [X] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
- Moved logic from `ColorScheme` sub-classes to `ranger.gui.ColorScheme.use`
- Created a dictionary in `ranger.gui.ColorScheme` called `colors`
- Moved tag-color_tuple relationship into aforementioned dictionary `colors` in the sub-class


#### MOTIVATION AND CONTEXT
This makes defining colorschemes easier for someone just getting into making colorschemes. It also shields the logic from the colorscheme creator, making it seem less of a hack or an afterthought.

#### TESTING
All current tests have passed with no changes necessary to the rest of the codebase. Good job @hut for making ranger very decoupled!