### PR TITLE
Fix for issue #1312 (wrong color format)

### DIFF
--- a/ranger/ext/img_display.py
+++ b/ranger/ext/img_display.py
@@ -588,14 +588,14 @@ class KittyImageDisplayer(ImageDisplayer):
             image = image.resize((int(scale * image.width), int(scale * image.height)),
                                  self.backend.LANCZOS)
 
+        if image.mode != 'RGB' and image.mode != 'RGBA':
+            image = image.convert('RGB')
         # start_x += ((box[0] - image.width) // 2) // self.pix_row
         # start_y += ((box[1] - image.height) // 2) // self.pix_col
         if self.stream:
             # encode the whole image as base64
             # TODO: implement z compression
             # to possibly increase resolution in sent image
-            if image.mode != 'RGB' and image.mode != 'RGBA':
-                image = image.convert('RGB')
             # t: transmissium medium, 'd' for embedded
             # f: size of a pixel fragment (8bytes per color)
             # s, v: size of the image to recompose the flattened data


### PR DESCRIPTION
Moved the format conversion line from the stream section to the general
one, as PIL does not autoconvert on save

#### ISSUE TYPE
- Bug fix

#### CHECKLIST
- [x] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [x] All changes follow the code style **[REQUIRED]**
- [x] All new and existing tests pass **[REQUIRED]**
- [ ] Changes require config files to be updated
    - [ ] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
the diff speaks for itself in this case


#### MOTIVATION AND CONTEXT
#1312 Example of the bug in the wild

#### TESTING
tested on a CYMK jpg image from wikipedia. It might be worthwhile to wait until I test on some different formats (palette gifs?). I have a bus to catch though for now :sweat_smile:. But it should work fine.

