### PR TITLE
Change scope.sh shebang for BSDs

### DIFF
--- a/ranger/core/fm.py
+++ b/ranger/core/fm.py
@@ -301,14 +301,18 @@ class FM(Actions,  # pylint: disable=too-many-instance-attributes
             copy('data/scope.sh', 'scope.sh')
             os.chmod(self.confpath('scope.sh'),
                      os.stat(self.confpath('scope.sh')).st_mode | stat.S_IXUSR)
-        if which in ('all', 'rifle', 'scope', 'commands', 'commands_full', 'rc'):
+        if which in ('all', 'rifle', 'scope', 'commands', 'commands_full',
+                     'rc'):
             sys.stderr.write("\n> Please note that configuration files may "
-                             "change as ranger evolves.\n  It's completely up to you to "
-                             "keep them up to date.\n")
-            if os.environ.get('RANGER_LOAD_DEFAULT_RC', 'TRUE').upper() != 'FALSE':
+                             "change as ranger evolves.\n  "
+                             "It's completely up to you to keep them up to "
+                             "date.\n")
+            if (os.environ.get('RANGER_LOAD_DEFAULT_RC', 'TRUE').upper()
+                    != 'FALSE'):
                 sys.stderr.write("\n> To stop ranger from loading "
-                                 "\033[1mboth\033[0m the default and your custom rc.conf,\n"
-                                 "  please set the environment variable "
+                                 "\033[1mboth\033[0m the default and your "
+                                 "custom rc.conf,\n  "
+                                 "please set the environment variable "
                                  "\033[1mRANGER_LOAD_DEFAULT_RC\033[0m to "
                                  "\033[1mFALSE\033[0m.\n")
         else:

--- a/ranger/core/fm.py
+++ b/ranger/core/fm.py
@@ -289,6 +289,8 @@ class FM(Actions,  # pylint: disable=too-many-instance-attributes
                     shutil.copy(self.relpath(src), self.confpath(dest))
                 except OSError as ex:
                     sys.stderr.write("  ERROR: %s\n" % str(ex))
+                return 'freshcopy'
+            return ''
         if which == 'rifle' or which == 'all':
             copy('config/rifle.conf', 'rifle.conf')
         if which == 'commands' or which == 'all':
@@ -298,9 +300,17 @@ class FM(Actions,  # pylint: disable=too-many-instance-attributes
         if which == 'rc' or which == 'all':
             copy('config/rc.conf', 'rc.conf')
         if which == 'scope' or which == 'all':
-            copy('data/scope.sh', 'scope.sh')
-            os.chmod(self.confpath('scope.sh'),
-                     os.stat(self.confpath('scope.sh')).st_mode | stat.S_IXUSR)
+            if copy('data/scope.sh', 'scope.sh') == 'freshcopy':
+                if 'bash' in ranger.ext.get_executables.get_executables():
+                    with open(self.confpath('scope.sh'), 'r') as scope_file:
+                        scope_file.readline()
+                        without_shebang = scope_file.read()
+                    with open(self.confpath('scope.sh'), 'w') as scope_file:
+                        scope_file.write('#!/usr/bin/env bash\n')
+                        scope_file.write(without_shebang)
+                os.chmod(self.confpath('scope.sh'),
+                         os.stat(self.confpath('scope.sh')).st_mode
+                         | stat.S_IXUSR)
         if which in ('all', 'rifle', 'scope', 'commands', 'commands_full',
                      'rc'):
             sys.stderr.write("\n> Please note that configuration files may "

--- a/ranger/data/scope.sh
+++ b/ranger/data/scope.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 set -o noclobber -o noglob -o nounset -o pipefail
 IFS=$'\n'


### PR DESCRIPTION
This would make scope.sh fully compatible with the BSDs and as an added bonus on some systems should lead to a small (probably hardly noticeable) performance improvement (dash is faster than bash for example).

I also implemented changing the shebang when copying `scope.sh`.
I don't actually think that's necessary but here's my rationale:
>Apparently the differences between sh and bash are mystical to people and vifon'd rather keep it that way than field issue reports about bashisms not working and educate them on the matter.
Woops ^U^U^U

Basically, people expect bash so we give them bash in their personal editable copy of `scope.sh`.