### PR TITLE
Change scope.sh for compatibility with BSDs

### DIFF
--- a/ranger/data/scope.sh
+++ b/ranger/data/scope.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 set -o noclobber -o noglob -o nounset -o pipefail
-IFS=$'\n'
+IFS=$(printf '\n')
 
 # If the option `use_preview_script` is set to `true`,
 # then this script will be called and its output will be displayed in ranger.

--- a/ranger/data/scope.sh
+++ b/ranger/data/scope.sh
@@ -109,7 +109,7 @@ handle_image() {
             orientation="$( identify -format '%[EXIF:Orientation]\n' -- "${FILE_PATH}" )"
             # If orientation data is present and the image actually
             # needs rotating ("1" means no rotation)...
-            if [[ -n "$orientation" && "$orientation" != 1 ]]; then
+            if [ -n "$orientation" && "$orientation" != 1 ]; then
                 # ...auto-rotate the image according to the EXIF data.
                 convert -- "${FILE_PATH}" -auto-orient "${IMAGE_CACHE_PATH}" && exit 6
             fi
@@ -178,10 +178,10 @@ handle_mime() {
         # Text
         text/* | */xml)
             # Syntax highlight
-            if [[ "$( stat --printf='%s' -- "${FILE_PATH}" )" -gt "${HIGHLIGHT_SIZE_MAX}" ]]; then
+            if [ "$( stat --printf='%s' -- "${FILE_PATH}" )" -gt "${HIGHLIGHT_SIZE_MAX}" ]; then
                 exit 2
             fi
-            if [[ "$( tput colors )" -ge 256 ]]; then
+            if [ "$( tput colors )" -ge 256 ]; then
                 local pygmentize_format='terminal256'
                 local highlight_format='xterm256'
             else
@@ -215,7 +215,7 @@ handle_fallback() {
 
 
 MIMETYPE="$( file --dereference --brief --mime-type -- "${FILE_PATH}" )"
-if [[ "${PV_IMAGE_ENABLED}" == 'True' ]]; then
+if [ "${PV_IMAGE_ENABLED}" = 'True' ]; then
     handle_image "${MIMETYPE}"
 fi
 handle_extension

--- a/ranger/data/scope.sh
+++ b/ranger/data/scope.sh
@@ -1,4 +1,13 @@
 #!/usr/bin/env bash
+# DISCLAIMER
+# This script adheres to POSIX sh with the exception of the `local` keyword
+# however nearly all shells used as sh on modern systems (e.g. dash, ash,
+# openBSD ksh) support it. There are ways to implement local scoping in
+# accordance with POSIX but ironically they are less portable than the keyword.
+# [Shellcheck wiki on bashisms](https://github.com/koalaman/shellcheck/wiki/SC2039)
+# [SO answer](https://stackoverflow.com/a/18600920)
+# [Ubuntu wiki about dash transition](https://wiki.ubuntu.com/DashAsBinSh)
+# [More bashism advice](http://mywiki.wooledge.org/Bashism)
 
 set -o noclobber -o noglob -o nounset -o pipefail
 IFS=$(printf '\n')


### PR DESCRIPTION
These changes should make `scope.sh` more POSIX compliant and more importantly compatible with the BSDs.

Everything but the `local` keyword is now POSIX compliant, however this keyword is available on all `sh` implementations that matter afaict. So I added a disclaimer. I'm open to rewording/shortening/removing it.