### PR TITLE
Fix run as root on macOS

### DIFF
--- a/ranger/ext/rifle.py
+++ b/ranger/ext/rifle.py
@@ -357,7 +357,7 @@ class Rifle(object):  # pylint: disable=too-many-instance-attributes
             self.hook_before_executing(command, self._mimetype, self._app_flags)
             try:
                 if 'r' in flags:
-                    prefix = ['sudo', '-E', 'su', '-mc']
+                    prefix = ['sudo', '-E', 'su', 'root', '-mc']
                 else:
                     prefix = ['/bin/sh', '-c']
 


### PR DESCRIPTION
`su` on macOS requires the user to be explicitly specified for a command
to be run.

<!-- Provide a descriptive summary of the changes in the title above -->

#### ISSUE TYPE
<!-- Pick relevant types and delete the rest -->
- Bug fix

#### RUNTIME ENVIRONMENT
<!-- Details of your runtime environment -->
<!-- Retrieve Python/ranger version and locale with `ranger -\-version` -->
- Operating system and version: macOS High Sierra 10.13.6
- Terminal emulator and version: Kitty 0.11.3
- Python version: 2.7.15 (default, Jul 15 2018, 16:11:37) [GCC 4.2.1 Compatible Clang 5.0.2 (tags/RELEASE_502/final)]
- Ranger version/commit: ranger-master 1.9.1 53e48ed0
- Locale: None.None

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [x] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [x] All changes follow the code style **[REQUIRED]**
- [x] All new and existing tests pass **[REQUIRED]**
- [ ] Changes require config files to be updated
    - [ ] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated