### PR TITLE
Added the ability to escape ';' delimiters used by the 'chain' command with a '\'.

### DIFF
--- a/ranger/config/commands.py
+++ b/ranger/config/commands.py
@@ -283,11 +283,30 @@ class chain(Command):
     Calls multiple commands at once, separated by semicolons.
     """
 
+    def _split(self, text):
+        result = []
+        token = ''
+        state = 0
+        for c in text:
+            if state == 0:
+                if c == '\\':
+                    state = 1
+                elif c == ';':
+                    result.append(token)
+                    token = ''
+                else:
+                    token += c
+            elif state == 1:
+                token += c
+                state = 0
+        result.append(token)
+        return result
+
     def execute(self):
         if not self.rest(1).strip():
             self.fm.notify('Syntax: chain <command1>; <command2>; ...', bad=True)
             return
-        for command in [s.strip() for s in self.rest(1).split(";")]:
+        for command in [s.strip() for s in self._split(self.rest(1))]:
             self.fm.execute_console(command)
 
 


### PR DESCRIPTION
#### ISSUE TYPE
- Bug fix
- Improvement/feature implementation

#### RUNTIME ENVIRONMENT
- Operating system and version: Arch Linux
- Terminal emulator and version: urxvt v9.22
- Python version: 3.7.3 (default, Mar 26 2019, 21:43:19) [GCC 8.2.1 20181127]
- Ranger version/commit: 1.9.2
- Locale: en_AU.UTF-8

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [X] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [X] All changes follow the code style **[REQUIRED]**
- [ ] All new and existing tests pass **[REQUIRED]**
- [X] Changes require config files to be updated
    - [X] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
The proposed patch allows the chain command's semi-colon delimiters to be escape with a backslash.


#### MOTIVATION AND CONTEXT
The proposed change addresses a important design flaw, in which a large number of commands cannot be given as arguments to a chain command. Examples include; renaming files with semi-colons, shell commands including semi-colons, etc.


#### TESTING
I attempted to run `make test` on my current machine, but it fails with the runtime exception `StopIteration`. Not sure if it's associated with #1244, but I wasn't able to successfully run the tests even with the current master branch and no changes. Whilst I couldn't run the automated tests, I did test the `chain` command with numerous possible inputs. The change is so small, doesn't affect the rest of the codebase, and is unlikely to fail the automated tests.