### PR TITLE
Switch manpage date from locale dependent to ISO UTC

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -127,9 +127,9 @@ test: test_py test_shellcheck
 
 man:
 	pod2man --stderr --center='ranger manual' --date='$(NAME)-$(VERSION)' \
-		--release=$(shell date +%x) doc/ranger.pod doc/ranger.1
+		--release=$(shell date -u '+%Y-%m-%d') doc/ranger.pod doc/ranger.1
 	pod2man --stderr --center='rifle manual' --date='$(NAME_RIFLE)-$(VERSION_RIFLE)' \
-		--release=$(shell date +%x) doc/rifle.pod doc/rifle.1
+		--release=$(shell date -u '+%Y-%m-%d') doc/rifle.pod doc/rifle.1
 
 manhtml:
 	pod2html doc/ranger.pod --outfile=doc/ranger.1.html


### PR DESCRIPTION
Having the date in the manpage depend on a user's locale and their
timezone makes the format change depending on which user generates it.