### PR TITLE
fix Ctrl+Space crash

### DIFF
--- a/ranger/gui/curses_shortcuts.py
+++ b/ranger/gui/curses_shortcuts.py
@@ -14,7 +14,7 @@ REVERSE_ADDCH_ARGS = sys.version[0:5] == '3.4.0'
 
 def _fix_surrogates(args):
     return [isinstance(arg, str) and arg.encode('utf-8', 'surrogateescape')
-            .decode('utf-8', 'replace').replace('\u0000', '') or arg for arg in args]
+            .decode('utf-8', 'replace').replace(u'\u0000', '') or arg for arg in args]
 
 
 class CursesShortcuts(SettingsAware):

--- a/ranger/gui/curses_shortcuts.py
+++ b/ranger/gui/curses_shortcuts.py
@@ -14,7 +14,7 @@ REVERSE_ADDCH_ARGS = sys.version[0:5] == '3.4.0'
 
 def _fix_surrogates(args):
     return [isinstance(arg, str) and arg.encode('utf-8', 'surrogateescape')
-            .decode('utf-8', 'replace') or arg for arg in args]
+            .decode('utf-8', 'replace').replace('\u0000', '') or arg for arg in args]
 
 
 class CursesShortcuts(SettingsAware):


### PR DESCRIPTION
When in input mode (e.g. search, :mkdir, :rename, etc.), pressing Ctrl+Space makes ranger crash
This will fix this issue

Crash example:
```
ranger version: ranger-master 1.9.2
Python version: 3.7.2 (default, Jan 10 2019, 23:51:51) [GCC 8.2.1 20181127]
Locale: el_GR.UTF-8
Current file: '/home/spiros/1. "aaa" \'aaa\''

Traceback (most recent call last):
  File "/usr/lib/python3.7/site-packages/ranger/gui/curses_shortcuts.py", line 36, in addstr
    self.win.addstr(*args)
ValueError: embedded null character

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/lib/python3.7/site-packages/ranger/core/main.py", line 195, in main
    fm.loop()
  File "/usr/lib/python3.7/site-packages/ranger/core/fm.py", line 394, in loop
    ui.redraw()
  File "/usr/lib/python3.7/site-packages/ranger/gui/ui.py", line 338, in redraw
    self.draw()
  File "/usr/lib/python3.7/site-packages/ranger/gui/ui.py", line 365, in draw
    DisplayableContainer.draw(self)
  File "/usr/lib/python3.7/site-packages/ranger/gui/displayable.py", line 256, in draw
    displayable.draw()
  File "/usr/lib/python3.7/site-packages/ranger/gui/widgets/console.py", line 111, in draw
    self.addstr(0, len(self.prompt), str(line[x:]))
  File "/usr/lib/python3.7/site-packages/ranger/gui/curses_shortcuts.py", line 44, in addstr
    self.win.addstr(*_fix_surrogates(args))
ValueError: embedded null character

ranger crashed. Please report this traceback at:
https://github.com/ranger/ranger/issues
```