### PR TITLE
Replace StopIteration with bare return

### DIFF
--- a/ranger/gui/widgets/pager.py
+++ b/ranger/gui/widgets/pager.py
@@ -234,7 +234,7 @@ class Pager(Widget):  # pylint: disable=too-many-instance-attributes
     def _generate_lines(self, starty, startx):
         i = starty
         if not self.source:
-            raise StopIteration
+            return
         while True:
             try:
                 line = self._get_line(i).expandtabs(4)
@@ -244,5 +244,5 @@ class Pager(Widget):  # pylint: disable=too-many-instance-attributes
                     line = line[startx:self.wid + startx]
                 yield line.rstrip().replace('\r\n', '\n')
             except IndexError:
-                raise StopIteration
+                return
             i += 1


### PR DESCRIPTION
#### ISSUE TYPE
- Bug fix

#### RUNTIME ENVIRONMENT
<!-- Details of your runtime environment -->
<!-- Retrieve Python/ranger version and locale with `ranger -\-version` -->
- Operating system and version: Arch Linux
- Terminal emulator and version: rxvt-unicode v9.22
- Python version: 3.7.0
- Ranger version/commit: 1.9.1
- Locale: US

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [X] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [X] All changes follow the code style **[REQUIRED]**
- [X] All new and existing tests pass **[REQUIRED]**
- [ ] Changes require config files to be updated
    - [ ] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
<!-- Describe the changes in detail -->
A bare `return` in generators raises `StopIteration` (this is backwards
compatible). Using `StopIteration` raised a warning in 3.6.x and raises an
Error in 3.7.0 (and probably upwards). So this is a compatibility patch that shouldn't be too controversial (even the `try/except` blocks on `StopIteration` should still work, since the same error is raised.

See https://docs.python.org/3/reference/simple_stmts.html#grammar-token-return_stmt

#### MOTIVATION AND CONTEXT
<!-- Why are these changes required? -->
Ranger crashes on Python 3.7.0 currently.
<!-- What problems do these changes solve? -->
The crashes.
<!-- Link to relevant issues -->


#### TESTING
<!-- What tests have been run? -->
All (the pylint ones obviously give a lot of warnings).
<!-- How does the changes affect other areas of the codebase? -->
They don't, as the bare return statement still raises a `StopIteration`. I could not find any other `StopIteration` in generators, but I might have missed some.