### PR TITLE
Previews for DjVu and ePub in scope.sh (commented out)

### DIFF
--- a/ranger/data/scope.sh
+++ b/ranger/data/scope.sh
@@ -141,10 +141,12 @@ handle_image() {
         #              -- "${FILE_PATH}" "${IMAGE_CACHE_PATH%.*}" \
         #         && exit 6 || exit 1;;
 
-        # ePub
-        # Needs <https://github.com/marianosimone/epub-thumbnailer>.
-        # Alternative with more supported formats but more dependencies:
-        # <https://inigo.katxi.org/devel/ebook-thumbnailer>.
+        # ePub, MOBI, FB2 (using Calibre)
+        # application/epub+zip|application/x-mobipocket-ebook|application/x-fictionbook+xml)
+        #     ebook-meta --get-cover="${IMAGE_CACHE_PATH}" -- "${FILE_PATH}" > /dev/null \
+        #         && exit 6 || exit 1;;
+
+        # ePub (using <https://github.com/marianosimone/epub-thumbnailer>)
         # application/epub+zip)
         #     epub-thumbnailer \
         #         "${FILE_PATH}" "${IMAGE_CACHE_PATH}" "${DEFAULT_SIZE%x*}" \

--- a/ranger/data/scope.sh
+++ b/ranger/data/scope.sh
@@ -31,7 +31,7 @@ IMAGE_CACHE_PATH="${4}"  # Full path that should be used to cache image preview
 PV_IMAGE_ENABLED="${5}"  # 'True' if image previews are enabled, 'False' otherwise.
 
 FILE_EXTENSION="${FILE_PATH##*.}"
-FILE_EXTENSION_LOWER=$(echo ${FILE_EXTENSION} | tr '[:upper:]' '[:lower:]')
+FILE_EXTENSION_LOWER="$(printf "%s" "${FILE_EXTENSION}" | tr '[:upper:]' '[:lower:]')"
 
 # Settings
 HIGHLIGHT_SIZE_MAX=262143  # 256KiB
@@ -101,7 +101,7 @@ handle_image() {
     case "${mimetype}" in
         # SVG
         # image/svg+xml)
-        #     convert "${FILE_PATH}" "${IMAGE_CACHE_PATH}" && exit 6
+        #     convert -- "${FILE_PATH}" "${IMAGE_CACHE_PATH}" && exit 6
         #     exit 1;;
 
         # DjVu.
@@ -130,6 +130,7 @@ handle_image() {
         #     # Thumbnail
         #     ffmpegthumbnailer -i "${FILE_PATH}" -o "${IMAGE_CACHE_PATH}" -s 0 && exit 6
         #     exit 1;;
+
         # PDF
         # application/pdf)
         #     pdftoppm -f 1 -l 1 \

--- a/ranger/data/scope.sh
+++ b/ranger/data/scope.sh
@@ -140,6 +140,15 @@ handle_image() {
         #              -- "${FILE_PATH}" "${IMAGE_CACHE_PATH%.*}" \
         #         && exit 6 || exit 1;;
 
+        # ePub.
+        # Needs <https://github.com/marianosimone/epub-thumbnailer>.
+        # Alternative with more supported formats but more dependencies:
+        # <https://inigo.katxi.org/devel/ebook-thumbnailer>.
+        # application/epub+zip)
+        #     epub-thumbnailer \
+        #         "${FILE_PATH}" "${IMAGE_CACHE_PATH}" "${DEFAULT_SIZE%x*}" \
+        #         && exit 6 || exit 1;;
+
         # Preview archives using the first image inside.
         # (Very useful for comic book collections for example.)
         # application/zip|application/x-rar|application/x-7z-compressed|\

--- a/ranger/data/scope.sh
+++ b/ranger/data/scope.sh
@@ -104,7 +104,7 @@ handle_image() {
         #     convert -- "${FILE_PATH}" "${IMAGE_CACHE_PATH}" && exit 6
         #     exit 1;;
 
-        # DjVu.
+        # DjVu
         # image/vnd.djvu)
         #     ddjvu -format=tiff -quality=90 -page=1 -size="${DEFAULT_SIZE}" \
         #           - "${IMAGE_CACHE_PATH}" < "${FILE_PATH}" \
@@ -141,7 +141,7 @@ handle_image() {
         #              -- "${FILE_PATH}" "${IMAGE_CACHE_PATH%.*}" \
         #         && exit 6 || exit 1;;
 
-        # ePub.
+        # ePub
         # Needs <https://github.com/marianosimone/epub-thumbnailer>.
         # Alternative with more supported formats but more dependencies:
         # <https://inigo.katxi.org/devel/ebook-thumbnailer>.

--- a/ranger/data/scope.sh
+++ b/ranger/data/scope.sh
@@ -92,12 +92,23 @@ handle_extension() {
 }
 
 handle_image() {
+    # Size of the preview if there are multiple options or it has to be rendered
+    # from vector graphics. If the conversion program allows specifying only one
+    # dimension while keeping the aspect ratio, the width will be used.
+    local DEFAULT_SIZE="1920x1080"
+
     local mimetype="${1}"
     case "${mimetype}" in
         # SVG
         # image/svg+xml)
         #     convert "${FILE_PATH}" "${IMAGE_CACHE_PATH}" && exit 6
         #     exit 1;;
+
+        # DjVu.
+        # image/vnd.djvu)
+        #     ddjvu -format=tiff -quality=90 -page=1 -size="${DEFAULT_SIZE}" \
+        #           - "${IMAGE_CACHE_PATH}" <"${FILE_PATH}" \
+        #           && exit 6 || exit 1;;
 
         # Image
         image/*)
@@ -122,7 +133,7 @@ handle_image() {
         # PDF
         # application/pdf)
         #     pdftoppm -f 1 -l 1 \
-        #              -scale-to-x 1920 \
+        #              -scale-to-x "${DEFAULT_SIZE%x*}" \
         #              -scale-to-y -1 \
         #              -singlefile \
         #              -jpeg -tiffcompression jpeg \

--- a/ranger/data/scope.sh
+++ b/ranger/data/scope.sh
@@ -107,7 +107,7 @@ handle_image() {
         # DjVu.
         # image/vnd.djvu)
         #     ddjvu -format=tiff -quality=90 -page=1 -size="${DEFAULT_SIZE}" \
-        #           - "${IMAGE_CACHE_PATH}" <"${FILE_PATH}" \
+        #           - "${IMAGE_CACHE_PATH}" < "${FILE_PATH}" \
         #           && exit 6 || exit 1;;
 
         # Image


### PR DESCRIPTION
This pull request adds commented-out code for DjVu and ePub image previews to `scope.sh`. It also includes some trivial robustness improvements that don't merit a separate pull request.

#### ISSUE TYPE
- Improvement/feature implementation

#### RUNTIME ENVIRONMENT
<!-- Details of your runtime environment -->
<!-- Retrieve Python/ranger version and locale with `ranger -\-version` -->
- Operating system and version: Debian GNU/Linux 10
- Terminal emulator and version: xterm 340
- Python version: 3.6.8rc1
- Ranger version/commit: 1.9.2
- Locale: en_GB.UTF-8

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [X] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [X] All changes follow the code style **[REQUIRED]**
- [ ] All new and existing tests pass **[REQUIRED]**
  --> There are some failures in `make test_doctest`, but they're unrelated to this pull request.
- [X] Changes require config files to be updated
    - [X] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION

This pull requests adds the following previews to `handle_image`, both commented out:
* DjVu, using `ddjvu`.
* ePub, using [epub-thumbnailer](https://github.com/marianosimone/epub-thumbnailer).

It also introduces a local variable `DEFAULT_SIZE`, controlling the size of previews that have to be rendered or selected from multiple options. (This value was used only once before but is now needed in multiple places.)

In addition, it includes two trivial changes that improve the handling of weird filenames (with a space in the extension or starting with a dash).

#### MOTIVATION AND CONTEXT

The previews make browsing e-book collections significantly more convenient.

#### TESTING

`make test_doctest` results in the following output:

```
Running doctests...
Testing ranger/gui/ansi.py...
Testing ranger/gui/widgets/console.py...
Testing ranger/ext/signals.py...
Testing ranger/ext/lazy_property.py...
Testing ranger/ext/rifle.py...
Testing ranger/ext/human_readable.py...
**********************************************************************
File "ranger/ext/human_readable.py", line 12, in __main__.human_readable
Failed example:
    human_readable(54)
Exception raised:
    Traceback (most recent call last):
      File "/usr/lib/python2.7/doctest.py", line 1315, in __run
        compileflags, 1) in test.globs
      File "<doctest __main__.human_readable[0]>", line 1, in <module>
        human_readable(54)
      File "ranger/ext/human_readable.py", line 24, in human_readable
        if SettingsAware.settings.size_in_bytes:
    AttributeError: type object 'SettingsAware' has no attribute 'settings'
**********************************************************************
File "ranger/ext/human_readable.py", line 14, in __main__.human_readable
Failed example:
    human_readable(1500)
Exception raised:
    Traceback (most recent call last):
      File "/usr/lib/python2.7/doctest.py", line 1315, in __run
        compileflags, 1) in test.globs
      File "<doctest __main__.human_readable[1]>", line 1, in <module>
        human_readable(1500)
      File "ranger/ext/human_readable.py", line 24, in human_readable
        if SettingsAware.settings.size_in_bytes:
    AttributeError: type object 'SettingsAware' has no attribute 'settings'
**********************************************************************
File "ranger/ext/human_readable.py", line 16, in __main__.human_readable
Failed example:
    human_readable(2 ** 20 * 1023)
Exception raised:
    Traceback (most recent call last):
      File "/usr/lib/python2.7/doctest.py", line 1315, in __run
        compileflags, 1) in test.globs
      File "<doctest __main__.human_readable[2]>", line 1, in <module>
        human_readable(2 ** 20 * 1023)
      File "ranger/ext/human_readable.py", line 24, in human_readable
        if SettingsAware.settings.size_in_bytes:
    AttributeError: type object 'SettingsAware' has no attribute 'settings'
**********************************************************************
1 items had failures:
   3 of   3 in __main__.human_readable
***Test Failed*** 3 failures.
Testing ranger/ext/iter_tools.py...
Testing ranger/ext/keybinding_parser.py...
Testing ranger/ext/direction.py...
Testing ranger/ext/widestring.py...
Testing ranger/api/commands.py...
```

However, these failures are completely unrelated to the changes in this pull request, which doesn't even touch Python code.