### PR TITLE
Share TERMCMD detection between :terminal and rifle

### DIFF
--- a/ranger/ext/get_executables.py
+++ b/ranger/ext/get_executables.py
@@ -55,9 +55,30 @@ def get_term():
 
     Either $TERMCMD, $TERM, "x-terminal-emulator" or "xterm", in this order.
     """
-    command = environ.get('TERMCMD', environ.get('TERM'))
-    if shlex.split(command)[0] not in get_executables():
-        command = 'x-terminal-emulator'
-        if command not in get_executables():
-            command = 'xterm'
-    return command
+    term = environ.get('TERMCMD', environ['TERM'])
+
+    # Handle aliases of xterm and urxvt, rxvt and st and
+    # termite
+    # Match 'xterm', 'xterm-256color'
+    if term in ['xterm', 'xterm-256color']:
+        term = 'xterm'
+    if term in ['xterm-kitty']:
+        term = 'kitty'
+    if term in ['xterm-termite']:
+        term = 'termite'
+    if term in ['st', 'st-256color']:
+        term = 'st'
+    if term in ['urxvt', 'rxvt-unicode',
+                'rxvt-unicode-256color']:
+        term = 'urxvt'
+    if term in ['rxvt', 'rxvt-256color']:
+        if 'rxvt' in get_executables():
+            term = 'rxvt'
+        else:
+            term = 'urxvt'
+
+    if shlex.split(term)[0] not in get_executables():
+        term = 'x-terminal-emulator'
+        if term not in get_executables():
+            term = 'xterm'
+    return term

--- a/ranger/ext/rifle.py
+++ b/ranger/ext/rifle.py
@@ -32,7 +32,7 @@ ENCODING = 'utf-8'
 # Imports from ranger library, plus reimplementations in case ranger is not
 # installed so rifle can be run as a standalone program.
 try:
-    from ranger.ext.get_executables import get_executables
+    from ranger.ext.get_executables import get_executables, get_term
 except ImportError:
     _CACHED_EXECUTABLES = None
 
@@ -361,28 +361,7 @@ class Rifle(object):  # pylint: disable=too-many-instance-attributes
 
                 cmd = prefix + [command]
                 if 't' in flags:
-                    term = os.environ.get('TERMCMD', os.environ['TERM'])
-
-                    # Handle aliases of xterm and urxvt, rxvt and st and
-                    # termite
-                    # Match 'xterm', 'xterm-256color'
-                    if term in ['xterm', 'xterm-256color']:
-                        term = 'xterm'
-                    if term in ['xterm-kitty']:
-                        term = 'kitty'
-                    if term in ['xterm-termite']:
-                        term = 'termite'
-                    if term in ['st', 'st-256color']:
-                        term = 'st'
-                    if term in ['urxvt', 'rxvt-unicode',
-                                'rxvt-unicode-256color']:
-                        term = 'urxvt'
-                    if term in ['rxvt', 'rxvt-256color']:
-                        if 'rxvt' in get_executables():
-                            term = 'rxvt'
-                        else:
-                            term = 'urxvt'
-
+                    term = get_term()
                     if term not in get_executables():
                         self.hook_logger("Can not determine terminal command, "
                                          "using rifle to determine fallback.  "


### PR DESCRIPTION

<!-- Provide a descriptive summary of the changes in the title above -->

#### ISSUE TYPE
<!-- Pick relevant types and delete the rest -->
- Bug fix

#### RUNTIME ENVIRONMENT
<!-- Details of your runtime environment -->
<!-- Retrieve Python/ranger version and locale with `ranger -\-version` -->
- Operating system and version: Arch Linux x86_64 v4.20.3; zsh 5.6.2
- Terminal emulator and version: termite v14
- Python version: 3.7.2
- Ranger version/commit: f9de84dd51bd6baa4de2cccbcf0c77569e5552c7
- Locale: en_US.UTF-8

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [x] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [x] All changes follow the code style **[REQUIRED]**
- [ ] All new and existing tests pass **[REQUIRED]**
- [ ] Changes require config files to be updated
    - [ ] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
<!-- Describe the changes in detail -->
Moved $TERM parsing section from rifle.py to `get_executables.get_term()`  
This fixes detection of $TERMCMD from $TERM, when using the `:terminal`
command.

#### MOTIVATION AND CONTEXT
<!-- Why are these changes required? -->
<!-- What problems do these changes solve? -->
<!-- Link to relevant issues -->
To have `:terminal` open the terminal emulator in use, instead of xterm.  
It makes sense to me, to simply put the $TERM parsing section in `get_executables.get_term()`, and then have rifle call that.  
Slightly off topic: would it be easier to just detect the terminal emulator that ranger is running in, rather than parse $TERM ?    
#1425 may conflict with this, but it's purpose is different.
#1401 is also somewhat related.

#### TESTING
<!-- What tests have been run? -->
<!-- How does the changes affect other areas of the codebase? -->
Running just `pytest` from project root, has all 7 tests pass.  
Manual testing works as expected: `:terminal` opens the correct terminal emulator, and rifle behaves the same way with the -t flag.

I ran `make test`, but it failed on a completely unrelated section.
```
************* Module ranger.gui.widgets.browsercolumn
ranger/gui/widgets/browsercolumn.py:539:11: R1716: Simplify chained comparison between the operands (chained-comparison)
Traceback (most recent call last):
  File "/usr/lib/python3.7/site-packages/astroid/inference.py", line 382, in infer_subscript
    assigned = value.getitem(index_value, context)
  File "/usr/lib/python3.7/site-packages/astroid/node_classes.py", line 2469, in getitem
    index_value = _infer_slice(index, context=context)
  File "/usr/lib/python3.7/site-packages/astroid/node_classes.py", line 187, in _infer_slice
    upper = _slice_value(node.upper, context)
  File "/usr/lib/python3.7/site-packages/astroid/node_classes.py", line 171, in _slice_value
    inferred = next(index.infer(context=context))
StopIteration
```


#### IMAGES / VIDEOS<!-- Only if relevant -->
<!-- Link or embed images and videos of screenshots, sketches etc. -->
