### PR TITLE
Add selection argument to move action

### DIFF
--- a/ranger/core/actions.py
+++ b/ranger/core/actions.py
@@ -407,7 +407,7 @@ class Actions(  # pylint: disable=too-many-instance-attributes,too-many-public-m
             are multiple choices
         label: a string to select an opening method by its label
         flags: a string specifying additional options, see `man rifle`
-        mimetyle: pass the mimetype to rifle, overriding its own guess
+        mimetype: pass the mimetype to rifle, overriding its own guess
         """
 
         mode = kw['mode'] if 'mode' in kw else 0

--- a/ranger/core/actions.py
+++ b/ranger/core/actions.py
@@ -489,7 +489,10 @@ class Actions(  # pylint: disable=too-many-instance-attributes,too-many-public-m
             if narg is not None:
                 mode = narg
             tfile = self.thisfile
-            selection = self.thistab.get_selection()
+            if not kw.get('selection', True):
+                selection = [tfile]
+            else:
+                selection = self.thistab.get_selection()
             if tfile.is_directory:
                 self.thistab.enter_dir(tfile)
             elif selection:

--- a/ranger/core/actions.py
+++ b/ranger/core/actions.py
@@ -489,10 +489,10 @@ class Actions(  # pylint: disable=too-many-instance-attributes,too-many-public-m
             if narg is not None:
                 mode = narg
             tfile = self.thisfile
-            if not kw.get('selection', True):
-                selection = [tfile]
-            else:
+            if kw.get('selection', True):
                 selection = self.thistab.get_selection()
+            else:
+                selection = [tfile]
             if tfile.is_directory:
                 self.thistab.enter_dir(tfile)
             elif selection:


### PR DESCRIPTION
If `selection == False` don't operate on the entire selection (the marked files) but only on the file under the cursor.

Inconsistent, I noticed `move to=100 percentage=true` works as expected
but `move right=1 selection=false` doesn't. You need to pass `False`,
most other values test as `True` in python, so `true` works *but*
surprisingly imo, `false == True`.

Fixes #1233