### PR TITLE
Decode bytes into str for image display of iTerm2

### DIFF
--- a/ranger/ext/img_display.py
+++ b/ranger/ext/img_display.py
@@ -308,7 +308,10 @@ class ITerm2ImageDisplayer(ImageDisplayer, FileManagerAware):
     def _encode_image_content(path):
         """Read and encode the contents of path"""
         with open(path, 'rb') as fobj:
-            return base64.b64encode(fobj.read())
+            r = base64.b64encode(fobj.read())
+            if isinstance(r, bytes):
+                r = r.decode('utf-8')
+            return r
 
     @staticmethod
     def _get_image_dimensions(path):


### PR DESCRIPTION
`base64.b64encode()` returns bytes in Python 3. We need to decode bytes into str to make image display for iTerm2 works under Python 3. This would fix #1546
