### PR TITLE
Handle exception when requested path is not directory.

### DIFF
--- a/ranger/core/main.py
+++ b/ranger/core/main.py
@@ -104,6 +104,10 @@ def main(
             continue
         if not os.access(path_abs, os.F_OK):
             paths_inaccessible += [path]
+        if not os.path.isdir(path):
+            print('{} is not directory'.format(path),
+                  file=sys.stderr)
+            return 1
     if paths_inaccessible:
         print('Inaccessible paths: {0}'.format(', '.join(paths_inaccessible)),
               file=sys.stderr)


### PR DESCRIPTION
If requested path given in ranger args is not directory, it will cause following error:

```
$ LANG=C python3 ./ranger.py $(which cat)
ranger version: ranger-master v1.9.2-212-g5ae67755
Python version: 3.7.3rc1 (default, Mar 13 2019, 11:01:15) [GCC 8.3.0]
Locale: en_US.UTF-8

Traceback (most recent call last):
  File "/home/jubnzv/Dev/ranger/ranger/core/main.py", line 191, in main
    fm.loop()
  File "/home/jubnzv/Dev/ranger/ranger/core/fm.py", line 398, in loop
    ui.redraw()
  File "/home/jubnzv/Dev/ranger/ranger/gui/ui.py", line 341, in redraw
    self.draw()
  File "/home/jubnzv/Dev/ranger/ranger/gui/ui.py", line 370, in draw
    cwd = self.fm.thisdir.path
AttributeError: 'NoneType' object has no attribute 'path'

ranger crashed. Please report this traceback at:
https://github.com/ranger/ranger/issues

$ LANG=C python2 ./ranger.py $(which cat)
ranger version: ranger-master v1.9.2-212-g5ae67755
Python version: 2.7.16 (default, Apr  6 2019, 01:42:57) [GCC 8.3.0]
Locale: None.None

Traceback (most recent call last):
  File "/home/jubnzv/Dev/ranger/ranger/core/main.py", line 191, in main
    fm.loop()
  File "/home/jubnzv/Dev/ranger/ranger/core/fm.py", line 398, in loop
    ui.redraw()
  File "/home/jubnzv/Dev/ranger/ranger/gui/ui.py", line 341, in redraw
    self.draw()
  File "/home/jubnzv/Dev/ranger/ranger/gui/ui.py", line 370, in draw
    cwd = self.fm.thisdir.path
AttributeError: 'NoneType' object has no attribute 'path'

ranger crashed. Please report this traceback at:
https://github.com/ranger/ranger/issues
```

After this commit:
```
$ LANG=C python2 ./ranger.py $(which cat)                            
/bin/cat is not directory

$ LANG=C python3 ./ranger.py $(which cat)
/bin/cat is not directory
``` 

#### ISSUE TYPE
<!-- Pick relevant types and delete the rest -->
- Improvement

#### RUNTIME ENVIRONMENT
<!-- Details of your runtime environment -->
<!-- Retrieve Python/ranger version and locale with `ranger -\-version` -->
- Operating system and version: Debian testing
- Terminal emulator and version: 
- Python version: 3.7.3rc1, 2.7.16
- Ranger version/commit: 5ae67755cfa84177613b48a698b4ed58e9751fc4
- Locale: en_US.UTF-8