### PR TITLE
Fix Python3 image preview in iTerm2

### DIFF
--- a/ranger/ext/img_display.py
+++ b/ranger/ext/img_display.py
@@ -308,7 +308,7 @@ class ITerm2ImageDisplayer(ImageDisplayer, FileManagerAware):
     def _encode_image_content(path):
         """Read and encode the contents of path"""
         with open(path, 'rb') as fobj:
-            return base64.b64encode(fobj.read())
+            return base64.b64encode(fobj.read()).decode('utf-8')
 
     @staticmethod
     def _get_image_dimensions(path):


### PR DESCRIPTION
Fixes image previews in iTerm2 when using Python3. See #1600 for some additional information.

#### ISSUE TYPE
<!-- Pick relevant types and delete the rest -->
- Bug fix

#### Runtime Environment

    Operating system and version:
    MacOS Sierra - 10.12.6
    Terminal emulator and version:
    iTerm2 - Build 3.3.0beta12
    Python version:
    Python 3.6.4 
    Type "help", "copyright", "credits" or "license" for more information.
    Ranger version/commit: 1.9.2


#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [x] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [x] All changes follow the code style **[REQUIRED]**
- [x] All new and existing tests pass **[REQUIRED]**

<img width="1680" alt="Screen Shot 2019-06-20 at 3 04 34 AM" src="https://user-images.githubusercontent.com/1813121/59836124-39305100-9308-11e9-85e7-ca94d1c45360.png">


#### DESCRIPTION

I compared the output in the function that generates the image, of Python2 and Python3 versions of ranger. I found that the output of the `_encode_base_image` returned a bytestring. This was being string interpolated into a string. In Python2, this will result in an implicit conversion of the bytestring to a unicode string and will be interpolated into a unicode string. In Python3, this will result in the representation of the bytestring interpolated into the unicode string. See following example for differences between Python2 and Python3:

<img width="795" alt="Screen Shot 2019-06-20 at 3 12 02 AM" src="https://user-images.githubusercontent.com/1813121/59836822-76491300-9309-11e9-92df-2c8de013e820.png">

The fix that I issued in this case is to decode the base image from a bytestring to a unicode string. This will do the right thing in Python2 and Python3.

<img width="795" alt="Screen Shot 2019-06-20 at 3 17 39 AM" src="https://user-images.githubusercontent.com/1813121/59837192-10a95680-930a-11e9-8493-eb5847e4876d.png">

There's probably other places this change needs to be made as well but this is the only environment I'm able to test on.

Additionally, I'm not sure if decoding the bytestring from utf-8 to a unicode string is the right thing to do. Maybe it should be `.decode('ascii')` instead? Let me know what you think.
