### PR TITLE
Add a multi-pane screenshot to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ out which program to use for what file type.
 
 ![screenshot](https://raw.githubusercontent.com/ranger/ranger-assets/master/screenshots/screenshot.png)
 
+For `mc` aficionados there's also the multi-pane viewmode.
+
+![multi-pane viewmode](https://raw.githubusercontent.com/ranger/ranger-assets/master/screenshots/multipane.png)
+
 This file describes ranger and how to get it to run.  For instructions on the
 usage, please read the man page (`man ranger` in a terminal).  See `HACKING.md`
 for development-specific information.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ out which program to use for what file type.
 
 For `mc` aficionados there's also the multi-pane viewmode.
 
-![multi-pane viewmode](https://raw.githubusercontent.com/ranger/ranger-assets/master/screenshots/multipane.png)
+![two panes](https://raw.githubusercontent.com/ranger/ranger-assets/master/screenshots/twopane.png) ![multi-pane viewmode](https://raw.githubusercontent.com/ranger/ranger-assets/master/screenshots/multipane.png)
 
 This file describes ranger and how to get it to run.  For instructions on the
 usage, please read the man page (`man ranger` in a terminal).  See `HACKING.md`

--- a/README.md
+++ b/README.md
@@ -15,7 +15,10 @@ out which program to use for what file type.
 
 For `mc` aficionados there's also the multi-pane viewmode.
 
-![two panes](https://raw.githubusercontent.com/ranger/ranger-assets/master/screenshots/twopane.png) ![multi-pane viewmode](https://raw.githubusercontent.com/ranger/ranger-assets/master/screenshots/multipane.png)
+<p>
+<img src="https://raw.githubusercontent.com/ranger/ranger-assets/master/screenshots/twopane.png" alt="two panes" width="49%" />
+<img src="https://raw.githubusercontent.com/ranger/ranger-assets/master/screenshots/multipane.png" alt="multiple panes" width="49%" />
+</p>
 
 This file describes ranger and how to get it to run.  For instructions on the
 usage, please read the man page (`man ranger` in a terminal).  See `HACKING.md`


### PR DESCRIPTION
The more effectively to tempt `mc` users over to the dark side with : )

As mentioned in #1557, the multi-pane viewmode may be a more important feature than we give it credit for, hence, let's highlight it in the README.