### PR TITLE
fix issue #1296

### DIFF
--- a/ranger/ext/vcs/svn.py
+++ b/ranger/ext/vcs/svn.py
@@ -98,6 +98,7 @@ class SVN(Vcs):
 
         # Paths with status
         lines = self._run(['status']).split('\n')
+        lines = list(filter(None, lines))
         if not lines:
             return 'sync'
         for line in lines:
@@ -116,6 +117,7 @@ class SVN(Vcs):
 
         # Paths with status
         lines = self._run(['status']).split('\n')
+        lines = list(filter(None, lines))
         for line in lines:
             code, path = line[0], line[8:]
             if code == ' ':


### PR DESCRIPTION
#### ISSUE TYPE
- Bug fix

#### RUNTIME ENVIRONMENT
- Operating system and version:  Arch linux 4.20.11-arch1-1-ARCH
- Terminal emulator and version: termite v14
- Python version: 3.7.2
- Ranger version/commit: 1.9.2
- Locale: en_US.UTF-8

#### CHECKLIST
- [X] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [X] All changes follow the code style **[REQUIRED]**
- [X] All new and existing tests pass **[REQUIRED]**
- [ ] Changes require config files to be updated
    - [ ] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
When invoking svn status on a clean working copy, subversion returns an empty string, which later causes an error when trying to parse its status and therefore the vcs icons are not drawn.
This PR avoids that by skipping empty results.
I couldn't use the same approach as in git because subversion won't add the LF character to the end of the string so ```self._run(['status']).split('\n')[:-1]``` would cause the last path to be missing.

#### MOTIVATION AND CONTEXT
This fixes #1296 
