### PR TITLE
Add `C-g` as an alias to `ESC` in console

### DIFF
--- a/ranger/config/rc.conf
+++ b/ranger/config/rc.conf
@@ -628,6 +628,7 @@ cmap <C-u>        eval fm.ui.console.delete_rest(-1)
 cmap <C-y>        eval fm.ui.console.paste()
 
 # And of course the emacs way
+copycmap <ESC>       <C-g>
 copycmap <up>        <C-p>
 copycmap <down>      <C-n>
 copycmap <left>      <C-b>


### PR DESCRIPTION
<!-- Provide a descriptive summary of the changes in the title above -->

#### ISSUE TYPE
<!-- Pick relevant types and delete the rest -->
- Improvement/feature implementation

#### RUNTIME ENVIRONMENT
<!-- Details of your runtime environment -->
<!-- Retrieve Python/ranger version and locale with `ranger -\-version` -->
- Operating system and version: Arch Linux x86_64
- Terminal emulator and version: terminator 1.91
- Python version: 3.7.0 (default, Jul 15 2018, 10:44:58) [GCC 8.1.1 20180531]
- Ranger version/commit: ranger-master 1.9.1
- Locale: En/GB

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [X] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [X] All changes follow the code style **[REQUIRED]**
- [X] All new and existing tests pass **[REQUIRED]**
- [X] Changes require config files to be updated
    - [X] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
<!-- Describe the changes in detail -->
Add <C-g> as an alias to <ESC> in console

#### MOTIVATION AND CONTEXT
<!-- Why are these changes required? -->
<!-- What problems do these changes solve? -->
<!-- Link to relevant issues -->
Mimics the behaviour of `C-g` in Emacs.
I couldn't find a line in the manual where I could document this change, so I guess this will have to wait.