### PR TITLE
Applies Tilde Setting to Window Title

### DIFF
--- a/ranger/gui/ui.py
+++ b/ranger/gui/ui.py
@@ -365,7 +365,7 @@ class UI(  # pylint: disable=too-many-instance-attributes,too-many-public-method
         DisplayableContainer.draw(self)
         if self._draw_title and self.settings.update_title:
             cwd = self.fm.thisdir.path
-            if cwd.startswith(self.fm.home_path):
+            if self.settings.tilde_in_titlebar and cwd.startswith(self.fm.home_path):
                 cwd = '~' + cwd[len(self.fm.home_path):]
             if self.settings.shorten_title:
                 split = cwd.rsplit(os.sep, self.settings.shorten_title)


### PR DESCRIPTION
#### ISSUE TYPE
- Bug fix

#### RUNTIME ENVIRONMENT
ranger version: ranger-master 1.9.1
Python version: 3.7.0 (default, Jul 15 2018, 10:44:58) [GCC 8.1.1 20180531]
Locale: ja_JP.UTF-8

#### CHECKLIST
- [X] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [X] All changes follow the code style **[REQUIRED]**
- [ ] All new and existing tests pass **[REQUIRED]**
- [ ] Changes require config files to be updated
    - [ ] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

Not all test pass, but it ain't my fault.  This shit's a joke, yo:

```■ LC_ALL=C make test
Running pylint...
pylint ./ranger/container ./ranger/core ./ranger/api ./ranger/ext ./ranger/gui ./ranger/colorschemes ./ranger/__init__.py ./doc/tools/convert_papermode_to_metadata.py ./doc/tools/print_colors.py ./doc/tools/print_keys.py ./doc/tools/performance_test.py ./examples/plugin_new_sorting_method.py ./examples/plugin_hello_world.py ./examples/plugin_chmod_keybindings.py ./examples/plugin_avfs.py ./examples/plugin_file_filter.py ./examples/plugin_pmount.py ./examples/plugin_fasd_add.py ./examples/plugin_ipc.py ./examples/plugin_new_macro.py ./examples/plugin_linemode.py ./ranger.py ./setup.py ./tests
************* Module ranger.container.directory
ranger/container/directory.py:96:0: R0205: Class 'InodeFilterConstants' inherits from object, can be safely removed from bases in python3 (useless-object-inheritance)
ranger/container/directory.py:248:8: R1705: Unnecessary "elif" after "return" (no-else-return)
ranger/container/directory.py:285:16: R1705: Unnecessary "elif" after "return" (no-else-return)
ranger/container/directory.py:520:16: W0143: Comparing against a callable, did you omit the parenthesis? (comparison-with-callable)
ranger/container/directory.py:524:16: W0143: Comparing against a callable, did you omit the parenthesis? (comparison-with-callable)
************* Module ranger.container.fsobject
ranger/container/fsobject.py:312:11: R1714: Consider merging these comparisons with "in" to 'fmt in (8192, 24576)' (consider-using-in)
************* Module ranger.container.settings
ranger/container/settings.py:300:0: R0205: Class 'LocalSettings' inherits from object, can be safely removed from bases in python3 (useless-object-inheritance)
************* Module ranger.container.bookmarks
ranger/container/bookmarks.py:90:8: R1705: Unnecessary "else" after "return" (no-else-return)
************* Module ranger.container.tags
ranger/container/tags.py:15:0: R0205: Class 'Tags' inherits from object, can be safely removed from bases in python3 (useless-object-inheritance)
ranger/container/tags.py:31:8: R1715: Consider using dict.get for getting values from a dict if a key is present or a default if not (consider-using-get)
ranger/container/tags.py:50:8: R1715: Consider using dict.get for getting values from a dict if a key is present or a default if not (consider-using-get)
************* Module ranger.container.history
ranger/container/history.py:13:0: R0205: Class 'History' inherits from object, can be safely removed from bases in python3 (useless-object-inheritance)
ranger/container/history.py:93:8: R1705: Unnecessary "else" after "return" (no-else-return)
************* Module ranger.core.fm
ranger/core/fm.py:85:4: R0915: Too many statements (62/50) (too-many-statements)
ranger/core/fm.py:229:8: R1705: Unnecessary "elif" after "return" (no-else-return)
ranger/core/fm.py:292:11: R1714: Consider merging these comparisons with "in" to "which in ('rifle', 'all')" (consider-using-in)
ranger/core/fm.py:294:11: R1714: Consider merging these comparisons with "in" to "which in ('commands', 'all')" (consider-using-in)
ranger/core/fm.py:296:11: R1714: Consider merging these comparisons with "in" to "which in ('commands_full', 'all')" (consider-using-in)
ranger/core/fm.py:298:11: R1714: Consider merging these comparisons with "in" to "which in ('rc', 'all')" (consider-using-in)
ranger/core/fm.py:300:11: R1714: Consider merging these comparisons with "in" to "which in ('scope', 'all')" (consider-using-in)
************* Module ranger.core.runner
ranger/core/runner.py:54:0: R0205: Class 'Context' inherits from object, can be safely removed from bases in python3 (useless-object-inheritance)
ranger/core/runner.py:104:0: R0205: Class 'Runner' inherits from object, can be safely removed from bases in python3 (useless-object-inheritance)
************* Module ranger.core.tab
ranger/core/tab.py:81:12: R1705: Unnecessary "elif" after "return" (no-else-return)
************* Module ranger.core.main
ranger/core/main.py:368:16: C0414: Import alias does not rename original package (useless-import-alias)
ranger/core/main.py:374:25: E1120: No value for argument 'fullname' in method call (no-value-for-parameter)
************* Module ranger.core.shared
ranger/core/shared.py:9:0: R0205: Class 'FileManagerAware' inherits from object, can be safely removed from bases in python3 (useless-object-inheritance)
ranger/core/shared.py:16:0: R0205: Class 'SettingsAware' inherits from object, can be safely removed from bases in python3 (useless-object-inheritance)
************* Module ranger.core.linemode
ranger/core/linemode.py:16:0: R0205: Class 'LinemodeBase' inherits from object, can be safely removed from bases in python3 (useless-object-inheritance)
ranger/core/linemode.py:100:8: R1705: Unnecessary "else" after "return" (no-else-return)
************* Module ranger.core.loader
ranger/core/loader.py:26:0: R0205: Class 'Loadable' inherits from object, can be safely removed from bases in python3 (useless-object-inheritance)
************* Module ranger.core.actions
ranger/core/actions.py:117:12: R1705: Unnecessary "elif" after "return" (no-else-return)
ranger/core/actions.py:1108:16: R1705: Unnecessary "elif" after "return" (no-else-return)
ranger/core/actions.py:998:4: R0915: Too many statements (77/50) (too-many-statements)
ranger/core/actions.py:1294:8: R0205: Class 'NaturalOrder' inherits from object, can be safely removed from bases in python3 (useless-object-inheritance)
************* Module ranger.core.metadata
ranger/core/metadata.py:25:0: R0205: Class 'MetadataManager' inherits from object, can be safely removed from bases in python3 (useless-object-inheritance)
************* Module ranger.core.filter_stack
ranger/core/filter_stack.py:15:0: R0205: Class 'BaseFilter' inherits from object, can be safely removed from bases in python3 (useless-object-inheritance)
************* Module ranger.api.commands
ranger/api/commands.py:32:12: R1705: Unnecessary "elif" after "return" (no-else-return)
ranger/api/commands.py:431:16: R1705: Unnecessary "else" after "return" (no-else-return)
************* Module ranger.ext.keybinding_parser
ranger/ext/keybinding_parser.py:220:0: R0205: Class 'KeyBuffer' inherits from object, can be safely removed from bases in python3 (useless-object-inheritance)
************* Module ranger.ext.rifle
ranger/ext/rifle.py:116:0: R0205: Class 'Rifle' inherits from object, can be safely removed from bases in python3 (useless-object-inheritance)
ranger/ext/rifle.py:221:12: R1705: Unnecessary "else" after "return" (no-else-return)
************* Module ranger.ext.widestring
ranger/ext/widestring.py:57:0: R0205: Class 'WideString' inherits from object, can be safely removed from bases in python3 (useless-object-inheritance)
ranger/ext/widestring.py:80:8: R1705: Unnecessary "elif" after "return" (no-else-return)
ranger/ext/widestring.py:91:8: R1705: Unnecessary "elif" after "return" (no-else-return)
************* Module ranger.ext.accumulator
ranger/ext/accumulator.py:9:0: R0205: Class 'Accumulator' inherits from object, can be safely removed from bases in python3 (useless-object-inheritance)
************* Module ranger.ext.img_display
ranger/ext/img_display.py:73:0: R0205: Class 'ImageDisplayer' inherits from object, can be safely removed from bases in python3 (useless-object-inheritance)
ranger/ext/img_display.py:146:8: W0706: The except handler raises immediately (try-except-raise)
ranger/ext/img_display.py:279:8: R1705: Unnecessary "elif" after "return" (no-else-return)
ranger/ext/img_display.py:625:8: R1705: Unnecessary "else" after "return" (no-else-return)
************* Module ranger.ext.signals
ranger/ext/signals.py:87:0: R0205: Class 'SignalHandler' inherits from object, can be safely removed from bases in python3 (useless-object-inheritance)
ranger/ext/signals.py:105:0: R0205: Class 'SignalDispatcher' inherits from object, can be safely removed from bases in python3 (useless-object-inheritance)
ranger/ext/signals.py:165:8: R1705: Unnecessary "elif" after "return" (no-else-return)
************* Module ranger.ext.lazy_property
ranger/ext/lazy_property.py:8:0: R0205: Class 'lazy_property' inherits from object, can be safely removed from bases in python3 (useless-object-inheritance)
************* Module ranger.ext.shell_escape
ranger/ext/shell_escape.py:12:12: R1717: Consider using a dictionary comprehension (consider-using-dict-comprehension)
************* Module ranger.ext.vcs.svn
ranger/ext/vcs/svn.py:141:8: R1705: Unnecessary "elif" after "return" (no-else-return)
ranger/ext/vcs/svn.py:142:12: R1705: Unnecessary "else" after "return" (no-else-return)
************* Module ranger.ext.vcs.bzr
ranger/ext/vcs/bzr.py:137:8: R1705: Unnecessary "elif" after "return" (no-else-return)
ranger/ext/vcs/bzr.py:138:12: R1705: Unnecessary "else" after "return" (no-else-return)
************* Module ranger.ext.vcs.hg
ranger/ext/vcs/hg.py:129:8: R1705: Unnecessary "elif" after "return" (no-else-return)
ranger/ext/vcs/hg.py:130:12: R1705: Unnecessary "else" after "return" (no-else-return)
************* Module ranger.ext.vcs.vcs
ranger/ext/vcs/vcs.py:27:0: R0205: Class 'Vcs' inherits from object, can be safely removed from bases in python3 (useless-object-inheritance)
ranger/ext/vcs/vcs.py:124:12: R1705: Unnecessary "else" after "return" (no-else-return)
************* Module ranger.ext.vcs.git
ranger/ext/vcs/git.py:188:8: R1705: Unnecessary "elif" after "return" (no-else-return)
ranger/ext/vcs/git.py:189:12: R1705: Unnecessary "else" after "return" (no-else-return)
************* Module ranger.gui.bar
ranger/gui/bar.py:14:0: R0205: Class 'Bar' inherits from object, can be safely removed from bases in python3 (useless-object-inheritance)
ranger/gui/bar.py:121:0: R0205: Class 'ColoredString' inherits from object, can be safely removed from bases in python3 (useless-object-inheritance)
************* Module ranger.gui.context
ranger/gui/context.py:31:0: R0205: Class 'Context' inherits from object, can be safely removed from bases in python3 (useless-object-inheritance)
************* Module ranger.gui.displayable
ranger/gui/displayable.py:113:16: R1716: Simplify chained comparison between the operands (chained-comparison)
ranger/gui/displayable.py:114:13: R1716: Simplify chained comparison between the operands (chained-comparison)
************* Module ranger.gui.ui
ranger/gui/ui.py:240:25: R1716: Simplify chained comparison between the operands (chained-comparison)
ranger/gui/ui.py:509:8: R1705: Unnecessary "elif" after "return" (no-else-return)
************* Module ranger.gui.mouse_event
ranger/gui/mouse_event.py:9:0: R0205: Class 'MouseEvent' inherits from object, can be safely removed from bases in python3 (useless-object-inheritance)
ranger/gui/mouse_event.py:45:8: R1705: Unnecessary "elif" after "return" (no-else-return)
************* Module ranger.gui.ansi
ranger/gui/ansi.py:83:21: R1716: Simplify chained comparison between the operands (chained-comparison)
ranger/gui/ansi.py:87:21: R1716: Simplify chained comparison between the operands (chained-comparison)
ranger/gui/ansi.py:93:21: R1716: Simplify chained comparison between the operands (chained-comparison)
ranger/gui/ansi.py:97:21: R1716: Simplify chained comparison between the operands (chained-comparison)
ranger/gui/ansi.py:162:13: R1716: Simplify chained comparison between the operands (chained-comparison)
************* Module ranger.gui.colorscheme
ranger/gui/colorscheme.py:44:0: R0205: Class 'ColorScheme' inherits from object, can be safely removed from bases in python3 (useless-object-inheritance)
************* Module ranger.gui.widgets.statusbar
ranger/gui/widgets/statusbar.py:70:12: R1705: Unnecessary "else" after "return" (no-else-return)
ranger/gui/widgets/statusbar.py:335:0: R0205: Class 'Message' inherits from object, can be safely removed from bases in python3 (useless-object-inheritance)
************* Module ranger.gui.widgets.browsercolumn
ranger/gui/widgets/browsercolumn.py:537:11: R1716: Simplify chained comparison between the operands (chained-comparison)
************* Module ranger.colorschemes.solarized
ranger/colorschemes/solarized.py:24:8: R1705: Unnecessary "elif" after "return" (no-else-return)
************* Module ranger.colorschemes.default
ranger/colorschemes/default.py:20:8: R1705: Unnecessary "elif" after "return" (no-else-return)
************* Module tests.ranger.container.test_fsobject
tests/ranger/container/test_fsobject.py:8:0: R0205: Class 'MockFM' inherits from object, can be safely removed from bases in python3 (useless-object-inheritance)

------------------------------------------------------------------
Your code has been rated at 9.91/10 (previous run: 9.91/10, +0.00)

make: *** [Makefile:90: test_pylint] Error 30
```