### PR TITLE
Add ape extension to mime.types

### DIFF
--- a/ranger/data/mime.types
+++ b/ranger/data/mime.types
@@ -15,6 +15,7 @@ audio/musepack          mpc mpp mp+
 audio/ogg               oga ogg spx
 audio/wavpack           wv wvc
 audio/webm              weba
+audio/x-ape             ape
 
 video/mkv               mkv
 video/webm              webm


### PR DESCRIPTION
Python's mimetypes module apparently doesn't know about Monkey's Audio.