### PR TITLE
Fixing macro expansions and fixing #1466

### DIFF
--- a/ranger/core/actions.py
+++ b/ranger/core/actions.py
@@ -308,7 +308,7 @@ class Actions(  # pylint: disable=too-many-instance-attributes,too-many-public-m
         else:
             macros['f'] = MACRO_FAIL
 
-        if self.fm.thistab.get_selection:
+        if self.fm.thistab and self.fm.thistab.get_selection:
             macros['p'] = [os.path.join(self.fm.thisdir.path, fl.relative_path)
                            for fl in self.fm.thistab.get_selection()]
             macros['s'] = [fl.relative_path for fl in self.fm.thistab.get_selection()]
@@ -321,7 +321,7 @@ class Actions(  # pylint: disable=too-many-instance-attributes,too-many-public-m
         else:
             macros['c'] = MACRO_FAIL
 
-        if self.fm.thisdir.files:
+        if self.fm.thisdir and self.fm.thisdir.files:
             macros['t'] = [fl.relative_path for fl in self.fm.thisdir.files
                            if fl.realpath in self.fm.tags or []]
         else:
@@ -338,6 +338,9 @@ class Actions(  # pylint: disable=too-many-instance-attributes,too-many-public-m
                 tab = self.fm.tabs[i]
             except KeyError:
                 continue
+            if not tab:
+                continue
+
             tabdir = tab.thisdir
             if not tabdir:
                 continue
@@ -356,6 +359,13 @@ class Actions(  # pylint: disable=too-many-instance-attributes,too-many-public-m
                 macros[i + 'f'] = MACRO_FAIL
 
         # define D/F/P/S for the next tab
+
+        if not self.fm.tabs:
+            macros['D'] = MACRO_FAIL
+            macros['F'] = MACRO_FAIL
+            macros['S'] = MACRO_FAIL
+            return macros
+
         found_current_tab = False
         next_tab = None
         first_tab = None

--- a/ranger/core/fm.py
+++ b/ranger/core/fm.py
@@ -245,12 +245,16 @@ class FM(Actions,  # pylint: disable=too-many-instance-attributes
         return ImageDisplayer()
 
     def _get_thisfile(self):
+        if not self.thistab:
+            return None
         return self.thistab.thisfile
 
     def _set_thisfile(self, obj):
         self.thistab.thisfile = obj
 
     def _get_thisdir(self):
+        if not self.thistab:
+            return None
         return self.thistab.thisdir
 
     def _set_thisdir(self, obj):


### PR DESCRIPTION
Fix for #1466.

#### TYPE
- Improvement/feature implementation

#### RUNTIME ENVIRONMENT
- Debian GNU/Linux busterr/sid
- Urxvt 9.22
- Python 3.6.6 
- ranger-master 1.9.2  
- Locale: en_US.UTF-8

- [x] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [x] All changes follow the code style **[REQUIRED]**
- [x] All new and existing tests pass **[REQUIRED]**
- [ ] Changes require config files to be updated
    - [ ] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION


#### CHECKLIST
- [x ] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [ x] All changes follow the code style **[REQUIRED]**
- [ x] All new and existing tests pass **[REQUIRED]**
- [ ] Changes require config files to be updated
    - [ ] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
Several checks make sure that the needed parameters for the checked macros are actually there and are not None.

#### MOTIVATION AND CONTEXT
Without the changes in this PR, I am pretty sure that macros cannot be properly expanded while sourcing `rc.conf`. The problem in the original issue was that `%confdir` was need in `rc.conf` so that additional file in the configuration directory could be sourced. It's important to note that the bug comes into play while one needs maco WHILE sourcing the `rc.conf` and not later while calling some defined function (in form of a key binding)  in `rc.conf`.