### PR TITLE
Check current dir exists when pasting

### DIFF
--- a/ranger/core/actions.py
+++ b/ranger/core/actions.py
@@ -1591,19 +1591,19 @@ class Actions(  # pylint: disable=too-many-instance-attributes,too-many-public-m
                 link(source_path,
                      next_available_filename(target_path))
 
-    def paste(self, overwrite=False, append=False, dest=None):
+    def paste(self, overwrite=False, append=False, dest=self.thistab.path):
         """:paste
 
         Paste the selected items into the current directory or to dest
         if provided.
         """
-        if dest is None or isdir(dest):
+        if isdir(dest):
             loadable = CopyLoader(self.copy_buffer, self.do_cut, overwrite,
                                   dest)
             self.loader.add(loadable, append=append)
             self.do_cut = False
         else:
-            self.notify('Failed to paste. The given path is invalid.', bad=True)
+            self.notify('Failed to paste. The destination is invalid.', bad=True)
 
     def delete(self, files=None):
         # XXX: warn when deleting mount points/unseen marked files?

--- a/ranger/core/actions.py
+++ b/ranger/core/actions.py
@@ -1591,12 +1591,14 @@ class Actions(  # pylint: disable=too-many-instance-attributes,too-many-public-m
                 link(source_path,
                      next_available_filename(target_path))
 
-    def paste(self, overwrite=False, append=False, dest=self.thistab.path):
+    def paste(self, overwrite=False, append=False, dest=None):
         """:paste
 
         Paste the selected items into the current directory or to dest
         if provided.
         """
+        if dest is None:
+            dest = self.thistab.path
         if isdir(dest):
             loadable = CopyLoader(self.copy_buffer, self.do_cut, overwrite,
                                   dest)


### PR DESCRIPTION
I changed the default `dest` for paste to the value that's used if
`None` were passed to the `CopyLoader`, i.e., `self.thistab.path`,
because the current directory was bypassing the `isdir()` check
otherwise.

Fixes #1660