### PR TITLE
Deprecate c/p/tunmap in favor of unc/p/tmap

### DIFF
--- a/ranger/config/commands.py
+++ b/ranger/config/commands.py
@@ -1321,28 +1321,62 @@ class unmap(Command):
             self.fm.ui.keymaps.unbind(self.context, arg)
 
 
-class cunmap(unmap):
-    """:cunmap <keys> [<keys2>, ...]
+class uncmap(unmap):
+    """:uncmap <keys> [<keys2>, ...]
 
     Remove the given "console" mappings
     """
     context = 'console'
 
+class cunmap(uncmap):
+    """:cunmap <keys> [<keys2>, ...]
 
-class punmap(unmap):
-    """:punmap <keys> [<keys2>, ...]
+    Remove the given "console" mappings
+    
+    DEPRECATED in favor of uncmap.
+    """
+
+    def execute(self):
+        self.fm.notify("cunmap is deprecated in favor of uncmap!")
+        super(cunmap, self).execute()
+
+class unpmap(unmap):
+    """:unpmap <keys> [<keys2>, ...]
 
     Remove the given "pager" mappings
     """
     context = 'pager'
 
+class punmap(unpmap):
+    """:punmap <keys> [<keys2>, ...]
 
-class tunmap(unmap):
-    """:tunmap <keys> [<keys2>, ...]
+    Remove the given "pager" mappings
+
+    DEPRECATED in favor of unpmap.
+    """
+
+    def execute(self):
+        self.fm.notify("punmap is deprecated in favor of unpmap!")
+        super(punmap, self).execute()
+
+class untmap(unmap):
+    """:untmap <keys> [<keys2>, ...]
 
     Remove the given "taskview" mappings
     """
     context = 'taskview'
+
+class tunmap(untmap):
+    """:tunmap <keys> [<keys2>, ...]
+
+    Remove the given "taskview" mappings
+
+    DEPRECATED in favor of uncmap.
+    """
+
+    def execute(self):
+        self.fm.notify("tunmap is deprecated in favor of untmap!")
+        super(tunmap, self).execute()
 
 
 class map_(Command):

--- a/ranger/config/commands.py
+++ b/ranger/config/commands.py
@@ -1328,6 +1328,7 @@ class uncmap(unmap):
     """
     context = 'console'
 
+
 class cunmap(uncmap):
     """:cunmap <keys> [<keys2>, ...]
 
@@ -1340,12 +1341,14 @@ class cunmap(uncmap):
         self.fm.notify("cunmap is deprecated in favor of uncmap!")
         super(cunmap, self).execute()
 
+
 class unpmap(unmap):
     """:unpmap <keys> [<keys2>, ...]
 
     Remove the given "pager" mappings
     """
     context = 'pager'
+
 
 class punmap(unpmap):
     """:punmap <keys> [<keys2>, ...]
@@ -1359,12 +1362,14 @@ class punmap(unpmap):
         self.fm.notify("punmap is deprecated in favor of unpmap!")
         super(punmap, self).execute()
 
+
 class untmap(unmap):
     """:untmap <keys> [<keys2>, ...]
 
     Remove the given "taskview" mappings
     """
     context = 'taskview'
+
 
 class tunmap(untmap):
     """:tunmap <keys> [<keys2>, ...]

--- a/ranger/config/commands.py
+++ b/ranger/config/commands.py
@@ -1326,7 +1326,7 @@ class cunmap(unmap):
 
     Remove the given "console" mappings
     """
-    context = 'browser'
+    context = 'console'
 
 
 class punmap(unmap):

--- a/ranger/config/commands.py
+++ b/ranger/config/commands.py
@@ -1332,7 +1332,7 @@ class cunmap(uncmap):
     """:cunmap <keys> [<keys2>, ...]
 
     Remove the given "console" mappings
-    
+
     DEPRECATED in favor of uncmap.
     """
 

--- a/ranger/config/commands.py
+++ b/ranger/config/commands.py
@@ -1371,7 +1371,7 @@ class tunmap(untmap):
 
     Remove the given "taskview" mappings
 
-    DEPRECATED in favor of uncmap.
+    DEPRECATED in favor of untmap.
     """
 
     def execute(self):


### PR DESCRIPTION
`cunmap` definitely won't be missed because it was buggy. I'd expect the other two to be even less missed.

I considered writing a decorator for deprecation because the code is repetitive but imo it should be removed in the *next* version after 1.9.3 so it shouldn't matter much.

Fixes #1698