### PR TITLE
Make the wiki more visible

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,4 +154,4 @@ Community
 ---------------
 For help, support, or if you just want to hang out with us, you can find us here:
 * **IRC**: channel **#ranger** on [freenode](https://freenode.net/kb/answer/chat)
-* **Subreddit**: [r/ranger](https://www.reddit.com/r/ranger/)
+* **Reddit**: [r/ranger](https://www.reddit.com/r/ranger/)

--- a/README.md
+++ b/README.md
@@ -141,3 +141,10 @@ Ranger can automatically copy default configuration files to `~/.config/ranger`
 if you run it with the switch `--copy-config=( rc | scope | ... | all )`.
 See `ranger --help` for a description of that switch.  Also check
 `ranger/config/` for the default configuration.
+
+
+Going further
+---------------
+For learning how to efficiently use ranger, see the [official user guide](https://github.com/ranger/ranger/wiki/Official-user-guide).
+
+For more information, see the [wiki](https://github.com/ranger/ranger/wiki).

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ About
 * git clone    https://github.com/ranger/ranger.git
 
 
-Design Goals
+Design goals
 ------------
 * An easily maintainable file manager in a high level language
 * A quick way to switch directories and browse the file system
@@ -130,7 +130,7 @@ This also saves a list of all installed files to `install_log.txt`, which you ca
 use to uninstall ranger.
 
 
-Getting Started
+Getting started
 ---------------
 After starting ranger, you can use the Arrow Keys or `h` `j` `k` `l` to
 navigate, `Enter` to open a file or `q` to quit.  The third column shows a

--- a/README.md
+++ b/README.md
@@ -148,3 +148,10 @@ Going further
 * To get the most out of ranger, read the [Official User Guide](https://github.com/ranger/ranger/wiki/Official-user-guide).
 * For frequently asked questions, see the [FAQ](https://github.com/ranger/ranger/wiki/FAQ%3A-Frequently-Asked-Questions).
 * For more information on customization, see the [wiki](https://github.com/ranger/ranger/wiki).
+
+
+Community
+---------------
+For help, support, or if you just want to hang out with us, you can find us here:
+* **IRC channel**: channel **#ranger** on [freenode](https://freenode.net/kb/answer/chat)
+* **Subreddit**: [r/ranger](https://www.reddit.com/r/ranger/)

--- a/README.md
+++ b/README.md
@@ -147,4 +147,6 @@ Going further
 ---------------
 For getting the most out of ranger, see the [official user guide](https://github.com/ranger/ranger/wiki/Official-user-guide).
 
+For frequently asked questions, see the [FAQ](https://github.com/ranger/ranger/wiki/FAQ%3A-Frequently-Asked-Questions).
+
 For more information on customization, see the [wiki](https://github.com/ranger/ranger/wiki).

--- a/README.md
+++ b/README.md
@@ -145,6 +145,6 @@ See `ranger --help` for a description of that switch.  Also check
 
 Going further
 ---------------
-* For getting the most out of ranger, see the [Official User Guide](https://github.com/ranger/ranger/wiki/Official-user-guide).
+* To get the most out of ranger, read the [Official User Guide](https://github.com/ranger/ranger/wiki/Official-user-guide).
 * For frequently asked questions, see the [FAQ](https://github.com/ranger/ranger/wiki/FAQ%3A-Frequently-Asked-Questions).
 * For more information on customization, see the [wiki](https://github.com/ranger/ranger/wiki).

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ You can also install ranger through PyPI: ```pip install ranger-fm```.
   </a>
 </details>
 
-### Installing from a Clone
+### Installing from a clone
 Note that you don't *have* to install ranger; you can simply run `ranger.py`.
 
 To install ranger manually:

--- a/README.md
+++ b/README.md
@@ -145,8 +145,6 @@ See `ranger --help` for a description of that switch.  Also check
 
 Going further
 ---------------
-For getting the most out of ranger, see the [Official User Guide](https://github.com/ranger/ranger/wiki/Official-user-guide).
-
-For frequently asked questions, see the [FAQ](https://github.com/ranger/ranger/wiki/FAQ%3A-Frequently-Asked-Questions).
-
-For more information on customization, see the [Wiki](https://github.com/ranger/ranger/wiki).
+* For getting the most out of ranger, see the [Official User Guide](https://github.com/ranger/ranger/wiki/Official-user-guide).
+* For frequently asked questions, see the [FAQ](https://github.com/ranger/ranger/wiki/FAQ%3A-Frequently-Asked-Questions).
+* For more information on customization, see the [Wiki](https://github.com/ranger/ranger/wiki).

--- a/README.md
+++ b/README.md
@@ -147,4 +147,4 @@ Going further
 ---------------
 For getting the most out of ranger, see the [official user guide](https://github.com/ranger/ranger/wiki/Official-user-guide).
 
-For more information, see the [wiki](https://github.com/ranger/ranger/wiki).
+For more information on customization, see the [wiki](https://github.com/ranger/ranger/wiki).

--- a/README.md
+++ b/README.md
@@ -145,8 +145,8 @@ See `ranger --help` for a description of that switch.  Also check
 
 Going further
 ---------------
-For getting the most out of ranger, see the [official user guide](https://github.com/ranger/ranger/wiki/Official-user-guide).
+For getting the most out of ranger, see the [Official User Guide](https://github.com/ranger/ranger/wiki/Official-user-guide).
 
 For frequently asked questions, see the [FAQ](https://github.com/ranger/ranger/wiki/FAQ%3A-Frequently-Asked-Questions).
 
-For more information on customization, see the [wiki](https://github.com/ranger/ranger/wiki).
+For more information on customization, see the [Wiki](https://github.com/ranger/ranger/wiki).

--- a/README.md
+++ b/README.md
@@ -147,4 +147,4 @@ Going further
 ---------------
 * For getting the most out of ranger, see the [Official User Guide](https://github.com/ranger/ranger/wiki/Official-user-guide).
 * For frequently asked questions, see the [FAQ](https://github.com/ranger/ranger/wiki/FAQ%3A-Frequently-Asked-Questions).
-* For more information on customization, see the [Wiki](https://github.com/ranger/ranger/wiki).
+* For more information on customization, see the [wiki](https://github.com/ranger/ranger/wiki).

--- a/README.md
+++ b/README.md
@@ -145,6 +145,6 @@ See `ranger --help` for a description of that switch.  Also check
 
 Going further
 ---------------
-For learning how to efficiently use ranger, see the [official user guide](https://github.com/ranger/ranger/wiki/Official-user-guide).
+For getting the most out of ranger, see the [official user guide](https://github.com/ranger/ranger/wiki/Official-user-guide).
 
 For more information, see the [wiki](https://github.com/ranger/ranger/wiki).

--- a/README.md
+++ b/README.md
@@ -153,5 +153,5 @@ Going further
 Community
 ---------------
 For help, support, or if you just want to hang out with us, you can find us here:
-* **IRC channel**: channel **#ranger** on [freenode](https://freenode.net/kb/answer/chat)
+* **IRC**: channel **#ranger** on [freenode](https://freenode.net/kb/answer/chat)
 * **Subreddit**: [r/ranger](https://www.reddit.com/r/ranger/)

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ About
 * git clone    https://github.com/ranger/ranger.git
 
 
-Design goals
+Design Goals
 ------------
 * An easily maintainable file manager in a high level language
 * A quick way to switch directories and browse the file system
@@ -113,7 +113,7 @@ You can also install ranger through PyPI: ```pip install ranger-fm```.
   </a>
 </details>
 
-### Installing from a clone
+### Installing from a Clone
 Note that you don't *have* to install ranger; you can simply run `ranger.py`.
 
 To install ranger manually:
@@ -130,7 +130,7 @@ This also saves a list of all installed files to `install_log.txt`, which you ca
 use to uninstall ranger.
 
 
-Getting started
+Getting Started
 ---------------
 After starting ranger, you can use the Arrow Keys or `h` `j` `k` `l` to
 navigate, `Enter` to open a file or `q` to quit.  The third column shows a
@@ -143,7 +143,7 @@ See `ranger --help` for a description of that switch.  Also check
 `ranger/config/` for the default configuration.
 
 
-Going further
+Going Further
 ---------------
 * To get the most out of ranger, read the [Official User Guide](https://github.com/ranger/ranger/wiki/Official-user-guide).
 * For frequently asked questions, see the [FAQ](https://github.com/ranger/ranger/wiki/FAQ%3A-Frequently-Asked-Questions).


### PR DESCRIPTION
Hello,

The goal of this PR is to make the wiki more visible.

To do this, I've added a 'Going further' section at the end of `README.md` which mentions the [Official User Guide](https://github.com/ranger/ranger/wiki/Official-User-Guide), the [FAQ](https://github.com/ranger/ranger/wiki/FAQ%3A-Frequently-Asked-Questions), and the [wiki](https://github.com/ranger/ranger/wiki).  The FAQ isn't too furnished, but having it on `README.md` might incentivise us to improve it.

This was prompted by two things:
1. Based on my experience, people do not have the habit of checking out the wiki on GitHub pages, especially when they're not used to GitHub.
2. People often ask us questions about the image-previews over at `#ranger`, even though we're addressing the common issues in the wiki.  This seems to indicate that those wiki articles do not have a good discoverability.

Also, please note that I've changed the capitalisation on a couple of headings in 
8cf531a.

HTH.