### PR TITLE
Treat KP_ENTER the same regardless of Num Lock state

### DIFF
--- a/ranger/gui/ui.py
+++ b/ranger/gui/ui.py
@@ -240,6 +240,8 @@ class UI(  # pylint: disable=too-many-instance-attributes,too-many-public-method
 
     def handle_input(self):
         key = self.win.getch()
+        if key == curses.KEY_ENTER:
+            key = ord('\n')
         if key == 27 or (key >= 128 and key < 256):
             # Handle special keys like ALT+X or unicode here:
             keys = [key]


### PR DESCRIPTION
KP_ENTER is only treated as newline by curses when Num Lock is on.
This, like anything involving Num Lock, is confusing and has therefore
been dealt with : )

Fixes #1568