### PR TITLE
Calculate the free space on remote filesystems correctly

### DIFF
--- a/ranger/gui/widgets/statusbar.py
+++ b/ranger/gui/widgets/statusbar.py
@@ -281,7 +281,7 @@ class StatusBar(Widget):  # pylint: disable=too-many-instance-attributes
             right.add(human_readable(target.disk_usage, separator='') + " sum")
             if self.settings.display_free_space_in_status_bar:
                 try:
-                    free = get_free_space(target.mount_path)
+                    free = get_free_space(target.path)
                 except OSError:
                     pass
                 else:


### PR DESCRIPTION
The remote filesystems report their mount path as the mount root even if they contain other mount points on the remote side.

Fixes #1505.