### PR TITLE
fix terminal flag in rifle.py

### DIFF
--- a/ranger/ext/rifle.py
+++ b/ranger/ext/rifle.py
@@ -412,8 +412,7 @@ class Rifle(object):  # pylint: disable=too-many-instance-attributes
                     elif term in ['tilda']:
                         execflags = ['-c']
                     elif term in ['guake']:
-                        # put pwd manually here? this won't get expanded
-                        execflags = ['-n', '${PWD}', '-e']
+                        execflags = ['-n', os.environ['PWD'], '-e']
                     else:
                         execflags = ['-e']
 


### PR DESCRIPTION
<!-- Provide a descriptive summary of the changes in the title above -->

#### ISSUE TYPE
<!-- Pick relevant types and delete the rest -->
- Bug fix
- Improvement/feature implementation

#### RUNTIME ENVIRONMENT
<!-- Details of your runtime environment -->
<!-- Retrieve Python/ranger version and locale with `ranger -\-version` -->
- Operating system and version: 4.19.12-arch1-1-ARCH
- Terminal emulator and version: termite v14-1-gfad28a5
- Python version: Python 3.7.1
- Ranger version/commit: 1.9.2.81.g7f20f313-1
- Locale: en_US.UTF8

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [X] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [X] All changes follow the code style **[REQUIRED]**
- [ ] All new and existing tests pass **[REQUIRED]** (pylint aborts on ranger.gui.widgets.statusbar)
- [ ] Changes require config files to be updated
    - [ ] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
<!-- Describe the changes in detail -->
Firstly,  always invoke the shell with `sh -c 'cmd "$@"' _ file1 file2` instead of `sh -c 'set -- file1 file; cmd "$@"'`. This is alot easier to handle: If the terminal consumes all arguments after its exec-flag, give it this list, otherwise wrap it in quotes and concatenate it. (Note that _in theory_ this should also work with the old way `sh` was invoked, but failed on filesnames with spaces, even though all the quoting should take care of that)
This now also works with the root flag.

#### MOTIVATION AND CONTEXT
<!-- Why are these changes required? -->
<!-- What problems do these changes solve? -->
<!-- Link to relevant issues -->
This should fix #1401, though I think there is some stuff left to do:
- I tested this with all hardcoded terminals except `lilyterm` which i couldn't build.
- On archlinux `pantheon-terminal`s executable has the name `io.elementary.terminal`. I don't know about other distros.
- Some refactoring: For example the function `build_command` used to build the `set -- file1 fil2; cmd`-string, but is pretty much useless now
- Fallback terminals in rifle.conf that take the command as a single argument don't work. Ranger can not know beforehand what the fallback is going to be, so it can't decide if it should wrap the command or not. One can, for example, give the wrapped command in an environment variable, or provide a script to wrap the args and call the terminal with `termite -e "$(quote "$@")"`.
- Launching a fallback terminal from within ranger in tmux will mangle tmux (try `TERMCMD=doesnotexist ranger.py` with one of the fallbacks that work, e.g. `xterm` or `urxvt`). This has to do with a missing hook (after the `finally` in `execute`) because we are returning from the function early.
- Some terminals don't set a unique `TERM` and just use some variant of `xterm`. This is irritating, because `xterm` will start instead of the preferred terminal. In this case the only way to have rifle start the right terminal is using `TERMCMD`. One could think about adding an option to ranger and call `rifle` with the appropriate `TERMCMD` set, so one does not have to set this variable globally.