### PR TITLE
Restoration of scrolling in pager.

### DIFF
--- a/ranger/core/actions.py
+++ b/ranger/core/actions.py
@@ -1004,10 +1004,7 @@ class Actions(  # pylint: disable=too-many-instance-attributes,too-many-public-m
         if preview_column.target and preview_column.target.is_file:
             if narg is not None:
                 lines = narg
-            target_scroll = preview_column.scroll_extra + lines
-            max_scroll = len(preview_column.lines) - preview_column.hei
-            preview_column.scroll_extra = max(0, min(target_scroll, max_scroll))
-            preview_column.request_redraw()
+            preview_column.scrollbit(lines)
 
     # --------------------------
     # -- Previews

--- a/ranger/gui/widgets/browsercolumn.py
+++ b/ranger/gui/widgets/browsercolumn.py
@@ -96,10 +96,7 @@ class BrowserColumn(Pager):  # pylint: disable=too-many-instance-attributes
                             self.fm.thisdir.move_to_obj(clicked_file)
                             self.fm.execute_file(clicked_file)
         elif self.target.is_file:
-            target_scroll = self.scroll_extra + direction
-            max_scroll = len(self.lines) - self.hei
-            self.scroll_extra = max(0, min(target_scroll, max_scroll))
-            self.need_redraw = True
+            self.scrollbit(direction)
         else:
             if self.level > 0 and not direction:
                 self.fm.move(right=0)

--- a/ranger/gui/widgets/pager.py
+++ b/ranger/gui/widgets/pager.py
@@ -75,6 +75,12 @@ class Pager(Widget):  # pylint: disable=too-many-instance-attributes
     def finalize(self):
         self.fm.ui.win.move(self.y, self.x)
 
+    def scrollbit(self, lines):
+        target_scroll = self.scroll_extra + lines
+        max_scroll = len(self.lines) - self.hei
+        self.scroll_extra = max(0, min(target_scroll, max_scroll))
+        self.need_redraw = True
+
     def draw(self):
         if self.need_clear_image:
             self.need_redraw = True


### PR DESCRIPTION

<!-- Provide a descriptive summary of the changes in the title above -->

#### ISSUE TYPE
<!-- Pick relevant types and delete the rest -->
- Bug fix

#### RUNTIME ENVIRONMENT
<!-- Details of your runtime environment -->
<!-- Retrieve Python/ranger version and locale with `ranger -\-version` -->
- Operating system and version:  Archlinux x86_64
- Terminal emulator and version:  rxvt-unicode (urxvt) v9.22
- Python version:  3.7.0 (default, Sep 15 2018, 19:13:07) [GCC 8.2.1 20180831]
- Ranger version/commit:  ranger-master v1.9.2-39-g4d84abad
- Locale:  en_US.UTF-8

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [X] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [X] All changes follow the code style **[REQUIRED]**
- [X] All new and existing tests pass **[REQUIRED]**
- [ ] Changes require config files to be updated
    - [ ] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
<!-- Describe the changes in detail -->
Scrolling in a pager (:display_file) was restored and at the same time new ability to scroll preview column is saved.

#### MOTIVATION AND CONTEXT
<!-- Why are these changes required? -->
<!-- What problems do these changes solve? -->
<!-- Link to relevant issues -->
Fixes #1347
