### PR TITLE
Make bulkrename create destination directories (fixes #963)

### DIFF
--- a/ranger/config/commands.py
+++ b/ranger/config/commands.py
@@ -1063,7 +1063,8 @@ class bulkrename(Command):
     After you close it, it will be executed.
     """
 
-    def execute(self):  # pylint: disable=too-many-locals,too-many-statements,too-many-branches
+    def execute(self):
+        # pylint: disable=too-many-locals,too-many-statements,too-many-branches
         import sys
         import tempfile
         from ranger.container.file import File
@@ -1092,17 +1093,23 @@ class bulkrename(Command):
         # Generate script
         cmdfile = tempfile.NamedTemporaryFile()
         script_lines = []
-        script_lines.append("# This file will be executed when you close the editor.\n")
-        script_lines.append("# Please double-check everything, clear the file to abort.\n")
+        script_lines.append("# This file will be executed when you close the"
+                            " editor.")
+        script_lines.append("# Please double-check everything, clear the file"
+                            " to abort.")
         new_dirs = []
         for old, new in zip(filenames, new_filenames):
             if old != new:
                 basepath, _ = os.path.split(new)
-                if basepath and basepath not in new_dirs and not os.path.isdir(basepath):
-                    script_lines.extend("mkdir -vp -- %s\n" % esc(basepath))
+                if (basepath is not None and basepath not in new_dirs
+                        and not os.path.isdir(basepath)):
+                    script_lines.append("mkdir -vp -- {dir}".format(
+                        dir=esc(basepath)))
                     new_dirs.append(basepath)
-                script_lines.extend("mv -vi -- %s %s\n" % (esc(old), esc(new)))
-        script_content = "".join(script_lines)
+                script_lines.append("mv -vi -- {old} {new}".format(
+                    old=esc(old), new=esc(new)))
+        # Make sure not to forget the ending newline
+        script_content = "\n".join(script_lines) + "\n"
         if py3:
             cmdfile.write(script_content.encode("utf-8"))
         else:

--- a/ranger/config/commands.py
+++ b/ranger/config/commands.py
@@ -1063,7 +1063,7 @@ class bulkrename(Command):
     After you close it, it will be executed.
     """
 
-    def execute(self):  # pylint: disable=too-many-locals,too-many-statements
+    def execute(self):  # pylint: disable=too-many-locals,too-many-statements,too-many-branches
         import sys
         import tempfile
         from ranger.container.file import File
@@ -1094,8 +1094,14 @@ class bulkrename(Command):
         script_lines = []
         script_lines.append("# This file will be executed when you close the editor.\n")
         script_lines.append("# Please double-check everything, clear the file to abort.\n")
-        script_lines.extend("mv -vi -- %s %s\n" % (esc(old), esc(new))
-                            for old, new in zip(filenames, new_filenames) if old != new)
+        new_dirs = []
+        for old, new in zip(filenames, new_filenames):
+            if old != new:
+                basepath, _ = os.path.split(new)
+                if basepath and basepath not in new_dirs and not os.path.isdir(basepath):
+                    script_lines.extend("mkdir -vp -- %s\n" % esc(basepath))
+                    new_dirs.append(basepath)
+                script_lines.extend("mv -vi -- %s %s\n" % (esc(old), esc(new)))
         script_content = "".join(script_lines)
         if py3:
             cmdfile.write(script_content.encode("utf-8"))


### PR DESCRIPTION
<!-- Provide a descriptive summary of the changes in the title above -->
#### ISSUE TYPE
<!-- Pick relevant types and delete the rest -->
- Improvement/feature implementation

#### RUNTIME ENVIRONMENT
<!-- Details of your runtime environment -->
<!-- Retrieve Python/ranger version and locale with `ranger -\-version` -->
- Operating system and version: Arch
- Terminal emulator and version: urxvt v9.22
- Python version: 3.7.0
- Ranger version/commit: ranger-master 1.9.2
- Locale: en_US.UTF-8

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [X] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [X] All changes follow the code style **[REQUIRED]**
- [X] All new and existing tests pass **[REQUIRED]**
- [ ] Changes require config files to be updated
    - [ ] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
<!-- Describe the changes in detail -->
Make bulkrename create missing destination directories

For example:

- Test directory:
```
$ ls -l 
1
2
3
```

- `:bulkrename` input:
```
test/1
2.txt
test/3.txt
```

- `:bulkrename` output script:
```
mkdir -vp -- test
mv -vi -- 1 test/1
mv -vi -- 2 2.txt
mv -vi -- 3 test/3.txt
```

- Resulting test directory:
```
ls -1R
.:
2.txt
test

./test:
1
3.txt
```

#### MOTIVATION AND CONTEXT
<!-- Why are these changes required? -->
<!-- What problems do these changes solve? -->
<!-- Link to relevant issues -->
https://github.com/ranger/ranger/issues/963

#### TESTING
<!-- What tests have been run? -->
<!-- How does the changes affect other areas of the codebase? -->
Tested with Python 2 and 3.

#### IMAGES / VIDEOS<!-- Only if relevant -->
<!-- Link or embed images and videos of screenshots, sketches etc. -->
