### PR TITLE
Change the = map

### DIFF
--- a/ranger/config/rc.conf
+++ b/ranger/config/rc.conf
@@ -461,7 +461,7 @@ map yn yank name
 map y. yank name_without_extension
 
 # Filesystem Operations
-map =  chmod
+map =  console chmod 000
 
 map cw console rename%space
 map a  rename_append


### PR DESCRIPTION
`=` (`:chmod` without an argument) made my ranger crash. The new mapping
opens the console with `:chmod 000<cursor>` this way it's easy to change
what permissions sets. It defaults to 000 because = in a chmod(1)
argument sets the mentioned bits and unsets all others, so `chmod =`
would unset all bits afaiu.