### PR TITLE
Check whether tfile is a dir not the entire selection

### DIFF
--- a/ranger/core/actions.py
+++ b/ranger/core/actions.py
@@ -483,13 +483,12 @@ class Actions(  # pylint: disable=too-many-instance-attributes,too-many-public-m
                 mode = narg
             tfile = self.thisfile
             selection = self.thistab.get_selection()
-            if selection:
-                if selection.is_directory:
-                    self.thistab.enter_dir(tfile)
-                else:
-                    result = self.execute_file(selection, mode=mode)
-                    if result in (False, ASK_COMMAND):
-                        self.open_console('open_with ')
+            if tfile.is_directory:
+                self.thistab.enter_dir(tfile)
+            elif selection:
+                result = self.execute_file(selection, mode=mode)
+                if result in (False, ASK_COMMAND):
+                    self.open_console('open_with ')
         elif direction.vertical() and cwd.files:
             pos_new = direction.move(
                 direction=direction.down(),


### PR DESCRIPTION
Was erroneously checking the entire selection for being *a* directory
but a list of 1 or more files/directories is obviously not a directory.

Fixes #1269