### PR TITLE
Update colorscheme creation method

### DIFF
--- a/ranger/colorschemes/default.py
+++ b/ranger/colorschemes/default.py
@@ -9,23 +9,23 @@ from ranger.gui.color import (
     normal, bold, reverse, dim, BRIGHT,
     default_colors,
 )
-from ranger.core.actions import Actions
-
 
 def color(fg=-1, bg=-1, attr=0):
     return (fg, bg, attr)
 
-def getkey(d, key):
+
+def getkey(dictionary, key):
     keys = key.split('.')
     code = ''
     for i in dir():
-        if eval(i) == d:
+        if eval(i) == dictionary:  # pylint: disable=eval-used
             code += i
 
     for k in keys:
         code += '["' + k + '"]'
 
-    return eval(code)
+    return eval(code)  # pylint: disable=eval-used
+
 
 def has_key(dictionary, key):
     try:
@@ -34,9 +34,10 @@ def has_key(dictionary, key):
         return False
     return True
 
+
 class Default(ColorScheme):
     progress_bar_color = None
-    colors = { 'progress_bar_color': blue }
+    colors = {'progress_bar_color': blue}
 
     def _color(self, clrtup, valtup):
         clr = []
@@ -57,108 +58,123 @@ class Default(ColorScheme):
 
         return clr
 
-    def use(self, context):
-        if not self.progress_bar_color is None: self.colors['progress_bar_color'] = self.progress_bar_color
+    def use(self, context):  # pylint: disable=too-many-branches, too-many-statements
+        if self.progress_bar_color is not None:
+            self.colors['progress_bar_color'] = self.progress_bar_color
         base_key = ''
         fg, bg, attr = default_colors
 
         if context.reset:
             if not has_key(self.colors, 'reset'):
                 return default_colors
-            else:
-                return getkey(self.colors, 'reset')
+            return getkey(self.colors, 'reset')
 
         elif context.in_browser:
             base_key = 'browser.'
             if context.selected:
-                if not has_key(self.colors, base_key+'selected'):
+                if not has_key(self.colors, base_key + 'selected'):
                     attr = reverse
                 else:
-                    fg, bg, attr = self._color((fg,bg,attr),getkey(self.colors, base_key+'selected'))
+                    fg, bg, attr = self._color(
+                        (fg, bg, attr), getkey(self.colors, base_key + 'selected'))
             else:
-                if not has_key(self.colors, base_key+'default'):
+                if not has_key(self.colors, base_key + 'default'):
                     attr = normal
                 else:
-                    fg, bg, attr = self._color((fg,bg,attr),getkey(self.colors, base_key+'default'))
+                    fg, bg, attr = self._color(
+                        (fg, bg, attr), getkey(self.colors, base_key + 'default'))
             if context.empty:
-                if not has_key(self.colors, base_key+'empty'):
+                if not has_key(self.colors, base_key + 'empty'):
                     bg = red
                 else:
-                    fg, bg, attr = self._color((fg,bg,attr),getkey(self.colors, base_key+'empty'))
+                    fg, bg, attr = self._color(
+                        (fg, bg, attr), getkey(self.colors, base_key + 'empty'))
             if context.error:
-                if not has_key(self.colors, base_key+'error'):
+                if not has_key(self.colors, base_key + 'error'):
                     bg = red
                 else:
-                    fg, bg, attr = self._color((fg,bg,attr),getkey(self.colors, base_key+'error'))
+                    fg, bg, attr = self._color(
+                        (fg, bg, attr), getkey(self.colors, base_key + 'error'))
             if context.border:
-                if not has_key(self.colors, base_key+'border'):
+                if not has_key(self.colors, base_key + 'border'):
                     fg = default
                 else:
-                    fg, bg, attr = self._color((fg,bg,attr),getkey(self.colors, base_key+'border'))
+                    fg, bg, attr = self._color(
+                        (fg, bg, attr), getkey(self.colors, base_key + 'border'))
             if context.media:
                 if context.image:
-                    if not has_key(self.colors, base_key+'media.image'):
+                    if not has_key(self.colors, base_key + 'media.image'):
                         fg = yellow
                     else:
-                        fg, bg, attr = self._color((fg,bg,attr),getkey(self.colors, base_key+'media.image'))
+                        fg, bg, attr = self._color(
+                            (fg, bg, attr), getkey(self.colors, base_key + 'media.image'))
                 else:
-                    if not has_key(self.colors, base_key+'default'):
+                    if not has_key(self.colors, base_key + 'default'):
                         fg = magenta
                     else:
-                        fg, bg, attr = self._color((fg,bg,attr),getkey(self.colors, base_key+'default'))
+                        fg, bg, attr = self._color(
+                            (fg, bg, attr), getkey(self.colors, base_key + 'default'))
             if context.container:
-                if not has_key(self.colors, base_key+'container'):
+                if not has_key(self.colors, base_key + 'container'):
                     fg = red
                 else:
-                    fg, bg, attr = self._color((fg,bg,attr),getkey(self.colors, base_key+'container'))
+                    fg, bg, attr = self._color(
+                        (fg, bg, attr), getkey(self.colors, base_key + 'container'))
             if context.directory:
-                if not has_key(self.colors, base_key+'directory'):
+                if not has_key(self.colors, base_key + 'directory'):
                     attr |= bold
                     fg = blue
                     fg += BRIGHT
                 else:
-                    fg, bg, attr = self._color((fg,bg,attr),getkey(self.colors, base_key+'directory'))
+                    fg, bg, attr = self._color(
+                        (fg, bg, attr), getkey(self.colors, base_key + 'directory'))
             elif context.executable and not \
                     any((context.media, context.container,
                          context.fifo, context.socket)):
-                if not has_key(self.colors, base_key+'executable'):
+                if not has_key(self.colors, base_key + 'executable'):
                     attr |= bold
                     fg = green
                     fg += BRIGHT
                 else:
-                    fg, bg, attr = self._color((fg,bg,attr),getkey(self.colors, base_key+'executable'))
+                    fg, bg, attr = self._color(
+                        (fg, bg, attr), getkey(self.colors, base_key + 'executable'))
             if context.socket:
-                if not has_key(self.colors, base_key+'socket'):
+                if not has_key(self.colors, base_key + 'socket'):
                     attr |= bold
                     fg = magenta
                     fg += BRIGHT
                 else:
-                    fg, bg, attr = self._color((fg,bg,attr),getkey(self.colors, base_key+'socket'))
+                    fg, bg, attr = self._color(
+                        (fg, bg, attr), getkey(self.colors, base_key + 'socket'))
             if context.fifo:
-                if not has_key(self.colors, base_key+'fifo'):
+                if not has_key(self.colors, base_key + 'fifo'):
                     fg = yellow
                 else:
-                    fg, bg, attr = self._color((fg,bg,attr),getkey(self.colors, base_key+'fifo'))
+                    fg, bg, attr = self._color(
+                        (fg, bg, attr), getkey(self.colors, base_key + 'fifo'))
             if context.device:
-                if not has_key(self.colors, base_key+'fifo'):
+                if not has_key(self.colors, base_key + 'fifo'):
                     fg = yellow
                     attr |= bold
                     fg += BRIGHT
                 else:
-                    fg, bg, attr = self._color((fg,bg,attr),getkey(self.colors, base_key+'fifo'))
+                    fg, bg, attr = self._color(
+                        (fg, bg, attr), getkey(self.colors, base_key + 'fifo'))
             if context.link:
                 if context.good:
-                    if not has_key(self.colors, base_key+'link.good'):
+                    if not has_key(self.colors, base_key + 'link.good'):
                         fg = cyan
                     else:
-                        fg, bg, attr = self._color((fg,bg,attr),getkey(self.colors, base_key+'link.good'))
+                        fg, bg, attr = self._color(
+                            (fg, bg, attr), getkey(self.colors, base_key + 'link.good'))
                 else:
-                    if not has_key(self.colors, base_key+'default'):
+                    if not has_key(self.colors, base_key + 'default'):
                         fg = magenta
                     else:
-                        fg, bg, attr = self._color((fg,bg,attr),getkey(self.colors, base_key+'default'))
+                        fg, bg, attr = self._color(
+                            (fg, bg, attr), getkey(self.colors, base_key + 'default'))
             if context.tag_marker and not context.selected:
-                if not has_key(self.colors, base_key+'tag_marker'):
+                if not has_key(self.colors, base_key + 'tag_marker'):
                     if fg in (red, magenta):
                         fg = white
                     else:
@@ -166,9 +182,10 @@ class Default(ColorScheme):
                     fg += BRIGHT
                     attr |= bold
                 else:
-                    fg, bg, attr = self._color((fg,bg,attr),getkey(self.colors, base_key+'tag_marker'))
+                    fg, bg, attr = self._color(
+                        (fg, bg, attr), getkey(self.colors, base_key + 'tag_marker'))
             if not context.selected and context.cut:
-                if not has_key(self.colors, base_key+'cut'):
+                if not has_key(self.colors, base_key + 'cut'):
                     attr |= bold
                     fg = black
                     fg += BRIGHT
@@ -178,9 +195,10 @@ class Default(ColorScheme):
                         attr |= dim
                         fg = white
                 else:
-                    fg, bg, attr = self._color((fg,bg,attr),getkey(self.colors, base_key+'cut'))
+                    fg, bg, attr = self._color(
+                        (fg, bg, attr), getkey(self.colors, base_key + 'cut'))
             if not context.selected and context.copied:
-                if not has_key(self.colors, base_key+'copied'):
+                if not has_key(self.colors, base_key + 'copied'):
                     attr |= bold
                     fg = black
                     fg += BRIGHT
@@ -190,253 +208,290 @@ class Default(ColorScheme):
                         attr |= dim
                         fg = white
                 else:
-                    fg, bg, attr = self._color((fg,bg,attr),getkey(self.colors, base_key+'copied'))
+                    fg, bg, attr = self._color(
+                        (fg, bg, attr), getkey(self.colors, base_key + 'copied'))
             if context.main_column:
                 base_key = 'browser.main.'
                 # Doubling up with BRIGHT here causes issues because it's
                 # additive not idempotent.
                 if context.selected:
-                    if not has_key(self.colors, base_key+'selected'):
+                    if not has_key(self.colors, base_key + 'selected'):
                         attr |= bold
                     else:
-                        fg, bg, attr = self._color((fg,bg,attr),getkey(self.colors, base_key+'selected'))
+                        fg, bg, attr = self._color(
+                            (fg, bg, attr), getkey(self.colors, base_key + 'selected'))
                 if context.marked:
-                    if not has_key(self.colors, base_key+'marked'):
+                    if not has_key(self.colors, base_key + 'marked'):
                         attr |= bold
                         fg = yellow
                     else:
-                        fg, bg, attr = self._color((fg,bg,attr),getkey(self.colors, base_key+'marked'))
+                        fg, bg, attr = self._color(
+                            (fg, bg, attr), getkey(self.colors, base_key + 'marked'))
             base_key = 'browser.'
             if context.badinfo:
-                if not has_key(self.colors, base_key+'badinfo'):
+                if not has_key(self.colors, base_key + 'badinfo'):
                     if attr & reverse:
                         bg = magenta
                     else:
                         fg = magenta
                 else:
-                    fg, bg, attr = self._color((fg,bg,attr),getkey(self.colors, base_key+'badinfo'))
+                    fg, bg, attr = self._color(
+                        (fg, bg, attr), getkey(self.colors, base_key + 'badinfo'))
             if context.inactive_pane:
-                if not has_key(self.colors, base_key+'inactive'):
+                if not has_key(self.colors, base_key + 'inactive'):
                     fg = cyan
                 else:
-                    fg, bg, attr = self._color((fg,bg,attr),getkey(self.colors, base_key+'inactive'))
+                    fg, bg, attr = self._color(
+                        (fg, bg, attr), getkey(self.colors, base_key + 'inactive'))
 
         elif context.in_titlebar:
             base_key = 'titlebar.'
 
             if context.hostname:
                 if context.bad:
-                    if not has_key(self.colors, base_key+'hostname.bad'):
+                    if not has_key(self.colors, base_key + 'hostname.bad'):
                         fg = red
                         attr |= bold
                         fg += BRIGHT
                     else:
-                        fg, bg, attr = self._color((fg,bg,attr),getkey(self.colors, base_key+'hostname.bad'))
+                        fg, bg, attr = self._color(
+                            (fg, bg, attr), getkey(self.colors, base_key + 'hostname.bad'))
                 else:
-                    if not has_key(self.colors, base_key+'hostname.default'):
+                    if not has_key(self.colors, base_key + 'hostname.default'):
                         fg = green
                     else:
-                        fg, bg, attr = self._color((fg,bg,attr),getkey(self.colors, base_key+'hostname.default'))
+                        fg, bg, attr = self._color(
+                            (fg, bg, attr), getkey(self.colors, base_key + 'hostname.default'))
             elif context.directory:
-                if not has_key(self.colors, base_key+'directory'):
+                if not has_key(self.colors, base_key + 'directory'):
                     fg = blue
                     attr |= bold
                     fg += BRIGHT
                 else:
-                    fg, bg, attr = self._color((fg,bg,attr),getkey(self.colors, base_key+'directory'))
+                    fg, bg, attr = self._color(
+                        (fg, bg, attr), getkey(self.colors, base_key + 'directory'))
             elif context.tab:
                 if context.good:
-                    if not has_key(self.colors, base_key+'tab.good'):
+                    if not has_key(self.colors, base_key + 'tab.good'):
                         bg = green
                         attr |= bold
                         fg += BRIGHT
                     else:
-                        fg, bg, attr = self._color((fg,bg,attr),getkey(self.colors, base_key+'tab.good'))
+                        fg, bg, attr = self._color(
+                            (fg, bg, attr), getkey(self.colors, base_key + 'tab.good'))
             elif context.link:
-                if not has_key(self.colors, base_key+'link'):
+                if not has_key(self.colors, base_key + 'link'):
                     fg = cyan
                     attr |= bold
                     fg += BRIGHT
                 else:
-                    fg, bg, attr = self._color((fg,bg,attr),getkey(self.colors, base_key+'link'))
+                    fg, bg, attr = self._color(
+                        (fg, bg, attr), getkey(self.colors, base_key + 'link'))
 
         elif context.in_statusbar:
             base_key = 'statusbar.'
 
             if context.permissions:
                 if context.good:
-                    if not has_key(self.colors, base_key+'permissions.good'):
+                    if not has_key(self.colors, base_key + 'permissions.good'):
                         fg = cyan
                     else:
-                        fg, bg, attr = self._color((fg,bg,attr),getkey(self.colors, base_key+'permissions.good'))
+                        fg, bg, attr = self._color(
+                            (fg, bg, attr), getkey(self.colors, base_key + 'permissions.good'))
                 elif context.bad:
-                    if not has_key(self.colors, base_key+'permissions.bad'):
+                    if not has_key(self.colors, base_key + 'permissions.bad'):
                         fg = magenta
                     else:
-                        fg, bg, attr = self._color((fg,bg,attr),getkey(self.colors, base_key+'permissions.bad'))
+                        fg, bg, attr = self._color(
+                            (fg, bg, attr), getkey(self.colors, base_key + 'permissions.bad'))
             if context.marked:
-                if not has_key(self.colors, base_key+'marked'):
+                if not has_key(self.colors, base_key + 'marked'):
                     attr |= bold | reverse
                     fg = yellow
                     fg += BRIGHT
                 else:
-                    fg, bg, attr = self._color((fg,bg,attr),getkey(self.colors, base_key+'marked'))
+                    fg, bg, attr = self._color(
+                        (fg, bg, attr), getkey(self.colors, base_key + 'marked'))
             if context.frozen:
-                if not has_key(self.colors, base_key+'frozen'):
+                if not has_key(self.colors, base_key + 'frozen'):
                     attr |= bold | reverse
                     fg = cyan
                     fg += BRIGHT
                 else:
-                    fg, bg, attr = self._color((fg,bg,attr),getkey(self.colors, base_key+'frozen'))
+                    fg, bg, attr = self._color(
+                        (fg, bg, attr), getkey(self.colors, base_key + 'frozen'))
             if context.message:
                 if context.bad:
-                    if not has_key(self.colors, base_key+'message'):
+                    if not has_key(self.colors, base_key + 'message'):
                         attr |= bold
                         fg = red
                         fg += BRIGHT
                     else:
-                        fg, bg, attr = self._color((fg,bg,attr),getkey(self.colors, base_key+'message'))
+                        fg, bg, attr = self._color(
+                            (fg, bg, attr), getkey(self.colors, base_key + 'message'))
             if context.loaded:
-                if not has_key(self.colors, base_key+'loaded'):
+                if not has_key(self.colors, base_key + 'loaded'):
                     bg = getkey(self.colors, 'progress_bar_color')
                 else:
-                    fg, bg, attr = self._color((fg,bg,attr),getkey(self.colors, base_key+'loaded'))
+                    fg, bg, attr = self._color(
+                        (fg, bg, attr), getkey(self.colors, base_key + 'loaded'))
             if context.vcsinfo:
-                if not has_key(self.colors, base_key+'vcsinfo'):
+                if not has_key(self.colors, base_key + 'vcsinfo'):
                     fg = blue
                     attr &= ~bold
                 else:
-                    fg, bg, attr = self._color((fg,bg,attr),getkey(self.colors, base_key+'vcsinfo'))
+                    fg, bg, attr = self._color(
+                        (fg, bg, attr), getkey(self.colors, base_key + 'vcsinfo'))
             if context.vcscommit:
-                if not has_key(self.colors, base_key+'vcscommit'):
+                if not has_key(self.colors, base_key + 'vcscommit'):
                     fg = yellow
                     attr &= ~bold
                 else:
-                    fg, bg, attr = self._color((fg,bg,attr),getkey(self.colors, base_key+'vcscommit'))
+                    fg, bg, attr = self._color(
+                        (fg, bg, attr), getkey(self.colors, base_key + 'vcscommit'))
             if context.vcsdate:
-                if not has_key(self.colors, base_key+'vcsdate'):
+                if not has_key(self.colors, base_key + 'vcsdate'):
                     fg = cyan
                     attr &= ~bold
                 else:
-                    fg, bg, attr = self._color((fg,bg,attr),getkey(self.colors, base_key+'vcsdate'))
+                    fg, bg, attr = self._color(
+                        (fg, bg, attr), getkey(self.colors, base_key + 'vcsdate'))
 
         if context.text:
             if context.highlight:
                 if not has_key(self.colors, 'text.highlight'):
                     attr |= reverse
                 else:
-                    fg, bg, attr = self._color((fg,bg,attr),getkey(self.colors, base_key+'text.highlight'))
+                    fg, bg, attr = self._color(
+                        (fg, bg, attr), getkey(self.colors, base_key + 'text.highlight'))
 
         if context.in_taskview:
             base_key = 'taskview'
 
             if context.title:
-                if not has_key(self.colors, base_key+'title'):
+                if not has_key(self.colors, base_key + 'title'):
                     fg = blue
                 else:
-                    fg, bg, attr = self._color((fg,bg,attr),getkey(self.colors, base_key+'title'))
+                    fg, bg, attr = self._color(
+                        (fg, bg, attr), getkey(self.colors, base_key + 'title'))
 
             if context.selected:
-                if not has_key(self.colors, base_key+'selected'):
+                if not has_key(self.colors, base_key + 'selected'):
                     attr |= reverse
                 else:
-                    fg, bg, attr = self._color((fg,bg,attr),getkey(self.colors, base_key+'selected'))
+                    fg, bg, attr = self._color(
+                        (fg, bg, attr), getkey(self.colors, base_key + 'selected'))
 
             if context.loaded:
                 if context.selected:
-                    if not has_key(self.colors, base_key+'loaded.selected'):
+                    if not has_key(self.colors, base_key + 'loaded.selected'):
                         fg = getkey(self.colors, 'progress_bar_color')
                     else:
-                        fg, bg, attr = self._color((fg,bg,attr),getkey(self.colors, base_key+'loaded.selected'))
+                        fg, bg, attr = self._color(
+                            (fg, bg, attr), getkey(self.colors, base_key + 'loaded.selected'))
                 else:
-                    if not has_key(self.colors, base_key+'loaded.default'):
+                    if not has_key(self.colors, base_key + 'loaded.default'):
                         bg = getkey(self.colors, 'progress_bar_color')
                     else:
-                        fg, bg, attr = self._color((fg,bg,attr),getkey(self.colors, base_key+'loaded.default'))
+                        fg, bg, attr = self._color(
+                            (fg, bg, attr), getkey(self.colors, base_key + 'loaded.default'))
 
         if context.vcsfile and not context.selected:
             base_key = 'vcsfile.'
 
             if context.vcsconflict:
-                if not has_key(self.colors, base_key+'vcsconflict'):
+                if not has_key(self.colors, base_key + 'vcsconflict'):
                     fg = magenta
                     attr &= ~bold
                 else:
-                    fg, bg, attr = self._color((fg,bg,attr),getkey(self.colors, base_key+''))
+                    fg, bg, attr = self._color(
+                        (fg, bg, attr), getkey(self.colors, base_key + ''))
             elif context.vcsuntracked:
-                if not has_key(self.colors, base_key+'vcsuntracked'):
+                if not has_key(self.colors, base_key + 'vcsuntracked'):
                     fg = cyan
                     attr &= ~bold
                 else:
-                    fg, bg, attr = self._color((fg,bg,attr),getkey(self.colors, base_key+''))
+                    fg, bg, attr = self._color(
+                        (fg, bg, attr), getkey(self.colors, base_key + ''))
             elif context.vcschanged:
-                if not has_key(self.colors, base_key+'vcschanged'):
+                if not has_key(self.colors, base_key + 'vcschanged'):
                     fg = red
                     attr &= ~bold
                 else:
-                    fg, bg, attr = self._color((fg,bg,attr),getkey(self.colors, base_key+'vcschanged'))
+                    fg, bg, attr = self._color(
+                        (fg, bg, attr), getkey(self.colors, base_key + 'vcschanged'))
             elif context.vcsunknown:
-                if not has_key(self.colors, base_key+'vcsunknown'):
+                if not has_key(self.colors, base_key + 'vcsunknown'):
                     fg = red
                     attr &= ~bold
                 else:
-                    fg, bg, attr = self._color((fg,bg,attr),getkey(self.colors, base_key+'vcsunknown'))
+                    fg, bg, attr = self._color(
+                        (fg, bg, attr), getkey(self.colors, base_key + 'vcsunknown'))
             elif context.vcsstaged:
-                if not has_key(self.colors, base_key+'vcsstaged'):
+                if not has_key(self.colors, base_key + 'vcsstaged'):
                     fg = green
                     attr &= ~bold
                 else:
-                    fg, bg, attr = self._color((fg,bg,attr),getkey(self.colors, base_key+''))
+                    fg, bg, attr = self._color(
+                        (fg, bg, attr), getkey(self.colors, base_key + ''))
             elif context.vcssync:
-                if not has_key(self.colors, base_key+'vcssync'):
+                if not has_key(self.colors, base_key + 'vcssync'):
                     fg = green
                     attr &= ~bold
                 else:
-                    fg, bg, attr = self._color((fg,bg,attr),getkey(self.colors, base_key+'vcssync'))
+                    fg, bg, attr = self._color(
+                        (fg, bg, attr), getkey(self.colors, base_key + 'vcssync'))
             elif context.vcsignored:
-                if not has_key(self.colors, base_key+'vcsignored'):
+                if not has_key(self.colors, base_key + 'vcsignored'):
                     fg = default
                     attr &= ~bold
                 else:
-                    fg, bg, attr = self._color((fg,bg,attr),getkey(self.colors, base_key+'vcsignored'))
+                    fg, bg, attr = self._color(
+                        (fg, bg, attr), getkey(self.colors, base_key + 'vcsignored'))
 
         elif context.vcsremote and not context.selected:
             base_key = 'vcsremote'
             if context.vcssync:
-                if not has_key(self.colors, base_key+'vcssync'):
+                if not has_key(self.colors, base_key + 'vcssync'):
                     fg = green
                     attr &= ~bold
                 else:
-                    fg, bg, attr = self._color((fg,bg,attr),getkey(self.colors, base_key+'vcssync'))
+                    fg, bg, attr = self._color(
+                        (fg, bg, attr), getkey(self.colors, base_key + 'vcssync'))
             if context.vcsnone:
-                if not has_key(self.colors, base_key+'vcsnone'):
+                if not has_key(self.colors, base_key + 'vcsnone'):
                     fg = green
                     attr &= ~bold
                 else:
-                    fg, bg, attr = self._color((fg,bg,attr),getkey(self.colors, base_key+'vcsnone'))
+                    fg, bg, attr = self._color(
+                        (fg, bg, attr), getkey(self.colors, base_key + 'vcsnone'))
             elif context.vcsbehind:
-                if not has_key(self.colors, base_key+'vcsbehind'):
+                if not has_key(self.colors, base_key + 'vcsbehind'):
                     fg = red
                     attr &= ~bold
                 else:
-                    fg, bg, attr = self._color((fg,bg,attr),getkey(self.colors, base_key+'vcsbehind'))
+                    fg, bg, attr = self._color(
+                        (fg, bg, attr), getkey(self.colors, base_key + 'vcsbehind'))
             elif context.vcsahead:
-                if not has_key(self.colors, base_key+'vcsahead'):
+                if not has_key(self.colors, base_key + 'vcsahead'):
                     fg = blue
                     attr &= ~bold
                 else:
-                    fg, bg, attr = self._color((fg,bg,attr),getkey(self.colors, base_key+'vcsahead'))
+                    fg, bg, attr = self._color(
+                        (fg, bg, attr), getkey(self.colors, base_key + 'vcsahead'))
             elif context.vcsdiverged:
-                if not has_key(self.colors, base_key+'vcsdiverged'):
+                if not has_key(self.colors, base_key + 'vcsdiverged'):
                     fg = magenta
                     attr &= ~bold
                 else:
-                    fg, bg, attr = self._color((fg,bg,attr),getkey(self.colors, base_key+'vcsdiverged'))
+                    fg, bg, attr = self._color(
+                        (fg, bg, attr), getkey(self.colors, base_key + 'vcsdiverged'))
             elif context.vcsunknown:
-                if not has_key(self.colors, base_key+'vcsunknown'):
+                if not has_key(self.colors, base_key + 'vcsunknown'):
                     fg = red
                     attr &= ~bold
                 else:
-                    fg, bg, attr = self._color((fg,bg,attr),getkey(self.colors, base_key+'vcsunknown'))
+                    fg, bg, attr = self._color(
+                        (fg, bg, attr), getkey(self.colors, base_key + 'vcsunknown'))
 
         return fg, bg, attr

--- a/ranger/colorschemes/default.py
+++ b/ranger/colorschemes/default.py
@@ -9,176 +9,434 @@ from ranger.gui.color import (
     normal, bold, reverse, dim, BRIGHT,
     default_colors,
 )
+from ranger.core.actions import Actions
 
+
+def color(fg=-1, bg=-1, attr=0):
+    return (fg, bg, attr)
+
+def getkey(d, key):
+    keys = key.split('.')
+    code = ''
+    for i in dir():
+        if eval(i) == d:
+            code += i
+
+    for k in keys:
+        code += '["' + k + '"]'
+
+    return eval(code)
+
+def has_key(dictionary, key):
+    try:
+        getkey(dictionary, key)
+    except KeyError:
+        return False
+    return True
 
 class Default(ColorScheme):
-    progress_bar_color = blue
+    progress_bar_color = None
+    colors = { 'progress_bar_color': blue }
 
-    def use(self, context):  # pylint: disable=too-many-branches,too-many-statements
+    def _color(self, clrtup, valtup):
+        clr = []
+        if valtup[0] == default_colors[0]:
+            clr.append(clrtup[0])
+        else:
+            clr.append(valtup[0])
+
+        if valtup[1] == default_colors[1]:
+            clr.append(clrtup[1])
+        else:
+            clr.append(valtup[1])
+
+        if valtup[2] == default_colors[2]:
+            clr.append(clrtup[2])
+        else:
+            clr.append(valtup[2])
+
+        return clr
+
+    def use(self, context):
+        if not self.progress_bar_color is None: self.colors['progress_bar_color'] = self.progress_bar_color
+        base_key = ''
         fg, bg, attr = default_colors
 
         if context.reset:
-            return default_colors
+            if not has_key(self.colors, 'reset'):
+                return default_colors
+            else:
+                return getkey(self.colors, 'reset')
 
         elif context.in_browser:
+            base_key = 'browser.'
             if context.selected:
-                attr = reverse
+                if not has_key(self.colors, base_key+'selected'):
+                    attr = reverse
+                else:
+                    fg, bg, attr = self._color((fg,bg,attr),getkey(self.colors, base_key+'selected'))
             else:
-                attr = normal
-            if context.empty or context.error:
-                bg = red
+                if not has_key(self.colors, base_key+'default'):
+                    attr = normal
+                else:
+                    fg, bg, attr = self._color((fg,bg,attr),getkey(self.colors, base_key+'default'))
+            if context.empty:
+                if not has_key(self.colors, base_key+'empty'):
+                    bg = red
+                else:
+                    fg, bg, attr = self._color((fg,bg,attr),getkey(self.colors, base_key+'empty'))
+            if context.error:
+                if not has_key(self.colors, base_key+'error'):
+                    bg = red
+                else:
+                    fg, bg, attr = self._color((fg,bg,attr),getkey(self.colors, base_key+'error'))
             if context.border:
-                fg = default
+                if not has_key(self.colors, base_key+'border'):
+                    fg = default
+                else:
+                    fg, bg, attr = self._color((fg,bg,attr),getkey(self.colors, base_key+'border'))
             if context.media:
                 if context.image:
-                    fg = yellow
+                    if not has_key(self.colors, base_key+'media.image'):
+                        fg = yellow
+                    else:
+                        fg, bg, attr = self._color((fg,bg,attr),getkey(self.colors, base_key+'media.image'))
                 else:
-                    fg = magenta
+                    if not has_key(self.colors, base_key+'default'):
+                        fg = magenta
+                    else:
+                        fg, bg, attr = self._color((fg,bg,attr),getkey(self.colors, base_key+'default'))
             if context.container:
-                fg = red
+                if not has_key(self.colors, base_key+'container'):
+                    fg = red
+                else:
+                    fg, bg, attr = self._color((fg,bg,attr),getkey(self.colors, base_key+'container'))
             if context.directory:
-                attr |= bold
-                fg = blue
-                fg += BRIGHT
+                if not has_key(self.colors, base_key+'directory'):
+                    attr |= bold
+                    fg = blue
+                    fg += BRIGHT
+                else:
+                    fg, bg, attr = self._color((fg,bg,attr),getkey(self.colors, base_key+'directory'))
             elif context.executable and not \
                     any((context.media, context.container,
                          context.fifo, context.socket)):
-                attr |= bold
-                fg = green
-                fg += BRIGHT
+                if not has_key(self.colors, base_key+'executable'):
+                    attr |= bold
+                    fg = green
+                    fg += BRIGHT
+                else:
+                    fg, bg, attr = self._color((fg,bg,attr),getkey(self.colors, base_key+'executable'))
             if context.socket:
-                attr |= bold
-                fg = magenta
-                fg += BRIGHT
-            if context.fifo or context.device:
-                fg = yellow
-                if context.device:
+                if not has_key(self.colors, base_key+'socket'):
+                    attr |= bold
+                    fg = magenta
+                    fg += BRIGHT
+                else:
+                    fg, bg, attr = self._color((fg,bg,attr),getkey(self.colors, base_key+'socket'))
+            if context.fifo:
+                if not has_key(self.colors, base_key+'fifo'):
+                    fg = yellow
+                else:
+                    fg, bg, attr = self._color((fg,bg,attr),getkey(self.colors, base_key+'fifo'))
+            if context.device:
+                if not has_key(self.colors, base_key+'fifo'):
+                    fg = yellow
                     attr |= bold
                     fg += BRIGHT
-            if context.link:
-                fg = cyan if context.good else magenta
-            if context.tag_marker and not context.selected:
-                attr |= bold
-                if fg in (red, magenta):
-                    fg = white
                 else:
-                    fg = red
-                fg += BRIGHT
-            if not context.selected and (context.cut or context.copied):
-                attr |= bold
-                fg = black
-                fg += BRIGHT
-                # If the terminal doesn't support bright colors, use dim white
-                # instead of black.
-                if BRIGHT == 0:
-                    attr |= dim
-                    fg = white
+                    fg, bg, attr = self._color((fg,bg,attr),getkey(self.colors, base_key+'fifo'))
+            if context.link:
+                if context.good:
+                    if not has_key(self.colors, base_key+'link.good'):
+                        fg = cyan
+                    else:
+                        fg, bg, attr = self._color((fg,bg,attr),getkey(self.colors, base_key+'link.good'))
+                else:
+                    if not has_key(self.colors, base_key+'default'):
+                        fg = magenta
+                    else:
+                        fg, bg, attr = self._color((fg,bg,attr),getkey(self.colors, base_key+'default'))
+            if context.tag_marker and not context.selected:
+                if not has_key(self.colors, base_key+'tag_marker'):
+                    if fg in (red, magenta):
+                        fg = white
+                    else:
+                        fg = red
+                    fg += BRIGHT
+                    attr |= bold
+                else:
+                    fg, bg, attr = self._color((fg,bg,attr),getkey(self.colors, base_key+'tag_marker'))
+            if not context.selected and context.cut:
+                if not has_key(self.colors, base_key+'cut'):
+                    attr |= bold
+                    fg = black
+                    fg += BRIGHT
+                    # If the terminal doesn't support bright colors, use dim white
+                    # instead of black.
+                    if BRIGHT == 0:
+                        attr |= dim
+                        fg = white
+                else:
+                    fg, bg, attr = self._color((fg,bg,attr),getkey(self.colors, base_key+'cut'))
+            if not context.selected and context.copied:
+                if not has_key(self.colors, base_key+'copied'):
+                    attr |= bold
+                    fg = black
+                    fg += BRIGHT
+                    # If the terminal doesn't support bright colors, use dim white
+                    # instead of black.
+                    if BRIGHT == 0:
+                        attr |= dim
+                        fg = white
+                else:
+                    fg, bg, attr = self._color((fg,bg,attr),getkey(self.colors, base_key+'copied'))
             if context.main_column:
+                base_key = 'browser.main.'
                 # Doubling up with BRIGHT here causes issues because it's
                 # additive not idempotent.
                 if context.selected:
-                    attr |= bold
+                    if not has_key(self.colors, base_key+'selected'):
+                        attr |= bold
+                    else:
+                        fg, bg, attr = self._color((fg,bg,attr),getkey(self.colors, base_key+'selected'))
                 if context.marked:
-                    attr |= bold
-                    fg = yellow
+                    if not has_key(self.colors, base_key+'marked'):
+                        attr |= bold
+                        fg = yellow
+                    else:
+                        fg, bg, attr = self._color((fg,bg,attr),getkey(self.colors, base_key+'marked'))
+            base_key = 'browser.'
             if context.badinfo:
-                if attr & reverse:
-                    bg = magenta
+                if not has_key(self.colors, base_key+'badinfo'):
+                    if attr & reverse:
+                        bg = magenta
+                    else:
+                        fg = magenta
                 else:
-                    fg = magenta
-
+                    fg, bg, attr = self._color((fg,bg,attr),getkey(self.colors, base_key+'badinfo'))
             if context.inactive_pane:
-                fg = cyan
+                if not has_key(self.colors, base_key+'inactive'):
+                    fg = cyan
+                else:
+                    fg, bg, attr = self._color((fg,bg,attr),getkey(self.colors, base_key+'inactive'))
 
         elif context.in_titlebar:
+            base_key = 'titlebar.'
+
             if context.hostname:
-                fg = red if context.bad else green
+                if context.bad:
+                    if not has_key(self.colors, base_key+'hostname.bad'):
+                        fg = red
+                        attr |= bold
+                        fg += BRIGHT
+                    else:
+                        fg, bg, attr = self._color((fg,bg,attr),getkey(self.colors, base_key+'hostname.bad'))
+                else:
+                    if not has_key(self.colors, base_key+'hostname.default'):
+                        fg = green
+                    else:
+                        fg, bg, attr = self._color((fg,bg,attr),getkey(self.colors, base_key+'hostname.default'))
             elif context.directory:
-                fg = blue
+                if not has_key(self.colors, base_key+'directory'):
+                    fg = blue
+                    attr |= bold
+                    fg += BRIGHT
+                else:
+                    fg, bg, attr = self._color((fg,bg,attr),getkey(self.colors, base_key+'directory'))
             elif context.tab:
                 if context.good:
-                    bg = green
+                    if not has_key(self.colors, base_key+'tab.good'):
+                        bg = green
+                        attr |= bold
+                        fg += BRIGHT
+                    else:
+                        fg, bg, attr = self._color((fg,bg,attr),getkey(self.colors, base_key+'tab.good'))
             elif context.link:
-                fg = cyan
-            attr |= bold
-            fg += BRIGHT
+                if not has_key(self.colors, base_key+'link'):
+                    fg = cyan
+                    attr |= bold
+                    fg += BRIGHT
+                else:
+                    fg, bg, attr = self._color((fg,bg,attr),getkey(self.colors, base_key+'link'))
 
         elif context.in_statusbar:
+            base_key = 'statusbar.'
+
             if context.permissions:
                 if context.good:
-                    fg = cyan
+                    if not has_key(self.colors, base_key+'permissions.good'):
+                        fg = cyan
+                    else:
+                        fg, bg, attr = self._color((fg,bg,attr),getkey(self.colors, base_key+'permissions.good'))
                 elif context.bad:
-                    fg = magenta
+                    if not has_key(self.colors, base_key+'permissions.bad'):
+                        fg = magenta
+                    else:
+                        fg, bg, attr = self._color((fg,bg,attr),getkey(self.colors, base_key+'permissions.bad'))
             if context.marked:
-                attr |= bold | reverse
-                fg = yellow
-                fg += BRIGHT
+                if not has_key(self.colors, base_key+'marked'):
+                    attr |= bold | reverse
+                    fg = yellow
+                    fg += BRIGHT
+                else:
+                    fg, bg, attr = self._color((fg,bg,attr),getkey(self.colors, base_key+'marked'))
             if context.frozen:
-                attr |= bold | reverse
-                fg = cyan
-                fg += BRIGHT
+                if not has_key(self.colors, base_key+'frozen'):
+                    attr |= bold | reverse
+                    fg = cyan
+                    fg += BRIGHT
+                else:
+                    fg, bg, attr = self._color((fg,bg,attr),getkey(self.colors, base_key+'frozen'))
             if context.message:
                 if context.bad:
-                    attr |= bold
-                    fg = red
-                    fg += BRIGHT
+                    if not has_key(self.colors, base_key+'message'):
+                        attr |= bold
+                        fg = red
+                        fg += BRIGHT
+                    else:
+                        fg, bg, attr = self._color((fg,bg,attr),getkey(self.colors, base_key+'message'))
             if context.loaded:
-                bg = self.progress_bar_color
+                if not has_key(self.colors, base_key+'loaded'):
+                    bg = getkey(self.colors, 'progress_bar_color')
+                else:
+                    fg, bg, attr = self._color((fg,bg,attr),getkey(self.colors, base_key+'loaded'))
             if context.vcsinfo:
-                fg = blue
-                attr &= ~bold
+                if not has_key(self.colors, base_key+'vcsinfo'):
+                    fg = blue
+                    attr &= ~bold
+                else:
+                    fg, bg, attr = self._color((fg,bg,attr),getkey(self.colors, base_key+'vcsinfo'))
             if context.vcscommit:
-                fg = yellow
-                attr &= ~bold
+                if not has_key(self.colors, base_key+'vcscommit'):
+                    fg = yellow
+                    attr &= ~bold
+                else:
+                    fg, bg, attr = self._color((fg,bg,attr),getkey(self.colors, base_key+'vcscommit'))
             if context.vcsdate:
-                fg = cyan
-                attr &= ~bold
+                if not has_key(self.colors, base_key+'vcsdate'):
+                    fg = cyan
+                    attr &= ~bold
+                else:
+                    fg, bg, attr = self._color((fg,bg,attr),getkey(self.colors, base_key+'vcsdate'))
 
         if context.text:
             if context.highlight:
-                attr |= reverse
+                if not has_key(self.colors, 'text.highlight'):
+                    attr |= reverse
+                else:
+                    fg, bg, attr = self._color((fg,bg,attr),getkey(self.colors, base_key+'text.highlight'))
 
         if context.in_taskview:
+            base_key = 'taskview'
+
             if context.title:
-                fg = blue
+                if not has_key(self.colors, base_key+'title'):
+                    fg = blue
+                else:
+                    fg, bg, attr = self._color((fg,bg,attr),getkey(self.colors, base_key+'title'))
 
             if context.selected:
-                attr |= reverse
+                if not has_key(self.colors, base_key+'selected'):
+                    attr |= reverse
+                else:
+                    fg, bg, attr = self._color((fg,bg,attr),getkey(self.colors, base_key+'selected'))
 
             if context.loaded:
                 if context.selected:
-                    fg = self.progress_bar_color
+                    if not has_key(self.colors, base_key+'loaded.selected'):
+                        fg = getkey(self.colors, 'progress_bar_color')
+                    else:
+                        fg, bg, attr = self._color((fg,bg,attr),getkey(self.colors, base_key+'loaded.selected'))
                 else:
-                    bg = self.progress_bar_color
+                    if not has_key(self.colors, base_key+'loaded.default'):
+                        bg = getkey(self.colors, 'progress_bar_color')
+                    else:
+                        fg, bg, attr = self._color((fg,bg,attr),getkey(self.colors, base_key+'loaded.default'))
 
         if context.vcsfile and not context.selected:
-            attr &= ~bold
+            base_key = 'vcsfile.'
+
             if context.vcsconflict:
-                fg = magenta
+                if not has_key(self.colors, base_key+'vcsconflict'):
+                    fg = magenta
+                    attr &= ~bold
+                else:
+                    fg, bg, attr = self._color((fg,bg,attr),getkey(self.colors, base_key+''))
             elif context.vcsuntracked:
-                fg = cyan
+                if not has_key(self.colors, base_key+'vcsuntracked'):
+                    fg = cyan
+                    attr &= ~bold
+                else:
+                    fg, bg, attr = self._color((fg,bg,attr),getkey(self.colors, base_key+''))
             elif context.vcschanged:
-                fg = red
+                if not has_key(self.colors, base_key+'vcschanged'):
+                    fg = red
+                    attr &= ~bold
+                else:
+                    fg, bg, attr = self._color((fg,bg,attr),getkey(self.colors, base_key+'vcschanged'))
             elif context.vcsunknown:
-                fg = red
+                if not has_key(self.colors, base_key+'vcsunknown'):
+                    fg = red
+                    attr &= ~bold
+                else:
+                    fg, bg, attr = self._color((fg,bg,attr),getkey(self.colors, base_key+'vcsunknown'))
             elif context.vcsstaged:
-                fg = green
+                if not has_key(self.colors, base_key+'vcsstaged'):
+                    fg = green
+                    attr &= ~bold
+                else:
+                    fg, bg, attr = self._color((fg,bg,attr),getkey(self.colors, base_key+''))
             elif context.vcssync:
-                fg = green
+                if not has_key(self.colors, base_key+'vcssync'):
+                    fg = green
+                    attr &= ~bold
+                else:
+                    fg, bg, attr = self._color((fg,bg,attr),getkey(self.colors, base_key+'vcssync'))
             elif context.vcsignored:
-                fg = default
+                if not has_key(self.colors, base_key+'vcsignored'):
+                    fg = default
+                    attr &= ~bold
+                else:
+                    fg, bg, attr = self._color((fg,bg,attr),getkey(self.colors, base_key+'vcsignored'))
 
         elif context.vcsremote and not context.selected:
-            attr &= ~bold
-            if context.vcssync or context.vcsnone:
-                fg = green
+            base_key = 'vcsremote'
+            if context.vcssync:
+                if not has_key(self.colors, base_key+'vcssync'):
+                    fg = green
+                    attr &= ~bold
+                else:
+                    fg, bg, attr = self._color((fg,bg,attr),getkey(self.colors, base_key+'vcssync'))
+            if context.vcsnone:
+                if not has_key(self.colors, base_key+'vcsnone'):
+                    fg = green
+                    attr &= ~bold
+                else:
+                    fg, bg, attr = self._color((fg,bg,attr),getkey(self.colors, base_key+'vcsnone'))
             elif context.vcsbehind:
-                fg = red
+                if not has_key(self.colors, base_key+'vcsbehind'):
+                    fg = red
+                    attr &= ~bold
+                else:
+                    fg, bg, attr = self._color((fg,bg,attr),getkey(self.colors, base_key+'vcsbehind'))
             elif context.vcsahead:
-                fg = blue
+                if not has_key(self.colors, base_key+'vcsahead'):
+                    fg = blue
+                    attr &= ~bold
+                else:
+                    fg, bg, attr = self._color((fg,bg,attr),getkey(self.colors, base_key+'vcsahead'))
             elif context.vcsdiverged:
-                fg = magenta
+                if not has_key(self.colors, base_key+'vcsdiverged'):
+                    fg = magenta
+                    attr &= ~bold
+                else:
+                    fg, bg, attr = self._color((fg,bg,attr),getkey(self.colors, base_key+'vcsdiverged'))
             elif context.vcsunknown:
-                fg = red
+                if not has_key(self.colors, base_key+'vcsunknown'):
+                    fg = red
+                    attr &= ~bold
+                else:
+                    fg, bg, attr = self._color((fg,bg,attr),getkey(self.colors, base_key+'vcsunknown'))
 
         return fg, bg, attr

--- a/ranger/colorschemes/jungle.py
+++ b/ranger/colorschemes/jungle.py
@@ -8,7 +8,7 @@ from ranger.gui.color import green, red, blue
 
 
 class Scheme(Default):
-    progress_bar_color = green
+    colors = { 'progress_bar_color': green }
 
     def use(self, context):
         fg, bg, attr = Default.use(self, context)

--- a/ranger/colorschemes/jungle.py
+++ b/ranger/colorschemes/jungle.py
@@ -8,7 +8,7 @@ from ranger.gui.color import green, red, blue
 
 
 class Scheme(Default):
-    colors = { 'progress_bar_color': green }
+    colors = {'progress_bar_color': green}
 
     def use(self, context):
         fg, bg, attr = Default.use(self, context)


### PR DESCRIPTION
Continuation of PR #1229. Sorry that this is a year later.
For those who don't know, this is going to make defining colorschemes easier.

With the proposed method, it goes from a (no offense) dirty interface to a cleaner one, imo:

```python
from ranger.colorschemes.default import Default, color

# Must be `Scheme` because of how ranger detects colorschemes
class Scheme(Default):
    colors = {
        'browser': {
            'selected': color(bg=red)
        }
    }
```

#### ISSUE TYPE
- Improvement/feature implementation

#### CHECKLIST
- [X] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [X] All changes follow the code style **[REQUIRED]**
- [X] All new and existing tests pass **[REQUIRED]**
- [ ] Changes require config files to be updated
    - [ ] Config files have been updated
- [X] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
Instead of overriding the entire use method directly for even the smallest changes, like changing the color of something, one can add keys to the `colors` dictionary, which makes life a lot easier. So as not to break the existing schemes, I modified the default scheme (which looks the same) and left the original colorscheme class alone, which @toonn suggested in #1229.

#### MOTIVATION AND CONTEXT
I went to create my own colorscheme and found a poorly documented (for a newcomer) mess of if statements and contexts. I just wanted to switch around a few colors.