### PR TITLE
Open image displaying subprocesses in safe workdir

### DIFF
--- a/ranger/ext/img_display.py
+++ b/ranger/ext/img_display.py
@@ -75,6 +75,8 @@ class ImgDisplayUnsupportedException(Exception):
 class ImageDisplayer(object):
     """Image display provider functions for drawing images in the terminal"""
 
+    working_dir = os.environ.get('XDG_RUNTIME_DIR', os.path.expanduser("~") or None)
+
     def draw(self, path, start_x, start_y, width, height):
         """Draw an image at the given coordinates."""
         pass
@@ -106,7 +108,7 @@ class W3MImageDisplayer(ImageDisplayer, FileManagerAware):
         """start w3mimgdisplay"""
         self.binary_path = None
         self.binary_path = self._find_w3mimgdisplay_executable()  # may crash
-        self.process = Popen([self.binary_path] + W3MIMGDISPLAY_OPTIONS,
+        self.process = Popen([self.binary_path] + W3MIMGDISPLAY_OPTIONS, cwd=self.working_dir,
                              stdin=PIPE, stdout=PIPE, universal_newlines=True)
         self.is_initialized = True
 
@@ -696,7 +698,7 @@ class UeberzugImageDisplayer(ImageDisplayer):
                 and not self.process.stdin.closed):
             return
 
-        self.process = Popen(['ueberzug', 'layer', '--silent'],
+        self.process = Popen(['ueberzug', 'layer', '--silent'], cwd=self.working_dir,
                              stdin=PIPE, universal_newlines=True)
         self.is_initialized = True
 


### PR DESCRIPTION

<!-- Provide a descriptive summary of the changes in the title above -->

#### ISSUE TYPE
<!-- Pick relevant types and delete the rest -->
- Bug fix
- Improvement

#### RUNTIME ENVIRONMENT
See #1565.

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [x] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [x] All changes follow the code style **[REQUIRED]**
- [x] All new and existing tests pass **[REQUIRED]** (pylint fails internally)
  *No tests were added.*
- [ ] Changes require config files to be updated
    - [ ] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION

Prevent lingering file handles to the working directory of ranger when the first image is being previewed with w3m or ueberzug.

Fixes #1565 .


#### MOTIVATION AND CONTEXT
<!-- Why are these changes required? -->
<!-- What problems do these changes solve? -->
<!-- Link to relevant issues -->


#### TESTING

1. Mount a drive.
2. Open a new ranger process at (or cd to it) `/data_win10/Images`, which contains a single image file that was then being previewed by ueberzug.
3. `gh` in ranger to change the working dir to $HOME (ranger must remain open)
4. attempt to unmount / show lsof output

```
~/code/ranger ∇ sudo mount /data_win10
[sudo] password for fichte:

~/code/ranger ∇ ls -l /proc/27442/cwd
lrwxrwxrwx 0 fichte 2019-05-22 21:56 /proc/27442/cwd -> /data_win10/Images/Screenshots

~/code/ranger Ξ lsof /data_win10
COMMAND    PID   USER   FD   TYPE DEVICE SIZE/OFF NODE NAME
ueberzug 27442 fichte  cwd    DIR   8,20        0  312 /data_win10/Images/Screenshots

~/code/ranger ∀ sudo umount /data_win10
umount: /data_win10: target is busy.
 ?=32
```

With the fix and the same procedure:

```
~/code/ranger > sudo mount /data_win10

~/code/ranger Σ ls -l /proc/30839/cwd
lrwxrwxrwx 0 fichte 2019-05-22 21:59 /proc/30839/cwd -> /run/user/1000

~/code/ranger Λ lsof /data_win10
 ?=1
~/code/ranger Δ sudo umount /data_win10
```