### PR TITLE
Apply debian patch 0004 desktop entry lacks keywords

### DIFF
--- a/doc/ranger.desktop
+++ b/doc/ranger.desktop
@@ -7,3 +7,4 @@ Terminal=true
 Exec=ranger
 Categories=ConsoleOnly;System;FileTools;FileManager
 MimeType=inode/directory;
+Keywords=File;Manager;Browser;Explorer;Vi;Vim;Python

--- a/doc/ranger.desktop
+++ b/doc/ranger.desktop
@@ -7,4 +7,4 @@ Terminal=true
 Exec=ranger
 Categories=ConsoleOnly;System;FileTools;FileManager
 MimeType=inode/directory;
-Keywords=File;Manager;Browser;Explorer;Vi;Vim;Python
+Keywords=File;Manager;Browser;Explorer;Launcher;Vi;Vim;Python


### PR DESCRIPTION
One of the Debian patches our `ranger.desktop` to include `Keywords`. I
figure if we apply this downstream need not bother and many people can
benefit.