### PR TITLE
Add GitHub Actions ci

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -1,0 +1,30 @@
+name: Python lints and tests
+
+on:
+  push:
+    paths:
+      - '.github/workflows/python.yml'
+      - '*.py'
+
+jobs:
+  test_py:
+    runs-on: ubuntu-latest
+    strategy:
+      max-parallel: 4
+      matrix:
+        python-version: [2.7, 3.5, 3.6, 3.7]
+    steps:
+    - uses: actions/checkout@v1
+      with:
+        fetch-depth: 1
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+    - name: Lint and test with pylint, flake8, doctest, pytest
+      run: |
+        make test_py

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,0 +1,22 @@
+name: Shellcheck scope.sh
+
+on: 
+  push:
+    paths:
+      - '.github/workflows/shellcheck.yml'
+      - 'ranger/data/scope.sh'
+
+jobs:
+  test_shellcheck:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+      with:
+        fetch-depth: 1
+    - name: Install newer shellcheck (0.7.0 rather than 0.4.6)
+      run: |
+        curl -LO "https://storage.googleapis.com/shellcheck/shellcheck-stable.linux.x86_64.tar.xz"
+        tar xf shellcheck-stable.linux.x86_64.tar.xz
+    - name: Shellcheck scope.sh
+      run: |
+        env PATH=shellcheck-stable:$PATH make test_shellcheck

--- a/ranger/data/scope.sh
+++ b/ranger/data/scope.sh
@@ -45,7 +45,6 @@ HIGHLIGHT_STYLE=${HIGHLIGHT_STYLE:-pablo}
 HIGHLIGHT_OPTIONS="--replace-tabs=${HIGHLIGHT_TABWIDTH} --style=${HIGHLIGHT_STYLE} ${HIGHLIGHT_OPTIONS:-}"
 PYGMENTIZE_STYLE=${PYGMENTIZE_STYLE:-autumn}
 
-
 handle_extension() {
     case "${FILE_EXTENSION_LOWER}" in
         ## Archive


### PR DESCRIPTION
Run our python tests and shellcheck in seperate workflows only when
relevant files are changed, respectively python files or `scope.sh`.

This tests with one extra version of python, 3.7.

GitHub's version of shellcheck seems to be missing a few flags. So we
download the latest stable version, 0.7.0 currently.