### PR TITLE
Treat comics as documents

### DIFF
--- a/ranger/container/fsobject.py
+++ b/ranger/container/fsobject.py
@@ -31,10 +31,10 @@ CONTAINER_EXTENSIONS = ('7z', 'ace', 'ar', 'arc', 'bz', 'bz2', 'cab', 'cpio',
                         'cpt', 'deb', 'dgc', 'dmg', 'gz', 'iso', 'jar', 'msi',
                         'pkg', 'rar', 'shar', 'tar', 'tbz', 'tgz', 'txz',
                         'xar', 'xpi', 'xz', 'zip')
-DOCUMENT_EXTENSIONS = ('cfg', 'css', 'cvs', 'djvu', 'doc', 'docx', 'gnm',
-                       'gnumeric', 'htm', 'html', 'md', 'odf', 'odg', 'odp',
-                       'ods', 'odt', 'pdf', 'pod', 'ps', 'rtf', 'sxc', 'txt',
-                       'xls', 'xlw', 'xml', 'xslx')
+DOCUMENT_EXTENSIONS = ('cbr', 'cbz', 'cfg', 'css', 'cvs', 'djvu', 'doc',
+                       'docx', 'gnm', 'gnumeric', 'htm', 'html', 'md', 'odf',
+                       'odg', 'odp', 'ods', 'odt', 'pdf', 'pod', 'ps', 'rtf',
+                       'sxc', 'txt', 'xls', 'xlw', 'xml', 'xslx')
 DOCUMENT_BASENAMES = ('bugs', 'bugs', 'changelog', 'copying', 'credits',
                       'hacking', 'help', 'install', 'license', 'readme', 'todo')
 


### PR DESCRIPTION
Some comics are pdf files and therefore treated as documents, comic
archives like cbz aren't. This brings the two in line.