### PR TITLE
Fix crash when entering directories with invalid mtimes

### DIFF
--- a/ranger/gui/widgets/statusbar.py
+++ b/ranger/gui/widgets/statusbar.py
@@ -183,7 +183,11 @@ class StatusBar(Widget):  # pylint: disable=too-many-instance-attributes
                 left.add(target.infostring.replace(" ", ""))
                 left.add_space()
 
-            left.add(strftime(self.timeformat, localtime(stat.st_mtime)), 'mtime')
+            try:
+                date = strftime(self.timeformat, localtime(stat.st_mtime))
+            except OSError:
+                date = '?'
+            left.add(date, 'mtime')
 
         directory = target if target.is_directory else \
             target.fm.get_directory(os.path.dirname(target.path))


### PR DESCRIPTION
#### ISSUE TYPE
- Bug fix

#### RUNTIME ENVIRONMENT
- Operating system and version: 
- Terminal emulator and version: 
- Python version: 3.7.2
- Ranger version/commit: 6944156c3150f1fe4ad8d7d75965e17b72017cc0
- Locale: 

#### CHECKLIST
- [x] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [x] All changes follow the code style **[REQUIRED]**
- [x] All new and existing tests pass **[REQUIRED]**
- [ ] Changes require config files to be updated
    - [ ] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
Simply ignore the invalid mtime value instead of trying to convert it
to a date, which fails.

#### MOTIVATION AND CONTEXT
See #1020 

#### TESTING
Tried a FUSE filesystem that sometimes reports invalid mtimes.
