### PR TITLE
added dircomp command and dependencies.

### DIFF
--- a/ranger/config/commands.py
+++ b/ranger/config/commands.py
@@ -1859,3 +1859,79 @@ class yank(Command):
             in sorted(self.modes.keys())
             if mode
         )
+
+
+class dircomp(Command):
+    """:dircomp [-FLAGS...]
+
+    Compare the content of two paths, provided by two open tabs
+    that will be compared.
+
+    Flags:
+     -s: compare directory structure.
+     -c: compare number of elements in the two paths.
+     -b: compare two file and folder wise identical structures for binary differences.
+     -p: output the result to the pager.
+     -e: output the result to file and open with editor in new tab.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super(dircomp, self).__init__(*args, **kwargs)
+        self.flags, _ = self.parse_flags()
+
+    def execute(self):
+        import ranger.ext.filetree as ft
+        from os.path import expanduser
+        home = expanduser("~")
+
+        tabs = self.fm.tabs
+        path_a = str(tabs[1].thisdir)
+        path_b = str(tabs[2].thisdir)
+
+        ft_a = ft.FileTree(path_a)
+        ft_b = ft.FileTree(path_b)
+
+        data_list = []
+
+        # count, set or bin comparison switch.
+        if "b" in self.flags:
+            res = ft_a.compare(ft_b, "bin")
+            diff = res["diff"]
+            data_list.append(">>> Binary difference in:")
+            for elem in diff:
+                data_list.append(str(elem))
+            data_output = "\n".join(data_list)
+
+        elif "c" in self.flags:
+            res = ft_a.compare(ft_b, "size")
+            data_list.append(">>> Elements in tab 1")
+            data_list.append(str(res["nfiles"][0]))
+            data_list.append("\n>>> Elements in tab 2")
+            data_list.append(str(res["nfiles"][1]))
+            data_output = "\n".join(data_list)
+
+        else:
+            res = ft_a.compare(ft_b, "set")
+            mis_a = res["mis_a"]
+            mis_b = res["mis_b"]
+
+            data_list.append(">>> Missing in tab 1")
+            for elem in mis_a:
+                data_list.append(str(elem))
+            data_list.append("\n>>> Missing in tab 2")
+            for elem in mis_b:
+                data_list.append(str(elem))
+            data_output = "\n".join(data_list)
+
+        output_dir = home + "/.cache/ranger/"
+        output_filename = "diff.txt"
+
+        # pager or editor output switch.
+        if "e" in self.flags:
+            with open((output_dir + output_filename), "w") as diff_file:
+                diff_file.write(data_output)
+            self.fm.tab_switch(output_dir)
+            self.fm.edit_file(output_filename)
+        else:
+            pager = self.fm.ui.open_pager()
+            pager.set_source(data_output)

--- a/ranger/ext/filetree.py
+++ b/ranger/ext/filetree.py
@@ -1,0 +1,299 @@
+#!/usr/bin/python3
+
+"""
+filetree.py - Compare File structures
+
+Module Containing the Filetree class to represent
+a file directory structure.
+
+The Module does also provide the nesecarry routines
+to compare these filetrees against each other.
+"""
+
+import os
+from hashlib import md5
+
+
+class EmptyList(Exception):
+    pass
+
+
+class FileTree:
+    """ The FileTree class represents the files in a filetree.
+
+        :param path: str with the path to directory
+        :param name: str with a name for the filetree object
+
+    """
+
+    def __init__(self, path, name=""):
+
+        self.name = name    # identifier name of the tree.
+        self._path = path    # absolute path to the root directory.
+
+        # parse the different ways of specifying a dir.
+        if path[-1] == "/":
+            path = path[0:-1]
+
+        # leading path is the path leading up to the root
+        # directory.  Directory is the name of the root directory.
+        self.leading_path, self.directory = self._seperate_path(self._path)
+
+        # file tree is a walk generator object.
+        self._file_tree = os.walk(self._path)
+
+        # file_list is a list of the underlying filesystem
+        # structure from with the absolute path
+        self._file_list = self._create_filelist(self._file_tree)
+
+        # filenames are the files relative to the root dir.
+        self._name_list = self._create_namelist()
+
+        if not self._file_list:
+            raise EmptyList("List of files is empty")
+
+        self._file_list.sort()
+
+    def __repr__(self):
+        return "FileTree object named: <{}>.\n" \
+               "Root: <{}>\n" \
+               "Elements: <{}>".format(self.name, self._path, self.size)
+
+    def __len__(self):
+        return self.size
+
+    def _seperate_path(self, path):
+        """ Seperate the leading path and the directory of
+        interest. /leading/path/to/directory
+
+        :param path: str with the path to seperate
+
+        :return: tuple with (leading_path, directory)
+
+        """
+
+        path_elements = path.split("/")
+        leading_path = "/" + "/".join(path_elements[1:-1]) + "/"
+        if path_elements[-1] == '':
+            directory = path_elements[-2]
+        else:
+            directory = path_elements[-1]
+        return leading_path, directory
+
+    def _create_filelist(self, tree):
+        """makes a list for all files in the tree.
+
+        :param tree: generator walk object containing the file tree.
+
+        :return: list with files in tree.
+
+        """
+        file_list = []
+        for root, dirs, files in tree:
+            for entry in files:
+                if root:
+                    file_list.append("{}/{}".format(root, entry))
+                else:
+                    file_list.append("{}".format(entry))
+        return file_list
+
+    def _create_namelist(self):
+        """makes a list for all files in the tree
+        relative to the root directory.
+
+        :return: list with files in tree relative to the root.
+
+        """
+        file_names = []
+
+        for path in self._file_list:
+            # strip the leading path from the file_list.
+            # /leading/path/to/root/with/file -> root/with/file
+            plength = len(self.leading_path + self.directory) + 1
+            file_names.append(path[plength:])
+        return file_names
+
+    def compare(self, tree, comp, verbose=False):
+        """ compare the filetree against another filetree.
+
+        :param: tree: FileTree object to compare against.
+        :param: comp: str comparison type (size, set, bin)
+        :param: verbose: print diffs.
+
+        :return: dict with comparison results.
+        """
+
+        if comp == "size":
+            res = size_comp(self, tree, verbose)
+
+        if comp == "set":
+            res = set_comp(self, tree, verbose)
+
+        if comp == "bin":
+            res = bin_comp(self, tree, verbose=verbose)
+
+        return res
+
+    @property
+    def filenames(self):
+        """ property holding tree filenames """
+        return self._name_list
+
+    @property
+    def files(self):
+        """ property holding list of files """
+        return self._file_list
+
+    @property
+    def size(self):
+        """ property returning the elements in tree """
+        return len(self._file_list)
+
+    @property
+    def path(self):
+        """ property providing the absolute path to the
+        root directory of the filetree.
+        """
+        return self._path
+
+    @path.setter
+    def path(self, path):
+        if path.startswith("./"):
+            self._path = os.path.abspath(path)
+        else:
+            self._path = path
+
+
+def size_comp(tree_a, tree_b, verbose=False):
+    """Analyze if there is a difference of number of files
+    in the two trees
+
+    :param tree_a: FileTree obj with files in tree A.
+    :param tree_b: FileTree obj with files in tree B.
+
+    :return: result dict with two fields.
+             "res": bool. Comparison outcome
+             "nfiles": list. number of files in dir a and b
+                       respectively.
+
+    """
+
+    result = {"res": 0, "nfiles": [0, 0]}
+
+    size_a = tree_a.size
+    size_b = tree_b.size
+
+    result["nfiles"] = [size_a, size_b]
+
+    name_a = tree_a.name
+    name_b = tree_b.name
+
+    if name_a == "":
+        name_a = "a"
+
+    if name_b == "":
+        name_b = "b"
+
+    if size_a == size_b:
+        if verbose:
+            print("[OK] - same number of elements: {}".format(size_a))
+        result["res"] = True
+    else:
+        if verbose:
+            print("[FAILED] - different number of elements in both trees")
+            print('{}: {} \n{}: {}'.format(name_a, size_a, name_b, size_b))
+        result["res"] = False
+
+    return result
+
+
+def set_comp(tree_a, tree_b, verbose=False):
+    """ Compare to filetree sets
+
+    :param set_a: first set for comparison
+    :param set_b: second set for comparison
+
+    :return: result dict with three fields.
+             "res": bool. Comparison outcome
+             "mis_a": list. files missing in folder a
+             "mis_b": list. files missing in folder b
+
+    """
+    result = {"res": 0, "mis_a": [], "mis_b": []}
+
+    set_a = set(tree_a.filenames)
+    set_b = set(tree_b.filenames)
+
+    if set_a == set_b:
+        if verbose:
+            print("[OK] - Same filenames in both trees.")
+        result["res"] = True
+    else:
+
+        diff_a = list(set_b.difference(set_a))
+        diff_b = list(set_a.difference(set_b))
+
+        if verbose:
+            print("[FAILED] - Missing in <{}>:".format(tree_a.path))
+            print("\n".join(diff_a))
+            print("[FAILED] - Missing in <{}>:".format(tree_b.path))
+            print("\n".join(diff_b))
+
+        result["res"] = False
+        result["mis_a"] = diff_a
+        result["mis_b"] = diff_b
+
+    return result
+
+
+def bin_comp(tree_a, tree_b, method=md5, verbose=False):
+    """Analyze any difference in the files in the tree. This analysis
+    is based on a binary comparision between the two trees.
+
+    :param tree_a: FileTree obj with files in tree A.
+    :param tree_b: FileTree obj with files in tree B.
+    :param method: provide a hash function to compare binary
+                   file content. (md5, sha1, sha256)
+
+    :return: result dict with two fields.
+             "res": bool. Comparison outcome
+             "diff": list. Differing files between the two dirs.
+
+    """
+    diff = []
+    result = {"res": False, "diff": []}
+
+    try:
+        for file_a, file_b in zip(tree_a.files, tree_b.files):
+            h_a = _hash(file_a, method)
+            h_b = _hash(file_b, method)
+            if h_a != h_b:
+                tmp = file_a.split(tree_a.leading_path)[1]
+                diff.append(tmp.split((tree_a.directory + "/"))[1])
+
+    except FileNotFoundError as err:
+        print("Ensure the same elements are in both trees")
+        print(err)
+
+    else:
+        if not diff:
+            print("[OK] - Same binary file content:")
+            result["res"] = True
+        else:
+            if verbose:
+                print("[FAILED] - Binary Difference in: ")
+                print("\n".join(diff))
+            result["res"] = False
+
+        result["diff"] = diff
+        return result
+
+
+def _hash(filepath, method):
+    hasher = method()
+    with open(filepath, 'rb') as file:
+        chunk = 0
+        while chunk != b'':
+            chunk = file.read(1024)
+            hasher.update(chunk)
+    return hasher.hexdigest()


### PR DESCRIPTION
<!-- Provide a descriptive summary of the changes in the title above -->

#### ISSUE TYPE
<!-- Pick relevant types and delete the rest -->
- Improvement/feature implementation

#### RUNTIME ENVIRONMENT
<!-- Details of your runtime environment -->

<!-- Retrieve Python/ranger version and locale with `ranger -\-version` -->
- Operating system and version: Ubuntu 18.04 LTS
- Terminal emulator and version:  gnome-terminal 
- Python version: 3.6.8
- Ranger version/commit: ranger-master / 5e66753a7222e585e8a31f617ac3a3c94743f288
- Locale: en_US.UTF-8

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [X] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [X] All changes follow the code style **[REQUIRED]**
- [X] All new and existing tests pass **[REQUIRED]**
- [X] Changes require config files to be updated
    - [X] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
<!-- Describe the changes in detail -->
A directory comparison feature that allows the user two open two directories
in two tabs. The two directories can then be compared in terms of number 
of elements, the file structure and binary content. 

#### MOTIVATION AND CONTEXT
<!-- Why are these changes required? -->
Because this feature does not exist yet and its useful.
<!-- What problems do these changes solve? -->
<!-- Link to relevant issues -->


#### TESTING
<!-- What tests have been run? -->

<!-- How does the changes affect other areas of the codebase? -->


#### IMAGES / VIDEOS<!-- Only if relevant -->
<!-- Link or embed images and videos of screenshots, sketches etc. -->
