### PR TITLE
add support for 3D files including STL and DXF

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ For enhanced file previews (with `scope.sh`):
 * `odt2txt` for OpenDocument text files (`odt`, `ods`, `odp` and `sxw`)
 * `python` or `jq` for JSON files
 * `fontimage` for font previews
+* `openscad` for 3D model previews (`stl`, `off`, `dxf`, `scad`, `csg`)
 
 Installing
 ----------

--- a/doc/ranger.pod
+++ b/doc/ranger.pod
@@ -1974,6 +1974,17 @@ I<highlight> will pick up command line options specified in this variable. A
 C<--style=> option specified here will override C<HIGHLIGHT_STYLE>. Similarly,
 C<--replace-tabs=> will override C<HIGHLIGHT_TABWIDTH>.
 
+=item OPENSCAD_COLORSCHEME
+
+Specifies the colorscheme used by I<openscad> while previewing 3D models. Read
+I<openscad> man page for colorschemes. Ranger will default to Tomorrow Night.
+
+=item OPENSCAD_IMGSIZE
+
+Specifies the internal resolution I<openscad> will use for rendering 3D models.
+The image will be downscaled to fit the preview pane. This resolution will
+default to "1000,1000" if no value is set.
+
 =item XDG_CONFIG_HOME
 
 Specifies the directory for configuration files. Defaults to F<$HOME/.config>.


### PR DESCRIPTION
This Pull Request leverages the free OpenSCAD software (available in a repository near you) to generate preview images for 3D model files. The two main file formats that most people will use are STL and DXF. And also include off, scad and csg. 

![image](https://user-images.githubusercontent.com/2087930/63111992-5479ae80-bf8f-11e9-896b-0e7f94cacf3b.png)