### PR TITLE
Added check if bookmark file is a symlink.

### DIFF
--- a/ranger/container/bookmarks.py
+++ b/ranger/container/bookmarks.py
@@ -185,7 +185,13 @@ class Bookmarks(FileManagerAware):
             old_perms = os.stat(self.path)
             os.chown(path_new, old_perms.st_uid, old_perms.st_gid)
             os.chmod(path_new, old_perms.st_mode)
-            os.rename(path_new, self.path)
+
+            if os.path.islink(self.path):
+                link_path = os.path.realpath(self.path)
+                os.rename(path_new, link_path)
+            else:
+                os.rename(path_new, self.path)
+
         except OSError as ex:
             self.fm.notify('Bookmarks error: {0}'.format(str(ex)), bad=True)
             return

--- a/ranger/container/bookmarks.py
+++ b/ranger/container/bookmarks.py
@@ -187,8 +187,8 @@ class Bookmarks(FileManagerAware):
             os.chmod(path_new, old_perms.st_mode)
 
             if os.path.islink(self.path):
-                link_path = os.path.realpath(self.path)
-                os.rename(path_new, link_path)
+                target_path = os.path.realpath(self.path)
+                os.rename(path_new, target_path)
             else:
                 os.rename(path_new, self.path)
 

--- a/tests/ranger/container/test_bookmarks.py
+++ b/tests/ranger/container/test_bookmarks.py
@@ -64,12 +64,12 @@ def test_bookmark_symlink(tmpdir):
     bookmarkfile_orig = tmpdir.join("bookmarkfile.org")
 
     # Create symlink pointing towards the original plain file.
-    os.symlink(bookmarkfile_orig, bookmarkfile_link)
+    os.symlink(str(bookmarkfile_orig), str(bookmarkfile_link))
 
     # Initialize the bookmark file and save the file.
     bmstore = Bookmarks(str(bookmarkfile_link))
     bmstore.save()
 
     # Once saved, the bookmark file should still be a symlink pointing towards the plain file.
-    assert os.path.islink(bookmarkfile_link)
-    assert not os.path.islink(bookmarkfile_orig)
+    assert os.path.islink(str(bookmarkfile_link))
+    assert not os.path.islink(str(bookmarkfile_orig))

--- a/tests/ranger/container/test_bookmarks.py
+++ b/tests/ranger/container/test_bookmarks.py
@@ -61,7 +61,7 @@ def testbookmarks(tmpdir):
 def test_bookmark_symlink(tmpdir):
     # Initialize plain file and symlink paths
     bookmarkfile_link = tmpdir.join("bookmarkfile")
-    bookmarkfile_orig = tmpdir.join("bookmarkfile.org")
+    bookmarkfile_orig = tmpdir.join("bookmarkfile.orig")
 
     # Create symlink pointing towards the original plain file.
     os.symlink(str(bookmarkfile_orig), str(bookmarkfile_link))

--- a/tests/ranger/container/test_bookmarks.py
+++ b/tests/ranger/container/test_bookmarks.py
@@ -56,3 +56,20 @@ def testbookmarks(tmpdir):
         secondstore.update_if_outdated()
     secondstore.update = origupdate
     secondstore.update_if_outdated()
+
+
+def test_bookmark_symlink(tmpdir):
+    # Initialize plain file and symlink paths
+    bookmarkfile_link = tmpdir.join("bookmarkfile")
+    bookmarkfile_orig = tmpdir.join("bookmarkfile.org")
+
+    # Create symlink pointing towards the original plain file.
+    os.symlink(bookmarkfile_orig, bookmarkfile_link)
+
+    # Initialize the bookmark file and save the file.
+    bmstore = Bookmarks(str(bookmarkfile_link))
+    bmstore.save()
+
+    # Once saved, the bookmark file should still be a symlink pointing towards the plain file.
+    assert os.path.islink(bookmarkfile_link)
+    assert not os.path.islink(bookmarkfile_orig)


### PR DESCRIPTION
If it is, the os.rename is performed on the original file path instead of overwriting the symlink.


#### ISSUE TYPE
- Improvement/feature implementation


#### RUNTIME ENVIRONMENT
- Operating system and version: Linux workstation 4.19.8-arch1-1-ARCH #1 SMP PREEMPT Sat Dec 8 13:49:11 UTC 2018 x86_64 GNU/Linux
- Terminal emulator and version: rxvt-unicode (urxvt) v9.22 - released: 2016-01-23
- Python version: Python version: 3.7.1 (default, Oct 22 2018, 10:41:28) [GCC 8.2.1 20180831]
- Ranger version/commit: ranger 1.9.2
- Locale: en_GB.UTF-8


#### CHECKLIST
- [X] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [X] All changes follow the code style **[REQUIRED]**
- [X] All new and existing tests pass **[REQUIRED]**
- [ ] Changes require config files to be updated
    - [ ] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [X] Changes require tests to be updated
    - [X] Tests have been updated


#### DESCRIPTION
When the bookmarks file is a symlink, it is overwritten on every save with a new file.
This pull requests implements a check to see if this is true, and performs the save at the link original location.
If the file is a plain file, the original behaviour remains.


#### MOTIVATION AND CONTEXT
I like having the bookmarks synced between my main computer and my laptop, where the bookmark file is located on a shared drive accessible by both.
This pull requests makes this possible.


#### TESTING
I've added a test for this implementation which runs successfully.
This change should not affect any other areas of the codebase.