### PR TITLE
Scope no longer interferes with users' configuration

### DIFF
--- a/ranger/data/scope.sh
+++ b/ranger/data/scope.sh
@@ -36,8 +36,9 @@ FILE_EXTENSION_LOWER="$(printf "%s" "${FILE_EXTENSION}" | tr '[:upper:]' '[:lowe
 # Settings
 HIGHLIGHT_SIZE_MAX=262143  # 256KiB
 HIGHLIGHT_TABWIDTH=8
-HIGHLIGHT_STYLE='pablo'
-PYGMENTIZE_STYLE='autumn'
+HIGHLIGHT_STYLE=${HIGHLIGHT_STYLE:-pablo}
+HIGHLIGHT_OPTIONS="--style=${HIGHLIGHT_STYLE} ${HIGHLIGHT_OPTIONS:-}"
+PYGMENTIZE_STYLE=${PYGMENTIZE_STYLE:-autumn}
 
 
 handle_extension() {
@@ -228,9 +229,11 @@ handle_mime() {
                 local pygmentize_format='terminal'
                 local highlight_format='ansi'
             fi
-            highlight --replace-tabs="${HIGHLIGHT_TABWIDTH}" --out-format="${highlight_format}" \
-                --style="${HIGHLIGHT_STYLE}" --force -- "${FILE_PATH}" && exit 5
-            # pygmentize -f "${pygmentize_format}" -O "style=${PYGMENTIZE_STYLE}" -- "${FILE_PATH}" && exit 5
+            env HIGHLIGHT_OPTIONS="${HIGHLIGHT_OPTIONS}" highlight --replace-tabs="${HIGHLIGHT_TABWIDTH}" \
+                --out-format="${highlight_format}" \
+                --force -- "${FILE_PATH}" && exit 5
+            pygmentize -f "${pygmentize_format}" -O "style=${PYGMENTIZE_STYLE}"\
+                -- "${FILE_PATH}" && exit 5
             exit 2;;
 
         # DjVu


### PR DESCRIPTION
Our setup for syntax highlighting in `scope.sh` was actively preventing
people's configuration for `highlight` from working. Now
`HIGHLIGHT_OPTIONS` takes precendence over the default and over the
`HIGHLIGHT_STYLE` environment variable.

Users can specify `HIGHLIGHT_STYLE` or `PYGMENTIZE_STYLE` enviroment
variables now to customize the syntax coloring theme without having to
edit *and keep up to date* `scope.sh`.

Fixes #1556