### PR TITLE
 Add mapping to open console and pre-fill it with previous command

### DIFF
--- a/doc/ranger.1
+++ b/doc/ranger.1
@@ -645,7 +645,7 @@ to use to open the current file selection.
 Open the console with the content \*(L"cd \*(R"
 .IP "^P" 14
 .IX Item "^P"
-Open the console with the content of the last command.
+Open the console with the most recent command.
 .IP "Alt\-\fIN\fR" 14
 .IX Item "Alt-N"
 Open a tab. N has to be a number from 0 to 9. If the tab doesn't exist yet, it

--- a/doc/ranger.1
+++ b/doc/ranger.1
@@ -643,6 +643,9 @@ to use to open the current file selection.
 .IP "cd" 14
 .IX Item "cd"
 Open the console with the content \*(L"cd \*(R"
+.IP "^P" 14
+.IX Item "^P"
+Open the console with the content of the last command.
 .IP "Alt\-\fIN\fR" 14
 .IX Item "Alt-N"
 Open a tab. N has to be a number from 0 to 9. If the tab doesn't exist yet, it

--- a/doc/ranger.pod
+++ b/doc/ranger.pod
@@ -599,7 +599,7 @@ Open the console with the content "cd "
 
 =item ^P
 
-Open the console with the content of the last command.
+Open the console with the most recent command.
 
 =item Alt-I<N>
 

--- a/doc/ranger.pod
+++ b/doc/ranger.pod
@@ -597,6 +597,10 @@ to use to open the current file selection.
 
 Open the console with the content "cd "
 
+=item ^P
+
+Open the console with the content of the last command.
+
 =item Alt-I<N>
 
 Open a tab. N has to be a number from 0 to 9. If the tab doesn't exist yet, it

--- a/ranger/config/rc.conf
+++ b/ranger/config/rc.conf
@@ -349,7 +349,7 @@ map r  chain draw_possible_programs; console open_with%%space
 map f  console find%space
 map cd console cd%space
 
-map <C-p> console
+map <C-p> chain console; eval fm.ui.console.history_move(-1)
 
 # Change the line mode
 map Mf linemode filename


### PR DESCRIPTION
<!-- Provide a descriptive summary of the changes in the title above -->

#### ISSUE TYPE
<!-- Pick relevant types and delete the rest -->
- Improvement/feature implementation

#### RUNTIME ENVIRONMENT
<!-- Details of your runtime environment -->
<!-- Retrieve Python/ranger version and locale with YY -->
- Operating system and version: Arch Linux x86_64
- Terminal emulator and version: terminator 1.91
- Python version: 3.7.0 (default, Jul 15 2018, 10:44:58) [GCC 8.1.1 20180531]
- Ranger version/commit: ranger-master 1.9.1
- Locale: En/GB

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [X] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [X] All changes follow the code style **[REQUIRED]**
- [X] All new and existing tests pass **[REQUIRED]**
- [X] Changes require config files to be updated
    - [X] Config files have been updated
- [X] Changes require documentation to be updated
    - [X] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
<!-- Describe the changes in detail -->
Add mapping to open console and pre-fill it with previous command.
Behaviour assigned to Ctrl-p.

#### MOTIVATION AND CONTEXT
<!-- Why are these changes required? -->
<!-- What problems do these changes solve? -->
<!-- Link to relevant issues -->
Follows from the discussion in #1293.
Non-essential change which can be removed if we find a better use for `Ctrl-p`.