### PR TITLE
initial mouse wheel scroll support in preview (Issue #147)

### DIFF
--- a/ranger/gui/widgets/browsercolumn.py
+++ b/ranger/gui/widgets/browsercolumn.py
@@ -95,7 +95,13 @@ class BrowserColumn(Pager):  # pylint: disable=too-many-instance-attributes
                         elif self.level == 0:
                             self.fm.thisdir.move_to_obj(clicked_file)
                             self.fm.execute_file(clicked_file)
-
+        elif self.target.is_file: ##scrolling through file preview?
+            if len(self.lines) > self.hei: ##is it longer than we can show?
+                if self.scrollbit > -1: ## have we reached the the top?
+                    self.scrollbit += direction # influence the start point
+                    if self.scrollbit < 0: #make sure we dont scroll before the file
+                        self.scrollbit = 0
+            self.need_redraw = True
         else:
             if self.level > 0 and not direction:
                 self.fm.move(right=0)
@@ -155,6 +161,7 @@ class BrowserColumn(Pager):  # pylint: disable=too-many-instance-attributes
         if target != self.old_dir:
             self.need_redraw = True
             self.old_dir = target
+            self.scrollbit = 0 # reset scroll start
 
         if target:
             target.use()

--- a/ranger/gui/widgets/browsercolumn.py
+++ b/ranger/gui/widgets/browsercolumn.py
@@ -60,7 +60,7 @@ class BrowserColumn(Pager):  # pylint: disable=too-many-instance-attributes
     def request_redraw(self):
         self.need_redraw = True
 
-    def click(self, event):
+    def click(self, event):     # pylint: disable=too-many-branches
         """Handle a MouseEvent"""
         direction = event.mouse_wheel_direction()
         if not (event.pressed(1) or event.pressed(3) or direction):
@@ -95,14 +95,8 @@ class BrowserColumn(Pager):  # pylint: disable=too-many-instance-attributes
                         elif self.level == 0:
                             self.fm.thisdir.move_to_obj(clicked_file)
                             self.fm.execute_file(clicked_file)
-        elif self.target.is_file:  # scrolling through file preview?
-            # Is there more to show?
-            if direction > 0 and len(self.lines) > self.hei + self.scrollbit:
-                self.scrollbit += direction  # influence the start point
-                if self.scrollbit < 0:  # make sure we dont scroll before or after the file
-                    self.scrollbit = 0
-            if direction < 0 and self.scrollbit > 0:  # have we reached the the top
-                self.scrollbit += direction  # influence the start point
+        elif self.target.is_file:
+            self.scrollbit = max(0, self.scrollbit + direction)
             self.need_redraw = True
         else:
             if self.level > 0 and not direction:

--- a/ranger/gui/widgets/browsercolumn.py
+++ b/ranger/gui/widgets/browsercolumn.py
@@ -96,11 +96,12 @@ class BrowserColumn(Pager):  # pylint: disable=too-many-instance-attributes
                             self.fm.thisdir.move_to_obj(clicked_file)
                             self.fm.execute_file(clicked_file)
         elif self.target.is_file: ##scrolling through file preview?
-            if len(self.lines) > self.hei: ##is it longer than we can show?
-                if self.scrollbit > -1: ## have we reached the the top?
-                    self.scrollbit += direction # influence the start point
-                    if self.scrollbit < 0: #make sure we dont scroll before the file
-                        self.scrollbit = 0
+            if direction > 0 and len(self.lines) > self.hei+self.scrollbit: ##is there more to show?
+                self.scrollbit += direction # influence the start point
+                if self.scrollbit < 0: #make sure we dont scroll before or after the file
+                    self.scrollbit = 0
+            if direction < 0 and self.scrollbit > 0: ## have we reached the the top
+                self.scrollbit += direction # influence the start point
             self.need_redraw = True
         else:
             if self.level > 0 and not direction:

--- a/ranger/gui/widgets/browsercolumn.py
+++ b/ranger/gui/widgets/browsercolumn.py
@@ -95,13 +95,14 @@ class BrowserColumn(Pager):  # pylint: disable=too-many-instance-attributes
                         elif self.level == 0:
                             self.fm.thisdir.move_to_obj(clicked_file)
                             self.fm.execute_file(clicked_file)
-        elif self.target.is_file: ##scrolling through file preview?
-            if direction > 0 and len(self.lines) > self.hei+self.scrollbit: ##is there more to show?
-                self.scrollbit += direction # influence the start point
-                if self.scrollbit < 0: #make sure we dont scroll before or after the file
+        elif self.target.is_file:  # scrolling through file preview?
+            # Is there more to show?
+            if direction > 0 and len(self.lines) > self.hei + self.scrollbit:
+                self.scrollbit += direction  # influence the start point
+                if self.scrollbit < 0:  # make sure we dont scroll before or after the file
                     self.scrollbit = 0
-            if direction < 0 and self.scrollbit > 0: ## have we reached the the top
-                self.scrollbit += direction # influence the start point
+            if direction < 0 and self.scrollbit > 0:  # have we reached the the top
+                self.scrollbit += direction  # influence the start point
             self.need_redraw = True
         else:
             if self.level > 0 and not direction:
@@ -162,7 +163,7 @@ class BrowserColumn(Pager):  # pylint: disable=too-many-instance-attributes
         if target != self.old_dir:
             self.need_redraw = True
             self.old_dir = target
-            self.scrollbit = 0 # reset scroll start
+            self.scrollbit = 0  # reset scroll start
 
         if target:
             target.use()

--- a/ranger/gui/widgets/pager.py
+++ b/ranger/gui/widgets/pager.py
@@ -97,7 +97,7 @@ class Pager(Widget):  # pylint: disable=too-many-instance-attributes
 
             if not self.image:
                 line_gen = self._generate_lines(
-                    starty=self.scrollbit, startx=self.startx) #updated for new scroll var
+                    starty=self.scrollbit, startx=self.startx)
 
                 for line, i in zip(line_gen, range(self.hei)):
                     self._draw_line(i, line)

--- a/ranger/gui/widgets/pager.py
+++ b/ranger/gui/widgets/pager.py
@@ -29,6 +29,7 @@ class Pager(Widget):  # pylint: disable=too-many-instance-attributes
     need_clear_image = False
     need_redraw_image = False
     max_width = None
+    scrollbit = 0
 
     def __init__(self, win, embedded=False):
         Widget.__init__(self, win)
@@ -39,6 +40,7 @@ class Pager(Widget):  # pylint: disable=too-many-instance-attributes
         self.lines = []
         self.image = None
         self.image_drawn = False
+        self.scrollbit = 0
 
     def _close_source(self):
         if self.source and self.source_is_stream:
@@ -95,7 +97,7 @@ class Pager(Widget):  # pylint: disable=too-many-instance-attributes
 
             if not self.image:
                 line_gen = self._generate_lines(
-                    starty=self.scroll_begin, startx=self.startx)
+                    starty=self.scrollbit, startx=self.startx) #updated for new scroll var
 
                 for line, i in zip(line_gen, range(self.hei)):
                     self._draw_line(i, line)


### PR DESCRIPTION
#### ISSUE TYPE
- Improvement/feature implementation

#### RUNTIME ENVIRONMENT
- Operating system and version: 4.18.11-arch1-1-ARCH
- Terminal emulator and version: rxvt-unicode (urxvt) v9.22 
- Ranger version: ranger-master v1.9.2-9-g41e19fd3
- Python version: 3.7.0 (default, Sep 15 2018, 19:13:07) [GCC 8.2.1 20180831]
- Locale: en_US.UTF-8

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [X] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [X] All changes follow the code style **[REQUIRED]**
- [X] All new and existing tests pass **[REQUIRED]**
- [ ] Changes require config files to be updated
    - [ ] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
Enabled the ability to use mouse wheel to scroll through files without going into preview.
It resets to the begin whenever the selected file changes.


#### MOTIVATION AND CONTEXT
This addresses feature-request (Issue) #147 


#### TESTING
I've run the default test. With the exception of introducing a new variable to the pager, there doesn't seem to be major changes