### PR TITLE
Make yank path work in empty directory

### DIFF
--- a/ranger/config/commands.py
+++ b/ranger/config/commands.py
@@ -1842,6 +1842,9 @@ class yank(Command):
 
         mode = self.modes[self.arg(1)]
         selection = self.get_selection_attr(mode)
+        # when in empty dir get CWD
+        if not selection:
+            selection = [str(self.fm.thisdir)]
 
         new_clipboard_contents = "\n".join(selection)
         for command in clipboard_commands:


### PR DESCRIPTION
Currently when using yank path/dir/name inside empty directory nothing is copied to clipboard. I think more sensible action is copying current working directory name.

#### ISSUE TYPE
- Improvement/feature implementation

#### RUNTIME ENVIRONMENT
- Operating system and version: openSUSE Tumbleweed
- Terminal emulator and version: Tilix
- Python version: 3.7.3
- Ranger version/commit: 1.9.2
- Locale: en_US.UTF-8

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [X] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [X] All changes follow the code style **[REQUIRED]**
- [X] All new and existing tests pass **[REQUIRED]**

#### DESCRIPTION
#### MOTIVATION AND CONTEXT
#### TESTING