### PR TITLE
added registry for ImageDisplayer classes

### DIFF
--- a/ranger/core/fm.py
+++ b/ranger/core/fm.py
@@ -22,7 +22,7 @@ from ranger.container.tags import Tags, TagsDummy
 from ranger.gui.ui import UI
 from ranger.container.bookmarks import Bookmarks
 from ranger.core.runner import Runner
-from ranger.ext import img_display
+from ranger.ext.img_display import get_image_displayer
 from ranger.core.metadata import MetadataManager
 from ranger.ext.rifle import Rifle
 from ranger.container.directory import Directory
@@ -100,7 +100,7 @@ class FM(Actions,  # pylint: disable=too-many-instance-attributes
         def set_image_displayer():
             if self.image_displayer:
                 self.image_displayer.quit()
-            self.image_displayer = self._get_image_displayer()
+            self.image_displayer = get_image_displayer(self.settings.preview_images_method)
         set_image_displayer()
         self.settings.signal_bind('setopt.preview_images_method', set_image_displayer,
                                   priority=settings.SIGNAL_PRIORITY_AFTER_SYNC)
@@ -222,11 +222,6 @@ class FM(Actions,  # pylint: disable=too-many-instance-attributes
         for entry in logutils.QUEUE:
             for line in entry.splitlines():
                 yield line
-
-    def _get_image_displayer(self):
-        registry = img_display.IMAGE_DISPLAYER_REGISTRY
-        cls = registry[self.settings.preview_images_method]
-        return cls()
 
     def _get_thisfile(self):
         return self.thistab.thisfile

--- a/ranger/core/fm.py
+++ b/ranger/core/fm.py
@@ -22,11 +22,7 @@ from ranger.container.tags import Tags, TagsDummy
 from ranger.gui.ui import UI
 from ranger.container.bookmarks import Bookmarks
 from ranger.core.runner import Runner
-from ranger.ext.img_display import (W3MImageDisplayer, ITerm2ImageDisplayer,
-                                    TerminologyImageDisplayer,
-                                    URXVTImageDisplayer, URXVTImageFSDisplayer,
-                                    KittyImageDisplayer, UeberzugImageDisplayer,
-                                    ImageDisplayer)
+from ranger.ext import img_display
 from ranger.core.metadata import MetadataManager
 from ranger.ext.rifle import Rifle
 from ranger.container.directory import Directory
@@ -227,22 +223,10 @@ class FM(Actions,  # pylint: disable=too-many-instance-attributes
             for line in entry.splitlines():
                 yield line
 
-    def _get_image_displayer(self):  # pylint: disable=too-many-return-statements
-        if self.settings.preview_images_method == "w3m":
-            return W3MImageDisplayer()
-        elif self.settings.preview_images_method == "iterm2":
-            return ITerm2ImageDisplayer()
-        elif self.settings.preview_images_method == "terminology":
-            return TerminologyImageDisplayer()
-        elif self.settings.preview_images_method == "urxvt":
-            return URXVTImageDisplayer()
-        elif self.settings.preview_images_method == "urxvt-full":
-            return URXVTImageFSDisplayer()
-        elif self.settings.preview_images_method == "kitty":
-            return KittyImageDisplayer()
-        elif self.settings.preview_images_method == "ueberzug":
-            return UeberzugImageDisplayer()
-        return ImageDisplayer()
+    def _get_image_displayer(self):
+        registry = img_display.IMAGE_DISPLAYER_REGISTRY
+        cls = registry[self.settings.preview_images_method]
+        return cls()
 
     def _get_thisfile(self):
         return self.thistab.thisfile

--- a/ranger/ext/img_display.py
+++ b/ranger/ext/img_display.py
@@ -510,6 +510,7 @@ class URXVTImageFSDisplayer(URXVTImageDisplayer):
         return self._get_centered_offsets()
 
 
+@register_image_displayer("kitty")
 class KittyImageDisplayer(ImageDisplayer, FileManagerAware):
     """Implementation of ImageDisplayer for kitty (https://github.com/kovidgoyal/kitty/)
     terminal. It uses the built APC to send commands and data to kitty,
@@ -705,6 +706,7 @@ class KittyImageDisplayer(ImageDisplayer, FileManagerAware):
         #         continue
 
 
+@register_image_displayer("ueberzug")
 class UeberzugImageDisplayer(ImageDisplayer):
     """Implementation of ImageDisplayer using ueberzug.
     Ueberzug can display images in a Xorg session.

--- a/ranger/ext/img_display.py
+++ b/ranger/ext/img_display.py
@@ -72,12 +72,16 @@ class ImageDisplayError(Exception):
 class ImgDisplayUnsupportedException(Exception):
     pass
 
+
 def fallback_image_displayer():
     """Simply makes some noise when chosen. Temporary fallback behavior."""
 
     raise ImgDisplayUnsupportedException
 
+
 IMAGE_DISPLAYER_REGISTRY = defaultdict(fallback_image_displayer)
+
+
 def register_image_displayer(nickname=None):
     """Register an ImageDisplayer by nickname if available."""
 
@@ -85,6 +89,7 @@ def register_image_displayer(nickname=None):
         IMAGE_DISPLAYER_REGISTRY[nickname or cls.__name__] = cls
         return cls
     return decorator
+
 
 class ImageDisplayer(object):
     """Image display provider functions for drawing images in the terminal"""

--- a/ranger/ext/img_display.py
+++ b/ranger/ext/img_display.py
@@ -91,6 +91,11 @@ def register_image_displayer(nickname=None):
     return decorator
 
 
+def get_image_displayer(key):
+    cls = IMAGE_DISPLAYER_REGISTRY[key]
+    return cls()
+
+
 class ImageDisplayer(object):
     """Image display provider functions for drawing images in the terminal"""
 

--- a/ranger/ext/img_display.py
+++ b/ranger/ext/img_display.py
@@ -85,15 +85,19 @@ IMAGE_DISPLAYER_REGISTRY = defaultdict(fallback_image_displayer)
 def register_image_displayer(nickname=None):
     """Register an ImageDisplayer by nickname if available."""
 
-    def decorator(cls):
-        IMAGE_DISPLAYER_REGISTRY[nickname or cls.__name__] = cls
-        return cls
+    def decorator(image_displayer_class):
+        if nickname:
+            registry_key = nickname
+        else:
+            registry_key = image_displayer_class.__name__
+        IMAGE_DISPLAYER_REGISTRY[registry_key] = image_displayer_class
+        return image_displayer_class
     return decorator
 
 
-def get_image_displayer(key):
-    cls = IMAGE_DISPLAYER_REGISTRY[key]
-    return cls()
+def get_image_displayer(registry_key):
+    image_displayer_class = IMAGE_DISPLAYER_REGISTRY[registry_key]
+    return image_displayer_class()
 
 
 class ImageDisplayer(object):


### PR DESCRIPTION
Added ImageDisplayer registry

#### ISSUE TYPE
- Improvement/feature implementation

#### RUNTIME ENVIRONMENT
- Operating system and version: Arch Linux
- Terminal emulator and version: st 0.7
- Python version: 3.7.4
- Ranger version/commit: ranger-master v1.9.2-319-g3b8a3252/86281229606e147870b365d7aff445e394883674
- Locale: en_us

#### CHECKLIST
- [X] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [X] All changes follow the code style **[REQUIRED]**
- [X] All new and existing tests pass **[REQUIRED]**
- [ ] Changes require config files to be updated
    - [ ] Config files have been updated
- [X] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
- commit 3b8a32522ebb392a29759ec814947db048592f2e
I've added a registry for ImageDisplayers, to manage a growing number of sub-classes and to allow users to add their own sub-classes. Each ImageDisplayer can register with a key by using the register_image_displayer class decorator. These classes can then be used by setting preview_images_method accordingly in their rc.conf.

For example, in commands.py:
```
from ranger.ext.img_display import register_image_displayer, ImageDisplayer

@register_image_displayer('my-custom-image-displayer')
class MyImageDisplayer(ImageDisplayer):
    def draw(self, path, start_x, start_y, width, height):
        import subprocess
        subprocess.check_call(['sxiv', path])
```

And in rc.conf:
```
set preview_images_method my-custom-image-displayer
```

#### MOTIVATION AND CONTEXT
To ease the management of many ImageDisplayers and allow users to easily implement their own.

Link to relevant issues:
Splits the registry portion of #872. Apologies for the asinine delay and thanks to @Vifon for splitting off the MPV portion of that old PR.



#### TESTING
What tests have been run?
I have run the included tests and have been using the registry myself with a few additional image preview methods (mostly various MPV configurations). Before submitting, I also re-ran it with w3m on urxvt.

How does the changes affect other areas of the codebase?
I don't think it will. However it should allow image displayers to be externalized.