### PR TITLE
support wayland condition for rifle

### DIFF
--- a/ranger/config/rifle.conf
+++ b/ranger/config/rifle.conf
@@ -27,6 +27,8 @@
 #   number <n>     | change the number of this command to n
 #   terminal       | stdin, stderr and stdout are connected to a terminal
 #   X              | $DISPLAY is not empty (i.e. Xorg runs)
+#   W              | $WAYLAND_DISPLAY is not empty (i.e. Wayland runs)
+#   XW or WX       | Wayland OR Xorg runs
 #
 # There are also pseudo-conditions which have a "side effect":
 #   flag <flags>  | Change how the program is run. See below.
@@ -70,7 +72,7 @@ ext x?html?, has chromium-browser, X, flag f = chromium-browser -- "$@"
 ext x?html?, has chromium,         X, flag f = chromium -- "$@"
 ext x?html?, has google-chrome,    X, flag f = google-chrome -- "$@"
 ext x?html?, has opera,            X, flag f = opera -- "$@"
-ext x?html?, has firefox,          X, flag f = firefox -- "$@"
+ext x?html?, has firefox,          XW, flag f = firefox -- "$@"
 ext x?html?, has seamonkey,        X, flag f = seamonkey -- "$@"
 ext x?html?, has iceweasel,        X, flag f = iceweasel -- "$@"
 ext x?html?, has epiphany,         X, flag f = epiphany -- "$@"

--- a/ranger/config/rifle.conf
+++ b/ranger/config/rifle.conf
@@ -26,9 +26,7 @@
 #   directory      | $1 is a directory
 #   number <n>     | change the number of this command to n
 #   terminal       | stdin, stderr and stdout are connected to a terminal
-#   X              | $DISPLAY is not empty (i.e. Xorg runs)
-#   W              | $WAYLAND_DISPLAY is not empty (i.e. Wayland runs)
-#   XW or WX       | Wayland OR Xorg runs
+#   X              | A graphical environment is available (darwin, Xorg, or Wayland)
 #
 # There are also pseudo-conditions which have a "side effect":
 #   flag <flags>  | Change how the program is run. See below.
@@ -72,7 +70,7 @@ ext x?html?, has chromium-browser, X, flag f = chromium-browser -- "$@"
 ext x?html?, has chromium,         X, flag f = chromium -- "$@"
 ext x?html?, has google-chrome,    X, flag f = google-chrome -- "$@"
 ext x?html?, has opera,            X, flag f = opera -- "$@"
-ext x?html?, has firefox,          XW, flag f = firefox -- "$@"
+ext x?html?, has firefox,          X, flag f = firefox -- "$@"
 ext x?html?, has seamonkey,        X, flag f = seamonkey -- "$@"
 ext x?html?, has iceweasel,        X, flag f = iceweasel -- "$@"
 ext x?html?, has epiphany,         X, flag f = epiphany -- "$@"

--- a/ranger/core/runner.py
+++ b/ranger/core/runner.py
@@ -214,7 +214,7 @@ class Runner(object):  # pylint: disable=too-few-public-methods
             toggle_ui = True
             context.wait = True
         if 't' in context.flags:
-            if 'DISPLAY' not in os.environ:
+            if 'DISPLAY' not in os.environ and 'WAYLAND_DISPLAY' not in os.environ:
                 return self._log("Can not run with 't' flag, no display found!")
             term = get_term()
             if isinstance(action, str):

--- a/ranger/core/runner.py
+++ b/ranger/core/runner.py
@@ -214,7 +214,7 @@ class Runner(object):  # pylint: disable=too-few-public-methods
             toggle_ui = True
             context.wait = True
         if 't' in context.flags:
-            if 'DISPLAY' not in os.environ and 'WAYLAND_DISPLAY' not in os.environ:
+            if not ('WAYLAND_DISPLAY' in os.environ or sys.platform == 'darwin' or 'DISPLAY' in os.environ):
                 return self._log("Can not run with 't' flag, no display found!")
             term = get_term()
             if isinstance(action, str):

--- a/ranger/ext/rifle.py
+++ b/ranger/ext/rifle.py
@@ -236,8 +236,13 @@ class Rifle(object):  # pylint: disable=too-many-instance-attributes
         elif function == 'flag':
             self._app_flags = argument
             return True
-        elif function == 'X':
-            return sys.platform == 'darwin' or 'DISPLAY' in os.environ
+        elif function.isupper():
+            if 'X' in function and 'W' in function:
+                return 'WAYLAND_DISPLAY' in os.environ or sys.platform == 'darwin' or 'DISPLAY' in os.environ
+            elif 'X' in function:
+                return sys.platform == 'darwin' or 'DISPLAY' in os.environ
+            elif 'W' in function:
+                return 'WAYLAND_DISPLAY' in os.environ
         elif function == 'env':
             return bool(os.environ.get(argument))
         elif function == 'else':

--- a/ranger/ext/rifle.py
+++ b/ranger/ext/rifle.py
@@ -236,13 +236,8 @@ class Rifle(object):  # pylint: disable=too-many-instance-attributes
         elif function == 'flag':
             self._app_flags = argument
             return True
-        elif function.isupper():
-            if 'X' in function and 'W' in function:
-                return 'WAYLAND_DISPLAY' in os.environ or sys.platform == 'darwin' or 'DISPLAY' in os.environ
-            elif 'X' in function:
-                return sys.platform == 'darwin' or 'DISPLAY' in os.environ
-            elif 'W' in function:
-                return 'WAYLAND_DISPLAY' in os.environ
+        elif function == 'X':
+            return 'WAYLAND_DISPLAY' in os.environ or sys.platform == 'darwin' or 'DISPLAY' in os.environ
         elif function == 'env':
             return bool(os.environ.get(argument))
         elif function == 'else':


### PR DESCRIPTION
Expands `X` and `t` flags to support Wayland as a graphical environment (to add to the current checks for darwin and Xorg).

fixes #1635

#### ISSUE TYPE
<!-- Pick relevant types and delete the rest -->
- Improvement/feature implementation
- Breaking changes (backwards compatible, but the XW condition in rifle.conf is not backwards compatible

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [x] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [x] All changes follow the code style **[REQUIRED]**
- [x] All new and existing tests pass **[REQUIRED]**
- [ ] Changes require config files to be updated
    - [ ] Config files have been updated
- [x] Changes require documentation to be updated
    - [x] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION

~This introduces the extra `W` condition. This checks if
`WAYLAND_DISPLAY` is set. It can be used with the `X` condition to mean
"X or Wayland is available". For example:~

```
# firefox supports X and wayland
ext x?html?, has firefox,          XW, flag f = firefox -- "$@"
# example program that only runs on wayland
ext test, has example,          W = example -- "$@"
# backwards compatible (just X still works)
ext x?html?, has chromium,       X, flag f = chromium -- "$@"
```


#### MOTIVATION AND CONTEXT

This is to support users running wayland. Users may be running pure
wayland (without xwayland available), or with xwayland for running
X-only applications within wayland. The `X` condition is not enough to
neatly support these scenarios without needing to add duplicate entries
to rifle.conf

#### TESTING

Manually verified this. Did not add unit tests as there are no existing
tests found for the `X` condition behaviour.