### PR TITLE
container.bookmarks: Remove invalid bookmarks only on access

### DIFF
--- a/ranger/container/bookmarks.py
+++ b/ranger/container/bookmarks.py
@@ -12,7 +12,7 @@ from ranger.core.shared import FileManagerAware
 ALLOWED_KEYS = string.ascii_letters + string.digits + "`'"
 
 
-class Bookmarks(FileManagerAware):  # pylint: disable=too-many-instance-attributes
+class Bookmarks(FileManagerAware):
     """Bookmarks is a container which associates keys with bookmarks.
 
     A key is a string with: len(key) == 1 and key in ALLOWED_KEYS.
@@ -29,7 +29,7 @@ class Bookmarks(FileManagerAware):  # pylint: disable=too-many-instance-attribut
     load_pattern = re.compile(r"^[\d\w']:.")
 
     def __init__(self, bookmarkfile, bookmarktype=str, autosave=False,
-                 validate=True, nonpersistent_bookmarks=()):
+                 nonpersistent_bookmarks=()):
         """Initializes Bookmarks.
 
         <bookmarkfile> specifies the path to the file where
@@ -41,7 +41,6 @@ class Bookmarks(FileManagerAware):  # pylint: disable=too-many-instance-attribut
         self.path = bookmarkfile
         self.bookmarktype = bookmarktype
         self.nonpersistent_bookmarks = set(nonpersistent_bookmarks)
-        self.validate = validate
 
     def load(self):
         """Load the bookmarks from path/bookmarks"""
@@ -90,7 +89,7 @@ class Bookmarks(FileManagerAware):  # pylint: disable=too-many-instance-attribut
             key = "'"
         if key in self.dct:
             value = self.dct[key]
-            if not self.validate or os.path.isdir(str(value)):
+            if self._validate(value):
                 return value
             else:
                 raise KeyError("Cannot open bookmark: `%s'!" % key)
@@ -258,3 +257,6 @@ class Bookmarks(FileManagerAware):  # pylint: disable=too-many-instance-attribut
 
     def _update_mtime(self):
         self.last_mtime = self._get_mtime()
+
+    def _validate(self, value):  # pylint: disable=no-self-use
+        return os.path.isdir(str(value))

--- a/ranger/container/bookmarks.py
+++ b/ranger/container/bookmarks.py
@@ -92,8 +92,7 @@ class Bookmarks(FileManagerAware):
             if os.path.isdir(value.path):
                 return value
             else:
-                del self[key]
-                raise KeyError("Invalid Bookmark: `%s'!" % key)
+                raise KeyError("Cannot open bookmark: `%s'!" % key)
         else:
             raise KeyError("Nonexistant Bookmark: `%s'!" % key)
 

--- a/ranger/container/bookmarks.py
+++ b/ranger/container/bookmarks.py
@@ -12,7 +12,7 @@ from ranger.core.shared import FileManagerAware
 ALLOWED_KEYS = string.ascii_letters + string.digits + "`'"
 
 
-class Bookmarks(FileManagerAware):
+class Bookmarks(FileManagerAware):  # pylint: disable=too-many-instance-attributes
     """Bookmarks is a container which associates keys with bookmarks.
 
     A key is a string with: len(key) == 1 and key in ALLOWED_KEYS.
@@ -29,7 +29,7 @@ class Bookmarks(FileManagerAware):
     load_pattern = re.compile(r"^[\d\w']:.")
 
     def __init__(self, bookmarkfile, bookmarktype=str, autosave=False,
-                 nonpersistent_bookmarks=()):
+                 validate=True, nonpersistent_bookmarks=()):
         """Initializes Bookmarks.
 
         <bookmarkfile> specifies the path to the file where
@@ -41,6 +41,7 @@ class Bookmarks(FileManagerAware):
         self.path = bookmarkfile
         self.bookmarktype = bookmarktype
         self.nonpersistent_bookmarks = set(nonpersistent_bookmarks)
+        self.validate = validate
 
     def load(self):
         """Load the bookmarks from path/bookmarks"""
@@ -89,7 +90,7 @@ class Bookmarks(FileManagerAware):
             key = "'"
         if key in self.dct:
             value = self.dct[key]
-            if os.path.isdir(value.path):
+            if not self.validate or os.path.isdir(str(value)):
                 return value
             else:
                 raise KeyError("Cannot open bookmark: `%s'!" % key)

--- a/ranger/container/bookmarks.py
+++ b/ranger/container/bookmarks.py
@@ -88,7 +88,12 @@ class Bookmarks(FileManagerAware):
         if key == '`':
             key = "'"
         if key in self.dct:
-            return self.dct[key]
+            value = self.dct[key]
+            if os.path.isdir(value.path):
+                return value
+            else:
+                del self[key]
+                raise KeyError("Invalid Bookmark: `%s'!" % key)
         else:
             raise KeyError("Nonexistant Bookmark: `%s'!" % key)
 
@@ -229,7 +234,7 @@ class Bookmarks(FileManagerAware):
         for line in fobj:
             if self.load_pattern.match(line):
                 key, value = line[0], line[2:-1]
-                if key in ALLOWED_KEYS and not os.path.isfile(value):
+                if key in ALLOWED_KEYS:
                     dct[key] = self.bookmarktype(value)
         fobj.close()
         return dct

--- a/tests/ranger/container/test_bookmarks.py
+++ b/tests/ranger/container/test_bookmarks.py
@@ -12,7 +12,7 @@ def testbookmarks(tmpdir):
     # Bookmarks point to directory location and allow fast access to
     # 'favorite' directories. They are persisted to a bookmark file, plain text.
     bookmarkfile = tmpdir.join("bookmarkfile")
-    bmstore = Bookmarks(str(bookmarkfile))
+    bmstore = Bookmarks(str(bookmarkfile), validate=False)
 
     # loading an empty bookmark file doesnot crash
     bmstore.load()
@@ -33,7 +33,7 @@ def testbookmarks(tmpdir):
 
     # We can persist bookmarks to disk and restore them from disk
     bmstore.save()
-    secondstore = Bookmarks(str(bookmarkfile))
+    secondstore = Bookmarks(str(bookmarkfile), validate=False)
     secondstore.load()
     assert "'" in secondstore
     assert secondstore["'"] == "the milk"

--- a/tests/ranger/container/test_bookmarks.py
+++ b/tests/ranger/container/test_bookmarks.py
@@ -8,11 +8,16 @@ import pytest
 from ranger.container.bookmarks import Bookmarks
 
 
+class NotValidatedBookmarks(Bookmarks):
+    def _validate(self, value):
+        return True
+
+
 def testbookmarks(tmpdir):
     # Bookmarks point to directory location and allow fast access to
     # 'favorite' directories. They are persisted to a bookmark file, plain text.
     bookmarkfile = tmpdir.join("bookmarkfile")
-    bmstore = Bookmarks(str(bookmarkfile), validate=False)
+    bmstore = NotValidatedBookmarks(str(bookmarkfile))
 
     # loading an empty bookmark file doesnot crash
     bmstore.load()
@@ -33,7 +38,7 @@ def testbookmarks(tmpdir):
 
     # We can persist bookmarks to disk and restore them from disk
     bmstore.save()
-    secondstore = Bookmarks(str(bookmarkfile), validate=False)
+    secondstore = NotValidatedBookmarks(str(bookmarkfile))
     secondstore.load()
     assert "'" in secondstore
     assert secondstore["'"] == "the milk"


### PR DESCRIPTION
Previously ranger was validating the bookmarks (whether they are existing
directories) when loading the bookmark file.  It caused the remote
filesystems like autofs to wake up unnecessarily and in general caused
more problems than solved.

Fixes #1365.