### PR TITLE
added support for DJVU text conversion

### DIFF
--- a/ranger/data/scope.sh
+++ b/ranger/data/scope.sh
@@ -94,6 +94,13 @@ handle_image() {
         #     convert "${FILE_PATH}" "${IMAGE_CACHE_PATH}" && exit 6
         #     exit 1;;
 
+		# DJVU
+        image/vnd.djvu)
+            # Preview as text conversion
+            djvutxt "${FILE_PATH}" && exit 5
+            exiftool "${FILE_PATH}" && exit 5
+            exit 1;;
+
         # Image
         image/*)
             local orientation

--- a/ranger/data/scope.sh
+++ b/ranger/data/scope.sh
@@ -94,13 +94,6 @@ handle_image() {
         #     convert "${FILE_PATH}" "${IMAGE_CACHE_PATH}" && exit 6
         #     exit 1;;
 
-        # DJVU
-        image/vnd.djvu)
-            # Preview as text conversion (requires djvulibre)
-            djvutxt "${FILE_PATH}" | fmt -w ${PV_WIDTH} && exit 5
-            exiftool "${FILE_PATH}" && exit 5
-            exit 1;;
-
         # Image
         image/*)
             local orientation
@@ -190,6 +183,13 @@ handle_mime() {
                 --style="${HIGHLIGHT_STYLE}" --force -- "${FILE_PATH}" && exit 5
             # pygmentize -f "${pygmentize_format}" -O "style=${PYGMENTIZE_STYLE}" -- "${FILE_PATH}" && exit 5
             exit 2;;
+
+        # DjVu
+        image/vnd.djvu)
+            # Preview as text conversion (requires djvulibre)
+            djvutxt "${FILE_PATH}" | fmt -w ${PV_WIDTH} && exit 5
+            exiftool "${FILE_PATH}" && exit 5
+            exit 1;;
 
         # Image
         image/*)

--- a/ranger/data/scope.sh
+++ b/ranger/data/scope.sh
@@ -94,9 +94,9 @@ handle_image() {
         #     convert "${FILE_PATH}" "${IMAGE_CACHE_PATH}" && exit 6
         #     exit 1;;
 
-		# DJVU
+        # DJVU
         image/vnd.djvu)
-			# Preview as text conversion (requires djvulibre)
+            # Preview as text conversion (requires djvulibre)
             djvutxt "${FILE_PATH}" | fmt -w ${PV_WIDTH} && exit 5
             exiftool "${FILE_PATH}" && exit 5
             exit 1;;

--- a/ranger/data/scope.sh
+++ b/ranger/data/scope.sh
@@ -96,8 +96,8 @@ handle_image() {
 
 		# DJVU
         image/vnd.djvu)
-            # Preview as text conversion
-            djvutxt "${FILE_PATH}" && exit 5
+			# Preview as text conversion (requires djvulibre)
+            djvutxt "${FILE_PATH}" | fmt -w ${PV_WIDTH} && exit 5
             exiftool "${FILE_PATH}" && exit 5
             exit 1;;
 


### PR DESCRIPTION
provides the ability to preview DJVU files with text preview, just like PDF files

#### ISSUE TYPE
- Improvement/feature implementation

#### RUNTIME ENVIRONMENT
Requires `djvutxt` program provided by `djvulibre` to convert

#### CHECKLIST
- [X] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [X] All changes follow the code style **[REQUIRED]**
- [X] All new and existing tests pass **[REQUIRED]**
- [X] Changes require config files to be updated
    - [x] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
Very simple implementation on `scope.sh` that provides the ability to preview DJVU files with text preview, just like PDF files, only requires `djvutxt` to be installed on system


#### MOTIVATION AND CONTEXT
These changes help with previewing DJVU files with text conversion, so that they can be previewed just like PDF documents. This solves the problem of not having a text preview of DJVU files

#### TESTING
No tests have been run, as this doesn't affect any of the existing code base.