### PR TITLE
Make setlocal path=... argument a regex again

### DIFF
--- a/doc/ranger.1
+++ b/doc/ranger.1
@@ -133,7 +133,7 @@
 .\" ========================================================================
 .\"
 .IX Title "RANGER 1"
-.TH RANGER 1 "ranger-1.9.3" "2021-09-01" "ranger manual"
+.TH RANGER 1 "ranger-1.9.3" "2021-09-02" "ranger manual"
 .\" For nroff, turn off justification.  Always turn off hyphenation; it makes
 .\" way too many mistakes in technical documents.
 .if n .ad l
@@ -1713,7 +1713,8 @@ directory. If no path is given, uses the current directory.
 .Sp
 \&\fIpath\fR is a regular expression.  This means that \f(CW\*(C`path=~/dl\*(C'\fR applies to all
 paths that start with \fI~/dl\fR, e.g. \fI~/dl2\fR and \fI~/dl/foo\fR. To avoid this,
-use \f(CW\*(C`path=~/dl$\*(C'\fR.
+use \f(CW\*(C`path=~/dl$\*(C'\fR.  To specify a folder with special characters
+(.^$\e*+?(){}[]|), escape them with a backslash.
 .Sp
 \&\fIpath\fR can be quoted with either single or double quotes to prevent unwanted
 splitting. \fIpath='~/dl dl$'\fR or \fIpath=\*(L"~/dl dl$\*(R"\fR

--- a/doc/ranger.1
+++ b/doc/ranger.1
@@ -133,7 +133,7 @@
 .\" ========================================================================
 .\"
 .IX Title "RANGER 1"
-.TH RANGER 1 "ranger-1.9.3" "2021-09-02" "ranger manual"
+.TH RANGER 1 "ranger-1.9.3" "2021-09-05" "ranger manual"
 .\" For nroff, turn off justification.  Always turn off hyphenation; it makes
 .\" way too many mistakes in technical documents.
 .if n .ad l
@@ -1288,6 +1288,8 @@ ranger.  For your convenience, this is a list of the \*(L"public\*(R" commands i
 \& search pattern
 \& search_inc pattern
 \& set option value
+\& setinpath [path=<path>] option value
+\& setinregex [re=<regex>] option value
 \& setintag tags option value
 \& setlocal [path=<path>] option value
 \& shell [\-FLAGS...] command
@@ -1693,6 +1695,30 @@ doesn't work for functions and regular expressions. Valid values are:
 \& list           | 1,2,3,4
 \& none           | none
 .Ve
+.IP "setinpath [path=\fIpath\fR] \fIoption\fR \fIvalue\fR" 2
+.IX Item "setinpath [path=path] option value"
+Assigns a new value to an option, but locally for the directory given by
+\&\fIpath\fR. This means, that this option only takes effect when visiting that
+directory. If no path is given, uses the current directory.
+.Sp
+\&\fIpath\fR can be quoted with either single or double quotes to prevent unwanted
+splitting, \fIpath='~/dl dl'\fR or \fIpath=\*(L"~/dl dl\*(R"\fR. You can use \*(L"pattern\*(R" rather
+than \*(L"path\*(R" for consistency with \f(CW\*(C`setinregex\*(C'\fR.
+.IP "setinregex [re=\fIregex\fR] \fIoption\fR \fIvalue\fR" 2
+.IX Item "setinregex [re=regex] option value"
+Assigns a new value to an option, but locally for directories matching
+\&\fIregex\fR. This means, that this option only takes effect when visiting such
+directories. If no regular expression is given, uses the current directory.
+.Sp
+\&\fIregex\fR is a regular expression.  This means that \f(CW\*(C`re=~/dl\*(C'\fR applies to all
+paths that start with \fI~/dl\fR, e.g. \fI~/dl2\fR and \fI~/dl/foo\fR. To avoid this,
+use \f(CW\*(C`path=~/dl$\*(C'\fR.  To specify a folder with special characters
+(.^$\e*+?(){}[]|), escape them with a backslash.
+.Sp
+\&\fIregex\fR can be quoted with either single or double quotes to prevent unwanted
+splitting,. \fIre='~/dl dl$'\fR or \fIre=\*(L"~/dl dl$\*(R"\fR. You can use \*(L"regex\*(R" rather
+than \*(L"re\*(R" to avoid having to remember the spelling and you can use \*(L"pattern\*(R"
+for consistency with \f(CW\*(C`setinpath\*(C'\fR.
 .IP "setintag \fItags\fR \fIoption\fR \fIvalue\fR" 2
 .IX Item "setintag tags option value"
 Assigns a new value to an option, but locally for the directories that are
@@ -1707,17 +1733,7 @@ with the \fIv\fR tag by typing \fI"v\fR, then use this command:
 .Ve
 .IP "setlocal [path=\fIpath\fR] \fIoption\fR \fIvalue\fR" 2
 .IX Item "setlocal [path=path] option value"
-Assigns a new value to an option, but locally for the directory given by
-\&\fIpath\fR. This means, that this option only takes effect when visiting that
-directory. If no path is given, uses the current directory.
-.Sp
-\&\fIpath\fR is a regular expression.  This means that \f(CW\*(C`path=~/dl\*(C'\fR applies to all
-paths that start with \fI~/dl\fR, e.g. \fI~/dl2\fR and \fI~/dl/foo\fR. To avoid this,
-use \f(CW\*(C`path=~/dl$\*(C'\fR.  To specify a folder with special characters
-(.^$\e*+?(){}[]|), escape them with a backslash.
-.Sp
-\&\fIpath\fR can be quoted with either single or double quotes to prevent unwanted
-splitting. \fIpath='~/dl dl$'\fR or \fIpath=\*(L"~/dl dl$\*(R"\fR
+Alias for \f(CW\*(C`setinpath\*(C'\fR.
 .IP "shell [\-\fIflags\fR] \fIcommand\fR" 2
 .IX Item "shell [-flags] command"
 Run a shell command.  \fIflags\fR are discussed in their own section.

--- a/doc/ranger.pod
+++ b/doc/ranger.pod
@@ -1388,6 +1388,8 @@ ranger.  For your convenience, this is a list of the "public" commands including
  search pattern
  search_inc pattern
  set option value
+ setinpath [path=<path>] option value
+ setinregex [re=<regex>] option value
  setintag tags option value
  setlocal [path=<path>] option value
  shell [-FLAGS...] command
@@ -1837,6 +1839,32 @@ doesn't work for functions and regular expressions. Valid values are:
  list           | 1,2,3,4
  none           | none
 
+=item setinpath [path=I<path>] I<option> I<value>
+
+Assigns a new value to an option, but locally for the directory given by
+I<path>. This means, that this option only takes effect when visiting that
+directory. If no path is given, uses the current directory.
+
+I<path> can be quoted with either single or double quotes to prevent unwanted
+splitting, I<path='~/dl dl'> or I<path="~/dl dl">. You can use "pattern" rather
+than "path" for consistency with C<setinregex>.
+
+=item setinregex [re=I<regex>] I<option> I<value>
+
+Assigns a new value to an option, but locally for directories matching
+I<regex>. This means, that this option only takes effect when visiting such
+directories. If no regular expression is given, uses the current directory.
+
+I<regex> is a regular expression.  This means that C<re=~/dl> applies to all
+paths that start with I<~/dl>, e.g. I<~/dl2> and I<~/dl/foo>. To avoid this,
+use C<path=~/dl$>.  To specify a folder with special characters
+(.^$\*+?(){}[]|), escape them with a backslash.
+
+I<regex> can be quoted with either single or double quotes to prevent unwanted
+splitting,. I<re='~/dl dl$'> or I<re="~/dl dl$">. You can use "regex" rather
+than "re" to avoid having to remember the spelling and you can use "pattern"
+for consistency with C<setinpath>.
+
 =item setintag I<tags> I<option> I<value>
 
 Assigns a new value to an option, but locally for the directories that are
@@ -1850,17 +1878,7 @@ with the I<v> tag by typing I<"v>, then use this command:
 
 =item setlocal [path=I<path>] I<option> I<value>
 
-Assigns a new value to an option, but locally for the directory given by
-I<path>. This means, that this option only takes effect when visiting that
-directory. If no path is given, uses the current directory.
-
-I<path> is a regular expression.  This means that C<path=~/dl> applies to all
-paths that start with I<~/dl>, e.g. I<~/dl2> and I<~/dl/foo>. To avoid this,
-use C<path=~/dl$>.  To specify a folder with special characters
-(.^$\*+?(){}[]|), escape them with a backslash.
-
-I<path> can be quoted with either single or double quotes to prevent unwanted
-splitting. I<path='~/dl dl$'> or I<path="~/dl dl$">
+Alias for C<setinpath>.
 
 =item shell [-I<flags>] I<command>
 

--- a/doc/ranger.pod
+++ b/doc/ranger.pod
@@ -1856,7 +1856,8 @@ directory. If no path is given, uses the current directory.
 
 I<path> is a regular expression.  This means that C<path=~/dl> applies to all
 paths that start with I<~/dl>, e.g. I<~/dl2> and I<~/dl/foo>. To avoid this,
-use C<path=~/dl$>.
+use C<path=~/dl$>.  To specify a folder with special characters
+(.^$\*+?(){}[]|), escape them with a backslash.
 
 I<path> can be quoted with either single or double quotes to prevent unwanted
 splitting. I<path='~/dl dl$'> or I<path="~/dl dl$">

--- a/ranger/config/commands.py
+++ b/ranger/config/commands.py
@@ -506,7 +506,7 @@ class setlocal(set_):
         if path is None:
             path = self._re_shift(self.PATH_RE_UNQUOTED.match(self.arg(1)))
         if path is None and self.fm.thisdir:
-            path = self.fm.thisdir.path
+            path = "^" + re.escape(self.fm.thisdir.path) + "$"
         if not path:
             return
 

--- a/ranger/config/commands.py
+++ b/ranger/config/commands.py
@@ -507,13 +507,13 @@ class setlocal_(set_):
         # We require quoting of paths with whitespace so we have to take care
         # not to match escaped quotes.
         self.path_re_dquoted = re.compile(
-            r'^set.+?\s+{arg}="(.*?[^\\])"'.format(arg=self._arg())
+            r'^set.+?\s+{arg}="(.*?[^\\])"'.format(arg=self._arg)
         )
         self.path_re_squoted = re.compile(
-            r"^set.+?\s+{arg}='(.*?[^\\])'".format(arg=self._arg())
+            r"^set.+?\s+{arg}='(.*?[^\\])'".format(arg=self._arg)
         )
         self.path_re_unquoted = re.compile(
-            r'^{arg}=(.+?)$'.format(arg=self._arg())
+            r'^{arg}=(.+?)$'.format(arg=self._arg)
         )
 
     def _re_shift(self, match):

--- a/ranger/config/commands.py
+++ b/ranger/config/commands.py
@@ -520,7 +520,9 @@ class setlocal_(set_):
         if not match:
             return None
         path = match.group(1)
-        for _ in range(1 + min(1, len(path.split()))):
+        # Prepend something that behaves like "path=" in case path starts with
+        # whitespace
+        for _ in "={0}".format(path).split():
             self.shift()
         return os.path.expanduser(path)
 

--- a/ranger/config/commands.py
+++ b/ranger/config/commands.py
@@ -571,6 +571,23 @@ class setlocal(setinpath):
     pass
 
 
+class setinregex(_setlocal):
+    """:setinregex re=<regex> <option name>=<python expression>
+
+    Sets an option when in a specific directory. If the <regex> contains
+    whitespace it needs to be quoted and nested quotes need to be
+    backslash-escaped. Special characters need to be escaped if they are
+    intended to match literally as documented in the ``re`` library
+    documentation. The "re" argument can also be named "regex" or "pattern,"
+    which allows for easier switching with ``setinpath``.
+    """
+    def _arg(self):
+        return "(?:re(?:gex)?|pattern)"
+
+    def _format_arg(self, arg):
+        return arg
+
+
 class setintag(set_):
     """:setintag <tag or tags> <option name>=<option value>
 

--- a/ranger/container/settings.py
+++ b/ranger/container/settings.py
@@ -281,7 +281,7 @@ class Settings(SignalDispatcher, FileManagerAware):
         if path:
             if path not in self._localsettings:
                 try:
-                    regex = re.compile(re.escape(path))
+                    regex = re.compile(path)
                 except re.error:  # Bad regular expression
                     return
                 self._localregexes[path] = regex


### PR DESCRIPTION
#### ISSUE TYPE
<!-- Pick relevant types and delete the rest -->
- Bug fix

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [x] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [x] All changes follow the code style **[REQUIRED]**
- [x] All new and existing tests pass **[REQUIRED]**
- [ ] Changes require config files to be updated
    - [ ] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated


From the `setlocal` section of the man page:
```
path is a regular expression.  This means that "path=~/dl" applies to
all paths that start with ~/dl, e.g. ~/dl2 and ~/dl/foo. To avoid
this, use "path=~/dl$".

```
#1652 caused the `path` argument to be regex escaped. This commit
fixes that.
