### PR TITLE
Add a reset_previews command

### DIFF
--- a/ranger/config/commands.py
+++ b/ranger/config/commands.py
@@ -1639,6 +1639,17 @@ class flat(Command):
         self.fm.thisdir.flat = level
         self.fm.thisdir.load_content()
 
+
+class reset_previews(Command):
+    """:reset_previews
+
+    Reset the file previews.
+    """
+    def execute(self):
+        self.fm.previews = {}
+        self.fm.ui.need_redraw = True
+
+
 # Version control commands
 # --------------------------------
 

--- a/ranger/core/actions.py
+++ b/ranger/core/actions.py
@@ -76,14 +76,6 @@ class Actions(  # pylint: disable=too-many-instance-attributes,too-many-public-m
         self.rifle.reload_config()
         self.fm.tags.sync()
 
-    def reset_previews(self):
-        """:reset_previews
-
-        Reset the file previews
-        """
-        self.fm.previews = {}
-        self.fm.ui.need_redraw = True
-
     def change_mode(self, mode=None):
         """:change_mode <mode>
 

--- a/ranger/core/actions.py
+++ b/ranger/core/actions.py
@@ -76,6 +76,14 @@ class Actions(  # pylint: disable=too-many-instance-attributes,too-many-public-m
         self.rifle.reload_config()
         self.fm.tags.sync()
 
+    def reset_previews(self):
+        """:reset_previews
+
+        Reset the file previews
+        """
+        self.fm.previews = {}
+        self.fm.ui.need_redraw = True
+
     def change_mode(self, mode=None):
         """:change_mode <mode>
 


### PR DESCRIPTION
This add a reset_previews command, which helps when switching preview_script
on-the-fly.

#### ISSUE TYPE
- Improvement/feature implementation

#### RUNTIME ENVIRONMENT
ranger version: ranger-master 1.9.2
Python version: 3.6.7 (default, Feb 28 2019, 08:33:23) [GCC 5.5.0]
Locale: en_GB.UTF-8

#### CHECKLIST

- [x] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [x] All changes follow the code style **[REQUIRED]**
- [x] All new and existing tests pass **[REQUIRED]**
- [ ] Changes require config files to be updated
    - [ ] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION

Add a new function 'reset_previews' to ranger/core/actions.py:

1. The previews are reset to {}
2. self.fm.ui.need_redraw is set to True

#### MOTIVATION AND CONTEXT

This new command means that ranger does not need a full reset when the preview_script is changed.

See: https://github.com/ranger/ranger/issues/1483 for more info.

#### TESTING
The preview_script has been set multiple times on-the-fly to different viewer scripts, and it appears to work well.

There are no affect on other areas that I am aware of.
