### PR TITLE
Add word/character transposition at the console

### DIFF
--- a/ranger/config/rc.conf
+++ b/ranger/config/rc.conf
@@ -650,6 +650,8 @@ cmap <A-d>        eval fm.ui.console.delete_word(backward=False)
 cmap <C-k>        eval fm.ui.console.delete_rest(1)
 cmap <C-u>        eval fm.ui.console.delete_rest(-1)
 cmap <C-y>        eval fm.ui.console.paste()
+cmap <C-t>        eval fm.ui.console.transpose_chars()
+cmap <A-t>        eval fm.ui.console.transpose_words()
 
 # And of course the emacs way
 copycmap <ESC>       <C-g>

--- a/ranger/gui/widgets/console.py
+++ b/ranger/gui/widgets/console.py
@@ -437,6 +437,81 @@ class Console(Widget):  # pylint: disable=too-many-instance-attributes,too-many-
             self.line = left_part + ''.join(uchar[upos + 1:]).encode('utf-8', 'ignore')
         self.on_line_change()
 
+    def transpose_subr(self, line, x, y):
+        # Transpose substrings x & y of line
+        # x & y are tuples of length two containing positions of endpoints
+        if not (x[0] <= x[1] <= y[0] <= y[1] <= len(line) or
+                x[0] == y[0] <= x[1] == y[1] <= len(line)):
+            self.fm.notify("Tried to transpose invalid regions.", bad=True)
+            return line
+
+        word_x = line[x[0]:x[1]]
+        word_y = line[y[0]:y[1]]
+        diff = len(word_y) - len(word_x)
+
+        line_begin = line[0:x[0]]
+        line_end = line[x[1]:]
+
+        line = line_begin + word_y + line_end
+
+        line_begin = line[0:(y[0] + diff)]
+        line_end = line[(y[1] + diff):]
+
+        line = line_begin + word_x + line_end
+        return line
+
+    def transpose_chars(self):
+        if self.pos == len(self.line):
+            x = max(0, self.pos - 2), max(0, self.pos - 1)
+            y = max(0, self.pos - 1), self.pos
+        else:
+            x = max(0, self.pos - 1), self.pos
+            y = self.pos, min(len(self.line), self.pos + 1)
+        self.line = self.transpose_subr(self.line, x, y)
+        self.pos = y[1]
+        self.on_line_change()
+
+    def transpose_words(self):
+        # Interchange adjacent words at the console with Alt-t
+        # like in Emacs and many terminal emulators
+        if self.line:
+            # If before the first word, interchange next two words
+            if not re.search(r'[\w\d]', self.line[:self.pos], re.UNICODE):
+                self.pos = self.move_by_word(self.line, self.pos, 1)
+
+            # If in/after last word, interchange last two words
+            if re.match(r'[\w\d]*\s*$', self.line[self.pos:], re.UNICODE):
+                self.pos = self.move_by_word(self.line, self.pos, -1)
+
+            # Util function to increment position until out of word/whitespace
+            def _traverse(line, pos, regex):
+                while pos < len(line) and re.match(
+                        regex, line[pos], re.UNICODE):
+                    pos += 1
+                return pos
+
+            # Calculate endpoints of target words and pass them to
+            # 'self.transpose_subr'
+            x_begin = self.move_by_word(self.line, self.pos, -1)
+            x_end = _traverse(self.line, x_begin, r'[\w\d]')
+            x = x_begin, x_end
+
+            y_begin = self.pos
+
+            # If in middle of word, move to end
+            if re.match(r'[\w\d]', self.line[self.pos - 1], re.UNICODE):
+                y_begin = _traverse(self.line, y_begin, r'[\w\d]')
+
+            # Traverse whitespace to beginning of next word
+            y_begin = _traverse(self.line, y_begin, r'\s')
+
+            y_end = _traverse(self.line, y_begin, r'[\w\d]')
+            y = y_begin, y_end
+
+            self.line = self.transpose_subr(self.line, x, y)
+            self.pos = y[1]
+            self.on_line_change()
+
     def execute(self, cmd=None):
         if self.question_queue and cmd is None:
             question = self.question_queue[0]

--- a/ranger/gui/widgets/console.py
+++ b/ranger/gui/widgets/console.py
@@ -440,8 +440,8 @@ class Console(Widget):  # pylint: disable=too-many-instance-attributes,too-many-
     def transpose_subr(self, line, x, y):
         # Transpose substrings x & y of line
         # x & y are tuples of length two containing positions of endpoints
-        if not (x[0] <= x[1] <= y[0] <= y[1] <= len(line) or
-                x[0] == y[0] <= x[1] == y[1] <= len(line)):
+        if not (x[0] <= x[1] <= y[0] <= y[1] <= len(line)
+                or x[0] == y[0] <= x[1] == y[1] <= len(line)):
             self.fm.notify("Tried to transpose invalid regions.", bad=True)
             return line
 


### PR DESCRIPTION
<!-- Provide a descriptive summary of the changes in the title above -->

#### ISSUE TYPE
<!-- Pick relevant types and delete the rest -->
Feature implementation

#### RUNTIME ENVIRONMENT
<!-- Details of your runtime environment -->
<!-- Retrieve Python/ranger version and locale with `ranger -\-version` -->
- Operating system and version: Ubuntu 18.04
- Terminal emulator and version: urxvt 9.22
- Python version: 2.7
- Ranger version/commit: 1.9.2
- Locale: en_US.UTF-8

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [X] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [X] All changes follow the code style **[REQUIRED]**
- [X] All new and existing tests pass **[REQUIRED]**
- [X] Changes require config files to be updated
    - [X] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
<!-- Describe the changes in detail -->
Added functions to transpose characters and words at the console. This is a line-editing feature in Emacs and many terminal emulators. By default, `alt-t` interchanges the words around the cursor and `ctrl-t` interchanges the characters around the cursor. 

#### MOTIVATION AND CONTEXT
<!-- Why are these changes required? -->
<!-- What problems do these changes solve? -->
<!-- Link to relevant issues -->
https://github.com/ranger/ranger/issues/1344 

#### TESTING
<!-- What tests have been run? -->
<!-- How does the changes affect other areas of the codebase? -->
Ran `make test` with no errors. Shouldn't affect other areas of the codebase.

#### IMAGES / VIDEOS<!-- Only if relevant -->
<!-- Link or embed images and videos of screenshots, sketches etc. -->
