### PR TITLE
Implementing destination argument for the built in paste command

### DIFF
--- a/ranger/config/rc.conf
+++ b/ranger/config/rc.conf
@@ -476,6 +476,9 @@ map pl paste_symlink relative=False
 map pL paste_symlink relative=True
 map phl paste_hardlink
 map pht paste_hardlinked_subtree
+map pd console paste dest=
+map p`<any> paste dest=%any_path
+map p'<any> paste dest=%any_path
 
 map dD console delete
 

--- a/ranger/core/actions.py
+++ b/ranger/core/actions.py
@@ -1562,8 +1562,8 @@ class Actions(  # pylint: disable=too-many-instance-attributes,too-many-public-m
     def paste(self, overwrite=False, append=False, dest=None):
         """:paste
 
-        Paste the selected items into the current directory or in dest
-        if given.
+        Paste the selected items into the current directory or to dest
+        if provided.
         """
         if dest is not None:
             if not exists(dest) and not isdir(dest):

--- a/ranger/core/actions.py
+++ b/ranger/core/actions.py
@@ -1559,12 +1559,17 @@ class Actions(  # pylint: disable=too-many-instance-attributes,too-many-public-m
                 link(source_path,
                      next_available_filename(target_path))
 
-    def paste(self, overwrite=False, append=False):
+    def paste(self, overwrite=False, append=False, dest=None):
         """:paste
-
-        Paste the selected items into the current directory.
+        
+        Paste the selected items into the current directory or in dest
+        if given.
         """
-        loadable = CopyLoader(self.copy_buffer, self.do_cut, overwrite)
+        if dest is not None:
+            if not exists(dest) and not isdir(dest):
+                self.notify('Failed to paste. The given path is invalid.', bad=True)
+                return
+        loadable = CopyLoader(self.copy_buffer, self.do_cut, overwrite, dest=dest)
         self.loader.add(loadable, append=append)
         self.do_cut = False
 

--- a/ranger/core/actions.py
+++ b/ranger/core/actions.py
@@ -1561,7 +1561,7 @@ class Actions(  # pylint: disable=too-many-instance-attributes,too-many-public-m
 
     def paste(self, overwrite=False, append=False, dest=None):
         """:paste
-        
+
         Paste the selected items into the current directory or in dest
         if given.
         """

--- a/ranger/core/loader.py
+++ b/ranger/core/loader.py
@@ -51,11 +51,11 @@ class Loadable(object):
 class CopyLoader(Loadable, FileManagerAware):  # pylint: disable=too-many-instance-attributes
     progressbar_supported = True
 
-    def __init__(self, copy_buffer, do_cut=False, overwrite=False):
+    def __init__(self, copy_buffer, do_cut=False, overwrite=False, dest=None):
         self.copy_buffer = tuple(copy_buffer)
         self.do_cut = do_cut
         self.original_copy_buffer = copy_buffer
-        self.original_path = self.fm.thistab.path
+        self.original_path = dest if dest is not None else self.fm.thistab.path
         self.overwrite = overwrite
         self.percent = 0
         if self.copy_buffer:
@@ -102,7 +102,7 @@ class CopyLoader(Loadable, FileManagerAware):  # pylint: disable=too-many-instan
                         tag = self.fm.tags.tags[path]
                         self.fm.tags.remove(path)
                         self.fm.tags.tags[
-                            path.replace(fobj.path, self.original_path + '/' + fobj.basename)
+                            path.replace(fobj.path, path.join(self.original_path, fobj.basename))
                         ] = tag
                         self.fm.tags.dump()
                 n = 0

--- a/ranger/core/loader.py
+++ b/ranger/core/loader.py
@@ -398,8 +398,8 @@ class Loader(FileManagerAware):
                 else:
                     break
             except IndexError:
-
                 return
+
         item.unpause()
 
         self.rotate()

--- a/ranger/core/loader.py
+++ b/ranger/core/loader.py
@@ -398,8 +398,8 @@ class Loader(FileManagerAware):
                 else:
                     break
             except IndexError:
-                return
 
+                return
         item.unpause()
 
         self.rotate()


### PR DESCRIPTION
This PR is directly addressing #1473 . I've implemented a _dest_ argument for the built in _paste_ command.


#### TYPE
- Improvement/feature implementation

#### RUNTIME ENVIRONMENT
- Debian GNU/Linux busterr/sid
- Urxvt 9.22
- Python 3.6.6 
- ranger-master 1.9.2  
- Locale: en_US.UTF-8

- [x] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [x] All changes follow the code style **[REQUIRED]**
- [x] All new and existing tests pass **[REQUIRED]**
- [ ] Changes require config files to be updated
    - [ ] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION

I've just added one additional argument to the `paste` method in the `Actions` class. The given value gets passed to the `CopyLoader` object and if it is not `None` and given it is a proper path, the it will be used as destination path.  



#### MOTIVATION AND CONTEXT
Everything discussed in #1473 and several personal problems with ranger. I really wanted to be able to quickly copy/paste/cut files in some of my bookmarks. The most of the functionality can be implemented as custom function/plugin and the accompanying keybindings but the problem with the paste stays. Programmatically or not, one can only paste in the current directory and nowhere else. With the made changes, I can now have custom function like 

```python
class copy_to_bookmark(Command):
    """
    Copy/cut file(s) to bookmark
    """    

    def execute(self):
        key = self.arg(1)
        if key in self.fm.bookmarks:
            destination = str(self.fm.bookmarks[str(key)])

            if self.arg(2) == '-c':
                self.fm.copy(mode='set')
            elif self.arg(2) == '-d':
                self.fm.cut(mode='set')    
            self.fm.paste(dest=destination)
            self.fm.uncut()
        else:
            self.fm.notify('The key isn\'t bound to bookmark!')
```

I also have several key bindings for the function:
```
map mp<any>     copy_to_bookmark %any -p
map mc<any>     copy_to_bookmark %any -c
map md<any>     copy_to_bookmark %any -d
```
which allow me to quickly perform the action I want.

- <kbd>mp</kbd> - pastes the files in the copy_buffer in the chosen bookmark
- <kbd>md</kbd> - cuts the currently selected file in the chosen bookmark 
- <kbd>mc</kbd> - copies the currently selected file in the chosen bookmark  



