### PR TITLE
Add setting to show only version controlled files

### DIFF
--- a/ranger/container/directory.py
+++ b/ranger/container/directory.py
@@ -179,7 +179,7 @@ class Directory(  # pylint: disable=too-many-instance-attributes,too-many-public
                 weak=True, autosort=False,
             )
             self._vcs_signal_handler_installed = True
-        if self.settings.vcs_aware:
+        if self.settings.vcs_aware or self.settings.vcs_filter:
             return Vcs(self)
         return None
 
@@ -270,6 +270,17 @@ class Directory(  # pylint: disable=too-many-instance-attributes,too-many-public
                         return False
                 return True
             filters.append(hidden_filter_func)
+
+        if self.settings.vcs_filter:
+            def vcs_filter_func(fobj):
+                if not fobj.is_directory and \
+                   fobj.vcsstatus == self.settings.vcs_filter:
+                    hide = False
+                else:
+                    hide = True
+                return hide
+            filters.append(vcs_filter_func)
+
         if self.narrow_filter:
             # pylint: disable=unsupported-membership-test
 

--- a/ranger/container/settings.py
+++ b/ranger/container/settings.py
@@ -92,6 +92,7 @@ ALLOWED_SETTINGS = {
     'vcs_backend_git': str,
     'vcs_backend_hg': str,
     'vcs_backend_svn': str,
+    'vcs_filter': str,
     'viewmode': str,
     'w3m_delay': float,
     'w3m_offset': int,
@@ -111,6 +112,7 @@ ALLOWED_VALUES = {
     'vcs_backend_git': ['enabled', 'disabled', 'local'],
     'vcs_backend_hg': ['disabled', 'local', 'enabled'],
     'vcs_backend_svn': ['disabled', 'local', 'enabled'],
+    'vcs_filter': ['untracked', 'changed', 'sync'],
     'viewmode': ['miller', 'multipane'],
 }
 


### PR DESCRIPTION
Issue #1074.

<!-- Provide a descriptive summary of the changes in the title above -->
Adds a setting "vcs_filter" which can be set to "untracked" in order to hide untracked files. Feature is _incomplete_.

#### ISSUE TYPE
<!-- Pick relevant types and delete the rest -->
- Improvement/feature implementation

#### RUNTIME ENVIRONMENT
<!-- Details of your runtime environment -->
<!-- Retrieve Python/ranger version and locale with `ranger -\-version` -->
- Operating system and version: Ubuntu 18.04
- Terminal emulator and version: urxvt v9.22
- Python version: 2.7.15
- Ranger version/commit: 1.9.2
- Locale: en_US.UTF-8

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [X] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [X] All changes follow the code style **[REQUIRED]**
- [X] All new and existing tests pass **[REQUIRED]**
- [X] Changes require config files to be updated
    - [ ] Config files have been updated
- [X] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
<!-- Describe the changes in detail -->
Setting "vcs_filter" to "untracked", and _then refiltering the directory_ with `reload_cwd` or `eval fm.thisdir.refilter()`, will hide untracked files in a version-controlled repository. I'm stuck on how to get past this limitation. If someone is interested in this feature and willing to help, we can try to complete it. You can use "set vcs_filter" (and reload) to unset the filter. And since it was no extra work, you can set "vcs_filter" to "sync" to hide all unchanged, tracked files, and "changed" to hide all changed, tracked files. 

#### MOTIVATION AND CONTEXT
<!-- Why are these changes required? -->
<!-- What problems do these changes solve? -->
<!-- Link to relevant issues -->
Issue #1074 requests a setting to toggle visibility of untracked files in repositories. 

#### TESTING
<!-- What tests have been run? -->
<!-- How does the changes affect other areas of the codebase? -->
Passed make test in Python 2. 