### PR TITLE
Add a configurable max VCS message length

### DIFF
--- a/doc/ranger.1
+++ b/doc/ranger.1
@@ -1126,7 +1126,8 @@ Sets the state for the version control backend. The possible values are:
 .Ve
 .IP "vcs_msg_length [int]" 4
 .IX Item "vcs_msg_length [int]"
-Truncate the long commit messages to this length when shown in the statusbar.
+Length to truncate first line of the commit messages to when shown in
+the statusbar.  Defaults to 50.
 .IP "viewmode [string]" 4
 .IX Item "viewmode [string]"
 Sets the view mode, which can be \fBmiller\fR to display the files in the

--- a/doc/ranger.1
+++ b/doc/ranger.1
@@ -133,7 +133,7 @@
 .\" ========================================================================
 .\"
 .IX Title "RANGER 1"
-.TH RANGER 1 "ranger-1.9.2" "2019-09-24" "ranger manual"
+.TH RANGER 1 "ranger-1.9.2" "2019-10-01" "ranger manual"
 .\" For nroff, turn off justification.  Always turn off hyphenation; it makes
 .\" way too many mistakes in technical documents.
 .if n .ad l
@@ -1124,6 +1124,9 @@ Sets the state for the version control backend. The possible values are:
 \& local      display only local state.
 \& enabled    display both, local and remote state. May be slow for hg and bzr.
 .Ve
+.IP "vcs_msg_length [int]" 4
+.IX Item "vcs_msg_length [int]"
+Truncate the long commit messages to this length when shown in the statusbar.
 .IP "viewmode [string]" 4
 .IX Item "viewmode [string]"
 Sets the view mode, which can be \fBmiller\fR to display the files in the

--- a/doc/ranger.pod
+++ b/doc/ranger.pod
@@ -1170,6 +1170,10 @@ Sets the state for the version control backend. The possible values are:
  local      display only local state.
  enabled    display both, local and remote state. May be slow for hg and bzr.
 
+=item vcs_msg_length [int]
+
+Truncate the long commit messages to this length when shown in the statusbar.
+
 =item viewmode [string]
 
 Sets the view mode, which can be B<miller> to display the files in the

--- a/doc/ranger.pod
+++ b/doc/ranger.pod
@@ -1172,7 +1172,8 @@ Sets the state for the version control backend. The possible values are:
 
 =item vcs_msg_length [int]
 
-Truncate the long commit messages to this length when shown in the statusbar.
+Length to truncate first line of the commit messages to when shown in
+the statusbar.  Defaults to 50.
 
 =item viewmode [string]
 

--- a/examples/rc_emacs.conf
+++ b/examples/rc_emacs.conf
@@ -59,6 +59,9 @@ set vcs_backend_git enabled
 set vcs_backend_hg disabled
 set vcs_backend_bzr disabled
 
+# Truncate the long commit messages to this length when shown in the statusbar.
+set vcs_msg_length 50
+
 # Use one of the supported image preview protocols
 set preview_images false
 

--- a/ranger/config/rc.conf
+++ b/ranger/config/rc.conf
@@ -67,6 +67,9 @@ set vcs_backend_hg disabled
 set vcs_backend_bzr disabled
 set vcs_backend_svn disabled
 
+# Truncate the long commit messages to this length when shown in the statusbar.
+set vcs_msg_length 50
+
 # Use one of the supported image preview protocols
 set preview_images false
 

--- a/ranger/container/settings.py
+++ b/ranger/container/settings.py
@@ -94,6 +94,7 @@ ALLOWED_SETTINGS = {
     'vcs_backend_git': str,
     'vcs_backend_hg': str,
     'vcs_backend_svn': str,
+    'vcs_msg_length': int,
     'viewmode': str,
     'w3m_delay': float,
     'w3m_offset': int,

--- a/ranger/gui/widgets/statusbar.py
+++ b/ranger/gui/widgets/statusbar.py
@@ -212,7 +212,11 @@ class StatusBar(Widget):  # pylint: disable=too-many-instance-attributes
                 left.add_space()
                 left.add(directory.vcs.rootvcs.head['date'].strftime(self.timeformat), 'vcsdate')
                 left.add_space()
-                left.add(directory.vcs.rootvcs.head['summary'][:50], 'vcscommit')
+                summary_length = self.settings.vcs_msg_length or 50
+                left.add(
+                    directory.vcs.rootvcs.head['summary'][:summary_length],
+                    'vcscommit'
+                )
 
     def _get_owner(self, target):
         uid = target.stat.st_uid


### PR DESCRIPTION
Previously it was hardcoded as 50, let's make it easy to change for the user.

Improves upon #1705.
Related to #1704.