### PR TITLE
Add human readable date linemodes

### DIFF
--- a/doc/ranger.1
+++ b/doc/ranger.1
@@ -133,7 +133,7 @@
 .\" ========================================================================
 .\"
 .IX Title "RANGER 1"
-.TH RANGER 1 "ranger-1.9.2" "2018-10-26" "ranger manual"
+.TH RANGER 1 "ranger-1.9.2" "2019-04-23" "ranger manual"
 .\" For nroff, turn off justification.  Always turn off hyphenation; it makes
 .\" way too many mistakes in technical documents.
 .if n .ad l
@@ -1296,10 +1296,16 @@ Flags:
 .IX Item "linemode linemodename"
 Sets the linemode of all files in the current directory.  The linemode may be:
 .Sp
-.Vb 6
+.Vb 12
 \& "filename": display each line as "<basename>...<size>"
 \& "fileinfo": display each line as "<basename>...<file(1) output>"
+\& "mtime": display each line as "<basename>...<mtime>" in ISO format
+\& "humanreadablemtime": display each line as "<basename>...<mtime>" in a human
+\&     readable format, more precise the more recent
 \& "permissions": display each line as "<permissions> <owner> <group> <basename>"
+\& "sizemtime": display each line as "<basename>...<size> <mtime>" in ISO format
+\& "humanreadablesizemtime": display each line as "<basename>...<size> <mtime>"
+\&     in a human readable format, more precise the more recent
 \& "metatitle": display metadata from .metadata.json files if
 \&     available, fall back to the "filename" linemode if no
 \&     metadata was found.  See :meta command.

--- a/doc/ranger.pod
+++ b/doc/ranger.pod
@@ -1382,7 +1382,13 @@ Sets the linemode of all files in the current directory.  The linemode may be:
 
  "filename": display each line as "<basename>...<size>"
  "fileinfo": display each line as "<basename>...<file(1) output>"
+ "mtime": display each line as "<basename>...<mtime>" in ISO format
+ "humanreadablemtime": display each line as "<basename>...<mtime>" in a human
+     readable format, more precise the more recent
  "permissions": display each line as "<permissions> <owner> <group> <basename>"
+ "sizemtime": display each line as "<basename>...<size> <mtime>" in ISO format
+ "humanreadablesizemtime": display each line as "<basename>...<size> <mtime>"
+     in a human readable format, more precise the more recent
  "metatitle": display metadata from .metadata.json files if
      available, fall back to the "filename" linemode if no
      metadata was found.  See :meta command.

--- a/ranger/config/rc.conf
+++ b/ranger/config/rc.conf
@@ -371,8 +371,10 @@ map <C-p> chain console; eval fm.ui.console.history_move(-1)
 map Mf linemode filename
 map Mi linemode fileinfo
 map Mm linemode mtime
+map Mh linemode humanmtime
 map Mp linemode permissions
 map Ms linemode sizemtime
+map Mg linemode sizehumanmtime
 map Mt linemode metatitle
 
 # Tagging / Marking

--- a/ranger/config/rc.conf
+++ b/ranger/config/rc.conf
@@ -371,10 +371,10 @@ map <C-p> chain console; eval fm.ui.console.history_move(-1)
 map Mf linemode filename
 map Mi linemode fileinfo
 map Mm linemode mtime
-map Mh linemode humanmtime
+map Mh linemode humanreadablemtime
 map Mp linemode permissions
 map Ms linemode sizemtime
-map Mg linemode sizehumanmtime
+map MH linemode sizehumanreadablemtime
 map Mt linemode metatitle
 
 # Tagging / Marking

--- a/ranger/container/fsobject.py
+++ b/ranger/container/fsobject.py
@@ -13,6 +13,7 @@ from time import time
 from ranger.core.linemode import (
     DEFAULT_LINEMODE, DefaultLinemode, TitleLinemode,
     PermissionsLinemode, FileInfoLinemode, MtimeLinemode, SizeMtimeLinemode,
+    HumanMtimeLinemode, SizeHumanMtimeLinemode
 )
 from ranger.core.shared import FileManagerAware, SettingsAware
 from ranger.ext.shell_escape import shell_escape
@@ -91,7 +92,8 @@ class FileSystemObject(  # pylint: disable=too-many-instance-attributes,too-many
     linemode_dict = dict(
         (linemode.name, linemode()) for linemode in
         [DefaultLinemode, TitleLinemode, PermissionsLinemode, FileInfoLinemode,
-         MtimeLinemode, SizeMtimeLinemode]
+         MtimeLinemode, SizeMtimeLinemode, HumanMtimeLinemode,
+         SizeHumanMtimeLinemode]
     )
 
     def __init__(self, path, preload=None, path_is_abs=False, basename_is_rel_to=None):

--- a/ranger/container/fsobject.py
+++ b/ranger/container/fsobject.py
@@ -13,7 +13,7 @@ from time import time
 from ranger.core.linemode import (
     DEFAULT_LINEMODE, DefaultLinemode, TitleLinemode,
     PermissionsLinemode, FileInfoLinemode, MtimeLinemode, SizeMtimeLinemode,
-    HumanMtimeLinemode, SizeHumanMtimeLinemode
+    HumanReadableMtimeLinemode, SizeHumanReadableMtimeLinemode
 )
 from ranger.core.shared import FileManagerAware, SettingsAware
 from ranger.ext.shell_escape import shell_escape
@@ -92,8 +92,8 @@ class FileSystemObject(  # pylint: disable=too-many-instance-attributes,too-many
     linemode_dict = dict(
         (linemode.name, linemode()) for linemode in
         [DefaultLinemode, TitleLinemode, PermissionsLinemode, FileInfoLinemode,
-         MtimeLinemode, SizeMtimeLinemode, HumanMtimeLinemode,
-         SizeHumanMtimeLinemode]
+         MtimeLinemode, SizeMtimeLinemode, HumanReadableMtimeLinemode,
+         SizeHumanReadableMtimeLinemode]
     )
 
     def __init__(self, path, preload=None, path_is_abs=False, basename_is_rel_to=None):

--- a/ranger/core/linemode.py
+++ b/ranger/core/linemode.py
@@ -146,12 +146,11 @@ class HumanMtimeLinemode(LinemodeBase):
         time_diff = datetime.now().date() - file_date.date()
         if time_diff.days > 364:
             return file_date.strftime("%-d %b %Y")
-        elif time_diff.days > 6:
+        if time_diff.days > 6:
             return file_date.strftime("%-d %b")
-        elif time_diff.days >= 1:
+        if time_diff.days >= 1:
             return file_date.strftime("%a")
-        else:
-            return file_date.strftime("%H:%M")
+        return file_date.strftime("%H:%M")
 
 
 class SizeHumanMtimeLinemode(LinemodeBase):
@@ -170,7 +169,6 @@ class SizeHumanMtimeLinemode(LinemodeBase):
             return "%s %11s" % (size, file_date.strftime("%-d %b %Y"))
         if time_diff.days > 6:
             return "%s %11s" % (size, file_date.strftime("%-d %b"))
-        elif time_diff.days >= 1:
+        if time_diff.days >= 1:
             return "%s %11s" % (size, file_date.strftime("%a"))
-        else:
-            return "%s %11s" % (size, file_date.strftime("%H:%M"))
+        return "%s %11s" % (size, file_date.strftime("%H:%M"))

--- a/ranger/core/linemode.py
+++ b/ranger/core/linemode.py
@@ -142,7 +142,7 @@ class HumanMtimeLinemode(LinemodeBase):
     def infostring(self, fobj, metadata):
         if fobj.stat is None:
             return '?'
-        return print_human_mtime(fobj.stat.st_mtime)
+        return _human_readable_mtime(fobj.stat.st_mtime)
 
 
 class SizeHumanMtimeLinemode(LinemodeBase):
@@ -155,10 +155,10 @@ class SizeHumanMtimeLinemode(LinemodeBase):
         if fobj.stat is None:
             return '?'
         size = human_readable(fobj.size)
-        return "%s %11s" % (size, print_human_mtime(fobj.stat.st_mtime))
+        return "%s %11s" % (size, _human_readable_mtime(fobj.stat.st_mtime))
 
 
-def print_human_mtime(file_mtime):
+def _human_readable_mtime(file_mtime):
     file_date = datetime.fromtimestamp(file_mtime)
     time_diff = datetime.now().date() - file_date.date()
     if time_diff.days >= 365:

--- a/ranger/core/linemode.py
+++ b/ranger/core/linemode.py
@@ -7,7 +7,7 @@ from __future__ import (absolute_import, division, print_function)
 
 from abc import ABCMeta, abstractproperty, abstractmethod
 from datetime import datetime
-from ranger.ext.human_readable import human_readable
+from ranger.ext.human_readable import human_readable, human_readable_time
 from ranger.ext import spawn
 
 DEFAULT_LINEMODE = "filename"
@@ -133,8 +133,8 @@ class SizeMtimeLinemode(LinemodeBase):
                           datetime.fromtimestamp(fobj.stat.st_mtime).strftime("%Y-%m-%d %H:%M"))
 
 
-class HumanMtimeLinemode(LinemodeBase):
-    name = "humanmtime"
+class HumanReadableMtimeLinemode(LinemodeBase):
+    name = "humanreadablemtime"
 
     def filetitle(self, fobj, metadata):
         return fobj.relative_path
@@ -142,11 +142,11 @@ class HumanMtimeLinemode(LinemodeBase):
     def infostring(self, fobj, metadata):
         if fobj.stat is None:
             return '?'
-        return _human_readable_mtime(fobj.stat.st_mtime)
+        return human_readable_time(fobj.stat.st_mtime)
 
 
-class SizeHumanMtimeLinemode(LinemodeBase):
-    name = "sizehumanmtime"
+class SizeHumanReadableMtimeLinemode(LinemodeBase):
+    name = "sizehumanreadablemtime"
 
     def filetitle(self, fobj, metadata):
         return fobj.relative_path
@@ -155,16 +155,4 @@ class SizeHumanMtimeLinemode(LinemodeBase):
         if fobj.stat is None:
             return '?'
         size = human_readable(fobj.size)
-        return "%s %11s" % (size, _human_readable_mtime(fobj.stat.st_mtime))
-
-
-def _human_readable_mtime(file_mtime):
-    file_date = datetime.fromtimestamp(file_mtime)
-    time_diff = datetime.now().date() - file_date.date()
-    if time_diff.days >= 365:
-        return file_date.strftime("%-d %b %Y")
-    if time_diff.days >= 7:
-        return file_date.strftime("%-d %b")
-    if time_diff.days >= 1:
-        return file_date.strftime("%a")
-    return file_date.strftime("%H:%M")
+        return "%s %11s" % (size, human_readable_time(fobj.stat.st_mtime))

--- a/ranger/core/linemode.py
+++ b/ranger/core/linemode.py
@@ -131,3 +131,46 @@ class SizeMtimeLinemode(LinemodeBase):
             return '?'
         return "%s %s" % (human_readable(fobj.size),
                           datetime.fromtimestamp(fobj.stat.st_mtime).strftime("%Y-%m-%d %H:%M"))
+
+
+class HumanMtimeLinemode(LinemodeBase):
+    name = "humanmtime"
+
+    def filetitle(self, fobj, metadata):
+        return fobj.relative_path
+
+    def infostring(self, fobj, metadata):
+        if fobj.stat is None:
+            return '?'
+        file_date = datetime.fromtimestamp(fobj.stat.st_mtime)
+        time_diff = datetime.now().date() - file_date.date()
+        if time_diff.days > 364:
+            return file_date.strftime("%-d %b %Y")
+        elif time_diff.days > 6:
+            return file_date.strftime("%-d %b")
+        elif time_diff.days >= 1:
+            return file_date.strftime("%a")
+        else:
+            return file_date.strftime("%H:%M")
+
+
+class SizeHumanMtimeLinemode(LinemodeBase):
+    name = "sizehumanmtime"
+
+    def filetitle(self, fobj, metadata):
+        return fobj.relative_path
+
+    def infostring(self, fobj, metadata):
+        if fobj.stat is None:
+            return '?'
+        size = human_readable(fobj.size)
+        file_date = datetime.fromtimestamp(fobj.stat.st_mtime)
+        time_diff = datetime.now().date() - file_date.date()
+        if time_diff.days > 364:
+            return "%s %11s" % (size, file_date.strftime("%-d %b %Y"))
+        if time_diff.days > 6:
+            return "%s %11s" % (size, file_date.strftime("%-d %b"))
+        elif time_diff.days >= 1:
+            return "%s %11s" % (size, file_date.strftime("%a"))
+        else:
+            return "%s %11s" % (size, file_date.strftime("%H:%M"))

--- a/ranger/core/linemode.py
+++ b/ranger/core/linemode.py
@@ -144,9 +144,9 @@ class HumanMtimeLinemode(LinemodeBase):
             return '?'
         file_date = datetime.fromtimestamp(fobj.stat.st_mtime)
         time_diff = datetime.now().date() - file_date.date()
-        if time_diff.days > 364:
+        if time_diff.days >= 365:
             return file_date.strftime("%-d %b %Y")
-        if time_diff.days > 6:
+        if time_diff.days >= 7:
             return file_date.strftime("%-d %b")
         if time_diff.days >= 1:
             return file_date.strftime("%a")
@@ -165,9 +165,9 @@ class SizeHumanMtimeLinemode(LinemodeBase):
         size = human_readable(fobj.size)
         file_date = datetime.fromtimestamp(fobj.stat.st_mtime)
         time_diff = datetime.now().date() - file_date.date()
-        if time_diff.days > 364:
+        if time_diff.days >= 365:
             return "%s %11s" % (size, file_date.strftime("%-d %b %Y"))
-        if time_diff.days > 6:
+        if time_diff.days >= 7:
             return "%s %11s" % (size, file_date.strftime("%-d %b"))
         if time_diff.days >= 1:
             return "%s %11s" % (size, file_date.strftime("%a"))

--- a/ranger/core/linemode.py
+++ b/ranger/core/linemode.py
@@ -142,15 +142,7 @@ class HumanMtimeLinemode(LinemodeBase):
     def infostring(self, fobj, metadata):
         if fobj.stat is None:
             return '?'
-        file_date = datetime.fromtimestamp(fobj.stat.st_mtime)
-        time_diff = datetime.now().date() - file_date.date()
-        if time_diff.days >= 365:
-            return file_date.strftime("%-d %b %Y")
-        if time_diff.days >= 7:
-            return file_date.strftime("%-d %b")
-        if time_diff.days >= 1:
-            return file_date.strftime("%a")
-        return file_date.strftime("%H:%M")
+        return print_human_mtime(fobj.stat.st_mtime)
 
 
 class SizeHumanMtimeLinemode(LinemodeBase):
@@ -163,12 +155,16 @@ class SizeHumanMtimeLinemode(LinemodeBase):
         if fobj.stat is None:
             return '?'
         size = human_readable(fobj.size)
-        file_date = datetime.fromtimestamp(fobj.stat.st_mtime)
-        time_diff = datetime.now().date() - file_date.date()
-        if time_diff.days >= 365:
-            return "%s %11s" % (size, file_date.strftime("%-d %b %Y"))
-        if time_diff.days >= 7:
-            return "%s %11s" % (size, file_date.strftime("%-d %b"))
-        if time_diff.days >= 1:
-            return "%s %11s" % (size, file_date.strftime("%a"))
-        return "%s %11s" % (size, file_date.strftime("%H:%M"))
+        return "%s %11s" % (size, print_human_mtime(fobj.stat.st_mtime))
+
+
+def print_human_mtime(file_mtime):
+    file_date = datetime.fromtimestamp(file_mtime)
+    time_diff = datetime.now().date() - file_date.date()
+    if time_diff.days >= 365:
+        return file_date.strftime("%-d %b %Y")
+    if time_diff.days >= 7:
+        return file_date.strftime("%-d %b")
+    if time_diff.days >= 1:
+        return file_date.strftime("%a")
+    return file_date.strftime("%H:%M")

--- a/ranger/ext/human_readable.py
+++ b/ranger/ext/human_readable.py
@@ -3,6 +3,7 @@
 
 from __future__ import (absolute_import, division, print_function)
 
+from datetime import datetime
 from ranger.core.shared import SettingsAware
 
 
@@ -52,6 +53,21 @@ def human_readable(byte, separator=' '):  # pylint: disable=too-many-return-stat
     if byte < 2**60:
         return '%.4g%sP' % ((byte / 2**50), separator)
     return '>9000'
+
+
+def human_readable_time(timestamp):
+    """Convert a timestamp to an easily readable format.
+    """
+    # Hard to test because it's relative to ``now()``
+    date = datetime.fromtimestamp(timestamp)
+    datediff = datetime.now().date() - date.date()
+    if datediff.days >= 365:
+        return date.strftime("%-d %b %Y")
+    elif datediff.days >= 7:
+        return date.strftime("%-d %b")
+    elif datediff.days >= 1:
+        return date.strftime("%a")
+    return date.strftime("%H:%M")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
@Vifon @toonn As per our discussion in #1364. I did not include the leap year section.

#### ISSUE TYPE
- Improvement/feature implementation

#### RUNTIME ENVIRONMENT
- Operating system and version: 4.19.4-arch1-1-ARCH  (Antergos)
- Terminal emulator and version: kitty 0.13.1 with tmux 2.8
- Python version: Python version: 3.7.1 (default, Oct 22 2018, 10:41:28) [GCC 8.2.1 20180831]                              
- Ranger version/commit: ranger version: ranger-master v1.9.2-78-g9cc6c451             
- Locale:  en_US.UTF-8  

#### CHECKLIST
- [x] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [x] All changes follow the code style **[REQUIRED]**
- [x] All new and existing tests pass **[REQUIRED]**
- [ ] Changes require config files to be updated
    - [ ] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
See #1364 for details. 

#### MOTIVATION AND CONTEXT
Easier to read dates. 

#### TESTING
`make test_pytest` PASS
`make test_pyflake8` PASS
<details><summary><code>make test_pylint</code> FAIL (seems unrelated)</summary>
<pre>
Running pylint...
pylint ./ranger/container ./ranger/api ./ranger/core ./ranger/gui ./ranger/colorschemes ./ranger/ext ./ranger/__init__.py ./doc/tools/print_colors.py ./doc/tools/convert_papermode_to_metadata.py ./doc/tools/print_keys.py ./doc/tools/performance_test.py ./examples/plugin_chmod_keybindings.py ./examples/plugin_linemode.py ./examples/plugin_pmount.py ./examples/plugin_new_macro.py ./examples/plugin_hello_world.py ./examples/plugin_avfs.py ./examples/plugin_new_sorting_method.py ./examples/plugin_ipc.py ./examples/plugin_file_filter.py ./examples/plugin_pmount_dynamic.py ./examples/plugin_fasd_add.py ./ranger.py ./setup.py ./tests
************* Module ranger.container.directory
ranger/container/directory.py:77:18: R1719: The if expression can be replaced with 'test' (simplifiable-if-expression)
ranger/container/directory.py:96:0: R0205: Class 'InodeFilterConstants' inherits from object, can be safely removed from bases in python3 (useless-object-inheritance)
ranger/container/directory.py:248:8: R1705: Unnecessary "elif" after "return" (no-else-return)
ranger/container/directory.py:285:16: R1705: Unnecessary "elif" after "return" (no-else-return)
ranger/container/directory.py:520:16: W0143: Comparing against a callable, did you omit the parenthesis? (comparison-with-callable)
ranger/container/directory.py:524:16: W0143: Comparing against a callable, did you omit the parenthesis? (comparison-with-callable)
************* Module ranger.container.settings
ranger/container/settings.py:304:0: R0205: Class 'LocalSettings' inherits from object, can be safely removed from bases in python3 (useless-object-inheritance)
************* Module ranger.container.fsobject
ranger/container/fsobject.py:297:26: R1719: The if expression can be replaced with 'bool(test)' (simplifiable-if-expression)
ranger/container/fsobject.py:310:26: R1719: The if expression can be replaced with 'bool(test)' (simplifiable-if-expression)
ranger/container/fsobject.py:314:11: R1714: Consider merging these comparisons with "in" to 'fmt in (8192, 24576)' (consider-using-in)
************* Module ranger.container.bookmarks
ranger/container/bookmarks.py:90:8: R1705: Unnecessary "else" after "return" (no-else-return)
************* Module ranger.container.tags
ranger/container/tags.py:15:0: R0205: Class 'Tags' inherits from object, can be safely removed from bases in python3 (useless-object-inheritance)
ranger/container/tags.py:31:8: R1715: Consider using dict.get for getting values from a dict if a key is present or a default if not (consider-using-get)
ranger/container/tags.py:50:8: R1715: Consider using dict.get for getting values from a dict if a key is present or a default if not (consider-using-get)
************* Module ranger.container.history
ranger/container/history.py:13:0: R0205: Class 'History' inherits from object, can be safely removed from bases in python3 (useless-object-inheritance)
ranger/container/history.py:93:8: R1705: Unnecessary "else" after "return" (no-else-return)
************* Module ranger.api.commands
ranger/api/commands.py:32:12: R1705: Unnecessary "elif" after "return" (no-else-return)
ranger/api/commands.py:431:16: R1705: Unnecessary "else" after "return" (no-else-return)
************* Module ranger.core.metadata
ranger/core/metadata.py:25:0: R0205: Class 'MetadataManager' inherits from object, can be safely removed from bases in python3 (useless-object-inheritance)
************* Module ranger.core.actions
ranger/core/actions.py:117:12: R1705: Unnecessary "elif" after "return" (no-else-return)
ranger/core/actions.py:1137:16: R1705: Unnecessary "elif" after "return" (no-else-return)
ranger/core/actions.py:1027:4: R0915: Too many statements (77/50) (too-many-statements)
ranger/core/actions.py:1279:4: R1711: Useless return at end of function or method (useless-return)
ranger/core/actions.py:1373:8: R0205: Class 'NaturalOrder' inherits from object, can be safely removed from bases in python3 (useless-object-inheritance)
************* Module ranger.core.fm
ranger/core/fm.py:85:4: R0915: Too many statements (64/50) (too-many-statements)
ranger/core/fm.py:231:8: R1705: Unnecessary "elif" after "return" (no-else-return)
ranger/core/fm.py:296:11: R1714: Consider merging these comparisons with "in" to "which in ('rifle', 'all')" (consider-using-in)
ranger/core/fm.py:298:11: R1714: Consider merging these comparisons with "in" to "which in ('commands', 'all')" (consider-using-in)
ranger/core/fm.py:300:11: R1714: Consider merging these comparisons with "in" to "which in ('commands_full', 'all')" (consider-using-in)
ranger/core/fm.py:302:11: R1714: Consider merging these comparisons with "in" to "which in ('rc', 'all')" (consider-using-in)
ranger/core/fm.py:304:11: R1714: Consider merging these comparisons with "in" to "which in ('scope', 'all')" (consider-using-in)
************* Module ranger.core.runner
ranger/core/runner.py:54:0: R0205: Class 'Context' inherits from object, can be safely removed from bases in python3 (useless-object-inheritance)
ranger/core/runner.py:104:0: R0205: Class 'Runner' inherits from object, can be safely removed from bases in python3 (useless-object-inheritance)
************* Module ranger.core.main
ranger/core/main.py:374:25: E1120: No value for argument 'fullname' in method call (no-value-for-parameter)
************* Module ranger.core.tab
ranger/core/tab.py:81:12: R1705: Unnecessary "elif" after "return" (no-else-return)
************* Module ranger.core.loader
ranger/core/loader.py:26:0: R0205: Class 'Loadable' inherits from object, can be safely removed from bases in python3 (useless-object-inheritance)
************* Module ranger.core.linemode
ranger/core/linemode.py:16:0: R0205: Class 'LinemodeBase' inherits from object, can be safely removed from bases in python3 (useless-object-inheritance)
ranger/core/linemode.py:100:8: R1705: Unnecessary "else" after "return" (no-else-return)
ranger/core/linemode.py:147:8: R1705: Unnecessary "elif" after "return" (no-else-return)
ranger/core/linemode.py:169:8: R1705: Unnecessary "elif" after "return" (no-else-return)
************* Module ranger.core.shared
ranger/core/shared.py:9:0: R0205: Class 'FileManagerAware' inherits from object, can be safely removed from bases in python3 (useless-object-inheritance)
ranger/core/shared.py:16:0: R0205: Class 'SettingsAware' inherits from object, can be safely removed from bases in python3 (useless-object-inheritance)
************* Module ranger.core.filter_stack
ranger/core/filter_stack.py:16:0: R0205: Class 'BaseFilter' inherits from object, can be safely removed from bases in python3 (useless-object-inheritance)
************* Module ranger.gui.colorscheme
ranger/gui/colorscheme.py:44:0: R0205: Class 'ColorScheme' inherits from object, can be safely removed from bases in python3 (useless-object-inheritance)
************* Module ranger.gui.displayable
ranger/gui/displayable.py:113:16: R1716: Simplify chained comparison between the operands (chained-comparison)
ranger/gui/displayable.py:114:13: R1716: Simplify chained comparison between the operands (chained-comparison)
ranger/gui/displayable.py:121:8: W0107: Unnecessary pass statement (unnecessary-pass)
ranger/gui/displayable.py:128:8: W0107: Unnecessary pass statement (unnecessary-pass)
ranger/gui/displayable.py:144:8: W0107: Unnecessary pass statement (unnecessary-pass)
************* Module ranger.gui.bar
ranger/gui/bar.py:14:0: R0205: Class 'Bar' inherits from object, can be safely removed from bases in python3 (useless-object-inheritance)
ranger/gui/bar.py:121:0: R0205: Class 'ColoredString' inherits from object, can be safely removed from bases in python3 (useless-object-inheritance)
************* Module ranger.gui.context
ranger/gui/context.py:31:0: R0205: Class 'Context' inherits from object, can be safely removed from bases in python3 (useless-object-inheritance)
************* Module ranger.gui.ansi
ranger/gui/ansi.py:83:21: R1716: Simplify chained comparison between the operands (chained-comparison)
ranger/gui/ansi.py:87:21: R1716: Simplify chained comparison between the operands (chained-comparison)
ranger/gui/ansi.py:93:21: R1716: Simplify chained comparison between the operands (chained-comparison)
ranger/gui/ansi.py:97:21: R1716: Simplify chained comparison between the operands (chained-comparison)
ranger/gui/ansi.py:162:13: R1716: Simplify chained comparison between the operands (chained-comparison)
************* Module ranger.gui.ui
ranger/gui/ui.py:243:25: R1716: Simplify chained comparison between the operands (chained-comparison)
ranger/gui/ui.py:514:8: R1705: Unnecessary "elif" after "return" (no-else-return)
************* Module ranger.gui.mouse_event
ranger/gui/mouse_event.py:9:0: R0205: Class 'MouseEvent' inherits from object, can be safely removed from bases in python3 (useless-object-inheritance)
ranger/gui/mouse_event.py:45:8: R1705: Unnecessary "elif" after "return" (no-else-return)
************* Module ranger.gui.widgets.browsercolumn
ranger/gui/widgets/browsercolumn.py:539:11: R1716: Simplify chained comparison between the operands (chained-comparison)
Traceback (most recent call last):
  File "/usr/lib/python3.7/site-packages/astroid/inference.py", line 382, in infer_subscript
    assigned = value.getitem(index_value, context)
  File "/usr/lib/python3.7/site-packages/astroid/node_classes.py", line 2469, in getitem
    index_value = _infer_slice(index, context=context)
  File "/usr/lib/python3.7/site-packages/astroid/node_classes.py", line 187, in _infer_slice
    upper = _slice_value(node.upper, context)
  File "/usr/lib/python3.7/site-packages/astroid/node_classes.py", line 171, in _slice_value
    inferred = next(index.infer(context=context))
StopIteration

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/usr/bin/pylint", line 11, in <module>
    load_entry_point('pylint==2.2.2', 'console_scripts', 'pylint')()
  File "/usr/lib/python3.7/site-packages/pylint/__init__.py", line 20, in run_pylint
    Run(sys.argv[1:])
  File "/usr/lib/python3.7/site-packages/pylint/lint.py", line 1608, in __init__
    linter.check(args)
  File "/usr/lib/python3.7/site-packages/pylint/lint.py", line 938, in check
    self._do_check(files_or_modules)
  File "/usr/lib/python3.7/site-packages/pylint/lint.py", line 1071, in _do_check
    self.check_astroid_module(ast_node, walker, rawcheckers, tokencheckers)
  File "/usr/lib/python3.7/site-packages/pylint/lint.py", line 1154, in check_astroid_module
    walker.walk(ast_node)
  File "/usr/lib/python3.7/site-packages/pylint/utils.py", line 1269, in walk
    self.walk(child)
  File "/usr/lib/python3.7/site-packages/pylint/utils.py", line 1269, in walk
    self.walk(child)
  File "/usr/lib/python3.7/site-packages/pylint/utils.py", line 1269, in walk
    self.walk(child)
  [Previous line repeated 5 more times]
  File "/usr/lib/python3.7/site-packages/pylint/utils.py", line 1266, in walk
    cb(astroid)
  File "/usr/lib/python3.7/site-packages/pylint/checkers/logging.py", line 215, in visit_call
    result, name = is_logger_class()
  File "/usr/lib/python3.7/site-packages/pylint/checkers/logging.py", line 197, in is_logger_class
    for inferred in node.func.infer():
  File "/usr/lib/python3.7/site-packages/astroid/decorators.py", line 95, in wrapped
    res = next(generator)
  File "/usr/lib/python3.7/site-packages/astroid/decorators.py", line 128, in raise_if_nothing_inferred
    yield next(generator)
  File "/usr/lib/python3.7/site-packages/astroid/inference.py", line 290, in infer_attribute
    for owner in self.expr.infer(context):
  File "/usr/lib/python3.7/site-packages/astroid/util.py", line 160, in limit_inference
    yield from islice(iterator, size)
  File "/usr/lib/python3.7/site-packages/astroid/context.py", line 113, in cache_generator
    for result in generator:
  File "/usr/lib/python3.7/site-packages/astroid/decorators.py", line 95, in wrapped
    res = next(generator)
  File "/usr/lib/python3.7/site-packages/astroid/decorators.py", line 128, in raise_if_nothing_inferred
    yield next(generator)
RuntimeError: generator raised StopIteration
make: *** [Makefile:90: test_pylint] Error 1
</pre>
</details>
<details><summary><code>make test_doctest</code> FAIL (seems unrelated)</summary>
<pre>
Running doctests...
Testing ranger/api/commands.py...
Testing ranger/gui/widgets/console.py...
Testing ranger/gui/ansi.py...
Testing ranger/ext/lazy_property.py...
Testing ranger/ext/widestring.py...
Testing ranger/ext/direction.py...
Testing ranger/ext/iter_tools.py...
Testing ranger/ext/human_readable.py...
**********************************************************************
File "ranger/ext/human_readable.py", line 12, in __main__.human_readable
Failed example:
    human_readable(54)
Exception raised:
    Traceback (most recent call last):
      File "/usr/lib/python3.7/doctest.py", line 1329, in __run
        compileflags, 1), test.globs)
      File "<doctest __main__.human_readable[0]>", line 1, in <module>
        human_readable(54)
      File "ranger/ext/human_readable.py", line 24, in human_readable
        if SettingsAware.settings.size_in_bytes:
    AttributeError: type object 'SettingsAware' has no attribute 'settings'
**********************************************************************
File "ranger/ext/human_readable.py", line 14, in __main__.human_readable
Failed example:
    human_readable(1500)
Exception raised:
    Traceback (most recent call last):
      File "/usr/lib/python3.7/doctest.py", line 1329, in __run
        compileflags, 1), test.globs)
      File "<doctest __main__.human_readable[1]>", line 1, in <module>
        human_readable(1500)
      File "ranger/ext/human_readable.py", line 24, in human_readable
        if SettingsAware.settings.size_in_bytes:
    AttributeError: type object 'SettingsAware' has no attribute 'settings'
**********************************************************************
File "ranger/ext/human_readable.py", line 16, in __main__.human_readable
Failed example:
    human_readable(2 ** 20 * 1023)
Exception raised:
    Traceback (most recent call last):
      File "/usr/lib/python3.7/doctest.py", line 1329, in __run
        compileflags, 1), test.globs)
      File "<doctest __main__.human_readable[2]>", line 1, in <module>
        human_readable(2 ** 20 * 1023)
      File "ranger/ext/human_readable.py", line 24, in human_readable
        if SettingsAware.settings.size_in_bytes:
    AttributeError: type object 'SettingsAware' has no attribute 'settings'
**********************************************************************
1 items had failures:
   3 of   3 in __main__.human_readable
***Test Failed*** 3 failures.
Testing ranger/ext/keybinding_parser.py...
Testing ranger/ext/signals.py...
Testing ranger/ext/rifle.py...
     
</pre>
</details>                                 

#### IMAGES / VIDEOS<!-- Only if relevant -->
<!-- Link or embed images and videos of screenshots, sketches etc. -->
