### PR TITLE
Fix quantifier check

### DIFF
--- a/ranger/config/commands.py
+++ b/ranger/config/commands.py
@@ -1028,8 +1028,9 @@ class chmod(Command):
     def execute(self):
         mode_str = self.rest(1)
         if not mode_str:
-            if not self.quantifier:
-                self.fm.notify("Syntax: chmod <octal number>", bad=True)
+            if self.quantifier is None:
+                self.fm.notify("Syntax: chmod <octal number> "
+                               "or specify a quantifier", bad=True)
                 return
             mode_str = str(self.quantifier)
 


### PR DESCRIPTION
`not self.quantifier` excluded `0`, which is a perfectly valid
quantifier for `chmod`.