### PR TITLE
zathura has been added as epub viewer

### DIFF
--- a/ranger/config/rifle.conf
+++ b/ranger/config/rifle.conf
@@ -167,6 +167,7 @@ ext djvu, has atril,  X, flag f = atril -- "$@"
 ext djvu, has djview, X, flag f = djview -- "$@"
 
 ext epub, has ebook-viewer, X, flag f = ebook-viewer -- "$@"
+ext epub, has zathura,      X, flag f = zathura -- "$@"
 ext mobi, has ebook-viewer, X, flag f = ebook-viewer -- "$@"
 
 #-------------------------------------------

--- a/ranger/config/rifle.conf
+++ b/ranger/config/rifle.conf
@@ -167,8 +167,8 @@ ext djvu, has atril,  X, flag f = atril -- "$@"
 ext djvu, has djview, X, flag f = djview -- "$@"
 
 ext epub, has ebook-viewer, X, flag f = ebook-viewer -- "$@"
-ext epub, has mupdf,        X, flag f = mupdf -- "$@"
 ext epub, has zathura,      X, flag f = zathura -- "$@"
+ext epub, has mupdf,        X, flag f = mupdf -- "$@"
 ext mobi, has ebook-viewer, X, flag f = ebook-viewer -- "$@"
 
 ext cbr,  has zathura,      X, flag f = zathura -- "$@"

--- a/ranger/config/rifle.conf
+++ b/ranger/config/rifle.conf
@@ -171,6 +171,9 @@ ext epub, has mupdf,        X, flag f = mupdf -- "$@"
 ext epub, has zathura,      X, flag f = zathura -- "$@"
 ext mobi, has ebook-viewer, X, flag f = ebook-viewer -- "$@"
 
+ext cbr,  has zathura,      X, flag f = zathura -- "$@"
+ext cbz,  has zathura,      X, flag f = zathura -- "$@"
+
 #-------------------------------------------
 # Images
 #-------------------------------------------

--- a/ranger/config/rifle.conf
+++ b/ranger/config/rifle.conf
@@ -167,6 +167,7 @@ ext djvu, has atril,  X, flag f = atril -- "$@"
 ext djvu, has djview, X, flag f = djview -- "$@"
 
 ext epub, has ebook-viewer, X, flag f = ebook-viewer -- "$@"
+ext epub, has mupdf,        X, flag f = mupdf -- "$@"
 ext epub, has zathura,      X, flag f = zathura -- "$@"
 ext mobi, has ebook-viewer, X, flag f = ebook-viewer -- "$@"
 


### PR DESCRIPTION
Adds support for opening `epub` ebook files and `cbr/cbz` comicbook files with [`zathura`](https://github.com/pwmt/zathura).
Adds support for opening `epub` ebook files with `mupdf`.

#### ISSUE TYPE

- Improvement/feature implementation

#### RUNTIME ENVIRONMENT

- Operating system and version: Arch Linux; latest `-Syu` as of a few hours ago
- Terminal emulator and version: urxvt 9.22
- Python version: Python 3.7.3
- Ranger version/commit: ranger 1.9.2
- Locale: en_US.UTF-8
 
#### CHECKLIST

- [x]  The `CONTRIBUTING` document has been read **[REQUIRED]**
- [x]  All changes follow the code style **[REQUIRED]**
- [x]  All new and existing tests pass **[REQUIRED]**
- [ ]  Changes require config files to be updated
- [ ]  Config files have been updated
- [ ]  Changes require documentation to be updated
- [ ]  Documentation has been updated
- [ ]  Changes require tests to be updated
- [ ]  Tests have been updated

 #### DESCRIPTION
 
Adds an entry for `zathura` to `rifle.conf`’s list of epub/cbr/cbz viewers.
Adds an entry for `mupdf` to `rifle.conf`'s list of epub viewers.

 #### MOTIVATION AND CONTEXT
 
Zathura is a minimalist document viewer. It also supports epub and cbr/cbz files. epub is a common ebook format and cbr/cbz is a common comicbook format. This adds support built-in support for opening such files with zathura from ranger.

#### TESTING
 
I made the modification to `~/.config/ranger/rifle.conf` first and tested it in action. No automated tests were written or run for this change.

