### PR TITLE
fix to call git describe in ranger's source directory

### DIFF
--- a/ranger/__init__.py
+++ b/ranger/__init__.py
@@ -23,6 +23,7 @@ def version_helper():
         try:
             git_describe = subprocess.Popen(['git', 'describe'],
                                             universal_newlines=True,
+                                            cwd=RANGERDIR,
                                             stdout=subprocess.PIPE)
             (git_description, _) = git_describe.communicate()
             version_string = version_string.format(git_description.strip('\n'))


### PR DESCRIPTION
Fixes ranger calling `git describe` in cwd instead of ranger's source directory.

#### ISSUE TYPE
<!-- Pick relevant types and delete the rest -->
- Bug fix

#### RUNTIME ENVIRONMENT
<!-- Details of your runtime environment -->
<!-- Retrieve Python/ranger version and locale with `ranger -\-version` -->
- Operating system and version: archlinux 5.1.6-arch1-1-ARCH x86_64
- Terminal emulator and version: rxvt-unicode
- Python version: 3.7.3
- Ranger version/commit: ranger-master v1.9.2-234-g2dad0b8
- Locale: en_US.UTF-8

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [X] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [X] All changes follow the code style **[REQUIRED]**
- [X] All new and existing tests pass **[REQUIRED]**
- [ ] Changes require config files to be updated
    - [ ] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
This patch changes the `version_helper()` function in `__init__.py` to specify the cwd parameter as ranger's source directory.


#### MOTIVATION AND CONTEXT
Ranger currently calls `git describe` in cwd, leading to git error messages as described in https://github.com/ranger/ranger/issues/1577.


#### TESTING
This patch passes `make test`, but I highly doubt it would break anything.