### PR TITLE
rename_append: Use `rename` if point is on a directory

### DIFF
--- a/ranger/config/commands.py
+++ b/ranger/config/commands.py
@@ -1000,6 +1000,10 @@ class rename_append(Command):
             self.fm.open_console('rename ' + relpath)
             return
 
+        if os.path.isdir(relpath):
+            self.fm.open_console('rename ' + relpath)
+            return
+
         if self._flag_ext_all:
             pos_ext = re.search(r'[^.]+', basename).end(0)
         else:

--- a/ranger/config/commands.py
+++ b/ranger/config/commands.py
@@ -996,11 +996,7 @@ class rename_append(Command):
         relpath = tfile.relative_path.replace(MACRO_DELIMITER, MACRO_DELIMITER_ESC)
         basename = tfile.basename.replace(MACRO_DELIMITER, MACRO_DELIMITER_ESC)
 
-        if basename.find('.') <= 0:
-            self.fm.open_console('rename ' + relpath)
-            return
-
-        if os.path.isdir(relpath):
+        if basename.find('.') <= 0 or os.path.isdir(relpath):
             self.fm.open_console('rename ' + relpath)
             return
 


### PR DESCRIPTION
<!-- Provide a descriptive summary of the changes in the title above -->

#### ISSUE TYPE
<!-- Pick relevant types and delete the rest -->
- Bug fix

#### RUNTIME ENVIRONMENT
<!-- Details of your runtime environment -->
<!-- Retrieve Python/ranger version and locale with `ranger -\-version` -->
- Operating system and version: Arch
- Terminal emulator and version: Terminator
- Python version: 3.7.2
- Ranger version/commit: 1.9.2
- Locale: en_GB

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [X] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [X] All changes follow the code style **[REQUIRED]**
- [X] All new and existing tests pass **[REQUIRED]**
- [ ] Changes require config files to be updated
    - [ ] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
<!-- Describe the changes in detail -->
When the directory at point has full-stops in it, rename_append would
put the point at the last period in the dir-name, as it would with a
file.  This commit addresses this issue.