### PR TITLE
File accessibility can change after `stat`ing

### DIFF
--- a/ranger/config/commands.py
+++ b/ranger/config/commands.py
@@ -1774,7 +1774,7 @@ class linemode(default_linemode):
             mode = DEFAULT_LINEMODE
 
         if self.fm.thisfile is None or (mode not in
-            self.fm.thisfile.linemode_dict):
+                                        self.fm.thisfile.linemode_dict):
             self.fm.notify("Unhandled linemode: `%s'" % mode, bad=True)
             return
 

--- a/ranger/config/commands.py
+++ b/ranger/config/commands.py
@@ -1773,7 +1773,8 @@ class linemode(default_linemode):
             from ranger.core.linemode import DEFAULT_LINEMODE
             mode = DEFAULT_LINEMODE
 
-        if mode not in self.fm.thisfile.linemode_dict:
+        if self.fm.thisfile is None or (mode not in
+            self.fm.thisfile.linemode_dict):
             self.fm.notify("Unhandled linemode: `%s'" % mode, bad=True)
             return
 

--- a/ranger/container/directory.py
+++ b/ranger/container/directory.py
@@ -509,7 +509,6 @@ class Directory(  # pylint: disable=too-many-instance-attributes,too-many-public
     def unload(self):
         self.loading = False
         self.load_generator = None
-        self.loaded = False
 
     def load_content(self, schedule=None):
         """Loads the contents of the directory.

--- a/ranger/container/directory.py
+++ b/ranger/container/directory.py
@@ -509,6 +509,7 @@ class Directory(  # pylint: disable=too-many-instance-attributes,too-many-public
     def unload(self):
         self.loading = False
         self.load_generator = None
+        self.loaded = False
 
     def load_content(self, schedule=None):
         """Loads the contents of the directory.

--- a/ranger/container/directory.py
+++ b/ranger/container/directory.py
@@ -559,6 +559,13 @@ class Directory(  # pylint: disable=too-many-instance-attributes,too-many-public
                     pass
                 self.load_generator = None
 
+            encountered = False
+            for fsobj in self.fm.thistab.pathway:
+                if encountered:
+                    self.pointed_obj = fsobj
+                    break
+                encountered = (self == fsobj)
+
     def sort(self):
         """Sort the contained files"""
         if self.files_all is None:

--- a/ranger/container/directory.py
+++ b/ranger/container/directory.py
@@ -756,8 +756,10 @@ class Directory(  # pylint: disable=too-many-instance-attributes,too-many-public
         """The number of containing files"""
         assert self.accessible
         assert self.content_loaded
-        assert self.files is not None
-        return len(self.files)
+        try:
+            return len(self.files)
+        except TypeError:
+            return 0
 
     def __eq__(self, other):
         """Check for equality of the directories paths"""

--- a/ranger/container/directory.py
+++ b/ranger/container/directory.py
@@ -509,6 +509,7 @@ class Directory(  # pylint: disable=too-many-instance-attributes,too-many-public
     def unload(self):
         self.loading = False
         self.load_generator = None
+        self.content_loaded = False
         self.pointed_obj = None
         self.correct_pointer()
 

--- a/ranger/container/directory.py
+++ b/ranger/container/directory.py
@@ -357,9 +357,9 @@ class Directory(  # pylint: disable=too-many-instance-attributes,too-many-public
                         # PermissionError is undefined in python 2
                         if ex.errno == errno.EACCES:
                             self.accessible = False
+                            filelist = []
                         else:
                             raise
-                        filelist = []
                     filenames = [mypath + (mypath == '/' and fname or '/' + fname)
                                  for fname in filelist]
                     self.load_content_mtime = os.stat(mypath).st_mtime

--- a/ranger/container/fsobject.py
+++ b/ranger/container/fsobject.py
@@ -185,6 +185,8 @@ class FileSystemObject(  # pylint: disable=too-many-instance-attributes,too-many
             return getpwuid(self.stat.st_uid)[0]
         except KeyError:
             return str(self.stat.st_uid)
+        except AttributeError:
+            return BAD_INFO
 
     @lazy_property
     def group(self):
@@ -192,6 +194,8 @@ class FileSystemObject(  # pylint: disable=too-many-instance-attributes,too-many
             return getgrgid(self.stat.st_gid)[0]
         except KeyError:
             return str(self.stat.st_gid)
+        except AttributeError:
+            return BAD_INFO
 
     for attr in ('video', 'audio', 'image', 'media', 'document', 'container'):
         exec(  # pylint: disable=exec-used
@@ -347,15 +351,19 @@ class FileSystemObject(  # pylint: disable=too-many-instance-attributes,too-many
         else:
             perms = ['-']
 
-        mode = self.stat.st_mode
-        test = 0o0400
-        while test:  # will run 3 times because 0o400 >> 9 = 0
-            for what in "rwx":
-                if mode & test:
-                    perms.append(what)
-                else:
-                    perms.append('-')
-                test >>= 1
+        try:
+            mode = self.stat.st_mode
+        except AttributeError:
+            perms = BAD_INFO
+        else:
+            test = 0o0400
+            while test:  # will run 3 times because 0o400 >> 9 = 0
+                for what in "rwx":
+                    if mode & test:
+                        perms.append(what)
+                    else:
+                        perms.append('-')
+                    test >>= 1
 
         self.permissions = ''.join(perms)
         return self.permissions

--- a/ranger/container/fsobject.py
+++ b/ranger/container/fsobject.py
@@ -336,6 +336,7 @@ class FileSystemObject(  # pylint: disable=too-many-instance-attributes,too-many
         self.last_load_time = time()
 
     def get_permission_string(self):
+        self.load_if_outdated()
         if self.permissions is not None:
             return self.permissions
 

--- a/ranger/container/fsobject.py
+++ b/ranger/container/fsobject.py
@@ -72,7 +72,6 @@ class FileSystemObject(  # pylint: disable=too-many-instance-attributes,too-many
     exists = False  # "exists" currently means "link_target_exists"
     loaded = False
     marked = False
-    runnable = False
     stopped = False
     tagged = False
 

--- a/ranger/container/fsobject.py
+++ b/ranger/container/fsobject.py
@@ -179,7 +179,7 @@ class FileSystemObject(  # pylint: disable=too-many-instance-attributes,too-many
     def safe_basename(self):
         return self.basename.translate(_SAFE_STRING_TABLE)
 
-    @lazy_property
+    @property
     def user(self):
         try:
             return getpwuid(self.stat.st_uid)[0]
@@ -188,7 +188,7 @@ class FileSystemObject(  # pylint: disable=too-many-instance-attributes,too-many
         except AttributeError:
             return BAD_INFO
 
-    @lazy_property
+    @property
     def group(self):
         try:
             return getgrgid(self.stat.st_gid)[0]

--- a/ranger/core/actions.py
+++ b/ranger/core/actions.py
@@ -64,7 +64,8 @@ class Actions(  # pylint: disable=too-many-instance-attributes,too-many-public-m
     def reset(self):
         """:reset
 
-        Reset the filemanager, clearing the directory buffer, reload rifle config
+        Reset the filemanager, clearing the directory buffer, reload rifle
+        config
         """
         old_path = self.thisdir.path
         self.previews = {}

--- a/ranger/core/actions.py
+++ b/ranger/core/actions.py
@@ -813,6 +813,7 @@ class Actions(  # pylint: disable=too-many-instance-attributes,too-many-public-m
         return None
 
     def search_next(self, order=None, offset=1, forward=True):
+        # pylint:disable=too-many-branches
         original_order = order
 
         if order is None:
@@ -859,7 +860,10 @@ class Actions(  # pylint: disable=too-many-instance-attributes,too-many-public-m
                 elif order == 'mtime':
                     def fnc(item):
                         return -int(item.stat and item.stat.st_mtime)
-                lst.sort(key=fnc)
+                try:
+                    lst.sort(key=fnc)
+                except TypeError:
+                    pass
                 cwd.set_cycle_list(lst)
                 return cwd.cycle(forward=None)
 

--- a/ranger/core/actions.py
+++ b/ranger/core/actions.py
@@ -76,6 +76,7 @@ class Actions(  # pylint: disable=too-many-instance-attributes,too-many-public-m
             self.metadata.reset()
         self.rifle.reload_config()
         self.fm.tags.sync()
+        self.fm.ui.redraw_window()
 
     def change_mode(self, mode=None):
         """:change_mode <mode>

--- a/ranger/core/actions.py
+++ b/ranger/core/actions.py
@@ -840,7 +840,10 @@ class Actions(  # pylint: disable=too-many-instance-attributes,too-many-public-m
         elif order in ('size', 'mimetype', 'ctime', 'mtime', 'atime'):
             cwd = self.thisdir
             if original_order is not None or not cwd.cycle_list:
-                lst = list(cwd.files)
+                try:
+                    lst = list(cwd.files)
+                except TypeError:
+                    return None
                 if order == 'size':
                     def fnc(item):
                         return -item.size

--- a/ranger/core/fm.py
+++ b/ranger/core/fm.py
@@ -369,7 +369,6 @@ class FM(Actions,  # pylint: disable=too-many-instance-attributes
             if value.is_directory:
                 value.files = None
                 value.loaded = False
-                value.content_loaded = False
                 value.unload()
         self.settings.signal_garbage_collect()
         self.signal_garbage_collect()

--- a/ranger/core/fm.py
+++ b/ranger/core/fm.py
@@ -346,7 +346,12 @@ class FM(Actions,  # pylint: disable=too-many-instance-attributes
         try:
             return self.directories[path]
         except KeyError:
-            obj = Directory(path, **dir_kwargs)
+            obj = None
+            for fsobj in self.thistab.pathway:
+                if path == fsobj.path:
+                    obj = fsobj
+            if obj is None:
+                obj = Directory(path, **dir_kwargs)
             self.directories[path] = obj
             return obj
 

--- a/ranger/core/fm.py
+++ b/ranger/core/fm.py
@@ -363,6 +363,9 @@ class FM(Actions,  # pylint: disable=too-many-instance-attributes
             del self.directories[key]
             if value.is_directory:
                 value.files = None
+                value.loaded = False
+                value.content_loaded = False
+                value.unload()
         self.settings.signal_garbage_collect()
         self.signal_garbage_collect()
 

--- a/ranger/core/tab.py
+++ b/ranger/core/tab.py
@@ -131,7 +131,7 @@ class Tab(FileManagerAware, SettingsAware):  # pylint: disable=too-many-instance
         try:
             os.chdir(path)
         except OSError:
-            new_thisdir.load_content_if_outdated()
+            previous.load_content_if_outdated()
             return True
         self.path = path
         self.thisdir = new_thisdir

--- a/ranger/core/tab.py
+++ b/ranger/core/tab.py
@@ -131,6 +131,7 @@ class Tab(FileManagerAware, SettingsAware):  # pylint: disable=too-many-instance
         try:
             os.chdir(path)
         except OSError:
+            new_thisdir.load_content_if_outdated()
             return True
         self.path = path
         self.thisdir = new_thisdir

--- a/ranger/gui/widgets/browsercolumn.py
+++ b/ranger/gui/widgets/browsercolumn.py
@@ -87,7 +87,7 @@ class BrowserColumn(Pager):  # pylint: disable=too-many-instance-attributes
                 elif event.pressed(3):
                     try:
                         clicked_file = self.target.files[index]
-                    except IndexError:
+                    except (IndexError, TypeError):
                         pass
                     else:
                         if clicked_file.is_directory:


### PR DESCRIPTION
Catch errors due to inaccessibility of directories. We relied on
permissions not changing on directories between `stat`ing to determine
accessibility and first trying to list their contents.

Fixes #1537