### PR TITLE
Add logo at the top of README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 ranger 1.9.2
 ============
 
+![logo](https://ranger.github.io/ranger_logo.png)
+
 [![Build Status](https://travis-ci.org/ranger/ranger.svg?branch=master)](https://travis-ci.org/ranger/ranger)
 <a href="https://repology.org/metapackage/ranger/versions">
   <img src="https://repology.org/badge/latest-versions/ranger.svg" alt="latest packaged version(s)">

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ranger 1.9.2
 ============
 
-![logo](https://ranger.github.io/ranger_logo.png)
+<img src="https://ranger.github.io/ranger_logo.png" width="150">
 
 [![Build Status](https://travis-ci.org/ranger/ranger.svg?branch=master)](https://travis-ci.org/ranger/ranger)
 <a href="https://repology.org/metapackage/ranger/versions">


### PR DESCRIPTION
Hi,

Since hut has added the logo to [github.io](https://ranger.github.io/) page, we might as well add it to the top of our `README.md`.

Note that I'm using the same version that hut picked, which isn't the same as the one that is in `ranger-assets`.  This is why I'm using an external URL rather than adding the logo to the repo.  I'd rather hold off until we have a final version for the logo.

HTH.