### PR TITLE
Add image/webp to known mimetypes

### DIFF
--- a/ranger/data/mime.types
+++ b/ranger/data/mime.types
@@ -17,6 +17,8 @@ audio/wavpack           wv wvc
 audio/webm              weba
 audio/x-ape             ape
 
+image/webp              webp
+
 video/mkv               mkv
 video/webm              webm
 video/flash             flv


### PR DESCRIPTION
<!-- Provide a descriptive summary of the changes in the title above -->

#### ISSUE TYPE
<!-- Pick relevant types and delete the rest -->
- Improvement/feature implementation

#### RUNTIME ENVIRONMENT
<!-- Details of your runtime environment -->
<!-- Retrieve Python/ranger version and locale with `ranger -\-version` -->
- Operating system and version: Linux (NixOS unstable)
- Ranger version/commit: 1.9.2

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [X] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [X] All changes follow the code style **[REQUIRED]**
- [X] All new and existing tests pass **[REQUIRED]**

#### DESCRIPTION
<!-- Describe the changes in detail -->

Ranger now identifies WebP images as having the MIME type of `image/webp`.

#### MOTIVATION AND CONTEXT
<!-- Why are these changes required? -->
<!-- What problems do these changes solve? -->
<!-- Link to relevant issues -->

WebP is new enough that Python's `mimetypes.guess_type` did not identify them, which meant the `.image` property on `FileSystemObject` was incorrectly set to `False`. This breaks functionality like the `open_all_images` setting.

#### TESTING
<!-- What tests have been run? -->
<!-- How does the changes affect other areas of the codebase? -->

Ranger now identifies `.webp` files as images, and `open_all_images` with sxiv works as expected on directories full of WebP images.