### PR TITLE
Truncate the VCS commit message

### DIFF
--- a/ranger/gui/widgets/statusbar.py
+++ b/ranger/gui/widgets/statusbar.py
@@ -212,7 +212,7 @@ class StatusBar(Widget):  # pylint: disable=too-many-instance-attributes
                 left.add_space()
                 left.add(directory.vcs.rootvcs.head['date'].strftime(self.timeformat), 'vcsdate')
                 left.add_space()
-                left.add(directory.vcs.rootvcs.head['summary'][:70], 'vcscommit')
+                left.add(directory.vcs.rootvcs.head['summary'][:50], 'vcscommit')
 
     def _get_owner(self, target):
         uid = target.stat.st_uid

--- a/ranger/gui/widgets/statusbar.py
+++ b/ranger/gui/widgets/statusbar.py
@@ -212,7 +212,7 @@ class StatusBar(Widget):  # pylint: disable=too-many-instance-attributes
                 left.add_space()
                 left.add(directory.vcs.rootvcs.head['date'].strftime(self.timeformat), 'vcsdate')
                 left.add_space()
-                left.add(directory.vcs.rootvcs.head['summary'], 'vcscommit')
+                left.add(directory.vcs.rootvcs.head['summary'][:70], 'vcscommit')
 
     def _get_owner(self, target):
         uid = target.stat.st_uid


### PR DESCRIPTION
Fixes #1704.

The last commit message shown in the status bar is now truncated at 70 characters so it doesn't get hidden entirely if it's ridiculously long. I chose 70 characters as a pretty common limit.