### PR TITLE
Add a snap

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,24 @@
+name: ranger
+base: core18
+version: git
+summary: A VIM-inspired filemanager for the console
+description: |
+  Ranger is a console file manager with VI key bindings. It provides a
+  minimalistic and nice curses interface with a view on the directory
+  hierarchy. It ships with rifle, a file launcher that is good at
+  automatically finding out which program to use for what file type.
+
+grade: stable
+confinement: classic
+
+parts:
+  ranger:
+    plugin: python
+    python-version: python3
+    source: .
+
+apps:
+  ranger:
+    command: python3 $SNAP/bin/ranger
+    environment:
+      PYTHONPATH: $PYTHONPATH:$SNAP/lib/python3.6/site-packages


### PR DESCRIPTION
#### ISSUE TYPE

- Improvement/feature implementation

#### CHECKLIST
- [x] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [x] All changes follow the code style **[REQUIRED]**
- [x] All new and existing tests pass **[REQUIRED]**
- [ ] Changes require config files to be updated
    - [ ] Config files have been updated
- [x] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION

It's currently hard to get an up to date version of Ranger on older versions of Ubuntu. 16.04 is at 1.7.1.

#### MOTIVATION AND CONTEXT

I've taken a bit of time to put a snap together (I work on Snapcraft) so ranger can be installed and upgraded from any version of Ubuntu, or one of many other distros (also version independent). As the Snap Store is [browsed](https://snapcraft.io/store) by millions, it'll also have the bonus of getting some more eyeballs on ranger.

#### TESTING

To build it, `snap install snapcraft` from Ubuntu, or [install Multipass](https://github.com/CanonicalLtd/multipass/releases) on MacOS then `brew install snapcraft`. Then run `snapcraft` to create the .snap file.

To publish, [create an account](https://snapcraft.io/account), then:
```
snapcraft login
snapcraft register ranger
snapcraft push --release=stable *.snap
```