### PR TITLE
Seperate failing GH Actions

### DIFF
--- a/.github/workflows/doctest.yml
+++ b/.github/workflows/doctest.yml
@@ -1,9 +1,9 @@
-name: Python lints and tests
+name: Python doctest and pytest
 
 on:
   push:
     paths:
-      - '.github/workflows/python.yml'
+      - '.github/workflows/doctest.yml'
       - '*.py'
 
 jobs:
@@ -25,6 +25,6 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
-    - name: Lint and test with pylint, flake8, -d-o-c-t-e-s-t-, -p-y-t-e-s-t-
+    - name: doctest
       run: |
-        make test_pylint test_flake8 test_pytest
+        make test_doctest test_other

--- a/.github/workflows/py37.yml
+++ b/.github/workflows/py37.yml
@@ -1,0 +1,30 @@
+name: Python 3.7 lints and tests
+
+on:
+  push:
+    paths:
+      - '.github/workflows/py37.yml'
+      - '*.py'
+
+jobs:
+  test_py:
+    runs-on: ubuntu-latest
+    strategy:
+      max-parallel: 4
+      matrix:
+        python-version: [3.7]
+    steps:
+    - uses: actions/checkout@v1
+      with:
+        fetch-depth: 1
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r <(sed 's/<2//' requirements.txt)
+    - name: Lint and test with pylint, flake8, doctest, pytest
+      run: |
+        make test_py

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [2.7, 3.5, 3.6, 3.7]
+        python-version: [2.7, 3.5, 3.6]
     steps:
     - uses: actions/checkout@v1
       with:


### PR DESCRIPTION
Some of our tests fail because the GH Actions runners don't provide a terminfo database which ncurses needs. I've seperated the troublesome tests so we still get *some* feedback.