### PR TITLE
Load plugin directories located in ~/.config/ranger/plugins

### DIFF
--- a/ranger/core/main.py
+++ b/ranger/core/main.py
@@ -407,8 +407,15 @@ def load_settings(  # pylint: disable=too-many-locals,too-many-branches,too-many
         except OSError:
             LOG.debug('Unable to access plugin directory: %s', plugindir)
         else:
-            plugins = [p[:-3] for p in plugin_files
-                       if p.endswith('.py') and not p.startswith('_')]
+            plugins = []
+            for path in plugin_files:
+                if not path.startswith('_'):
+                    if path.endswith('.py'):
+                        # remove trailing '.py'
+                        plugins.append(path[:-3])
+                    elif os.path.isdir(os.path.join(plugindir, path)):
+                        plugins.append(path)
+
             if not os.path.exists(fm.confpath('plugins', '__init__.py')):
                 LOG.debug("Creating missing '__init__.py' file in plugin folder")
                 fobj = open(fm.confpath('plugins', '__init__.py'), 'w')


### PR DESCRIPTION
<!-- Provide a descriptive summary of the changes in the title above -->

#### ISSUE TYPE
- Improvement/feature implementation

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [X] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [X] All changes follow the code style **[REQUIRED]**
- [ ] All new and existing tests pass **[REQUIRED]**
- [ ] Changes require config files to be updated
    - [ ] Config files have been updated
- [X] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
Adds support for loading plugins located in `<ranger.args.datadir>/plugins/` (defaults to `~/.local/share/ranger/plugins/`). Plugins need to have a `__init__.py` file as an entrypoint.

#### MOTIVATION AND CONTEXT
Solves issues with plugin standardization, installation, uninstallation, and updating. It is intended that plugins will be `git clone`d into the new plugin location and managed there. Also makes it much easier to create a ranger-plugin-manager. Plugins will have to be updated to work with the new location.

#### TESTING
<!-- What tests have been run? -->
<!-- How does the changes affect other areas of the codebase? -->