### PR TITLE
Add a trash-cli support to the default rifle.conf

### DIFF
--- a/ranger/config/commands.py
+++ b/ranger/config/commands.py
@@ -699,6 +699,64 @@ class delete(Command):
             self.fm.delete(files)
 
 
+class trash(Command):
+    """:trash
+
+    Tries to move the selection or the files passed in arguments (if any) to
+    the trash, using rifle rules with label "trash".
+    The arguments use a shell-like escaping.
+
+    "Selection" is defined as all the "marked files" (by default, you
+    can mark files with space or v). If there are no marked files,
+    use the "current file" (where the cursor is)
+
+    When attempting to trash non-empty directories or multiple
+    marked files, it will require a confirmation.
+    """
+
+    allow_abbrev = False
+    escape_macros_for_shell = True
+
+    def execute(self):
+        import shlex
+        from functools import partial
+
+        def is_directory_with_files(path):
+            return os.path.isdir(path) and not os.path.islink(path) and len(os.listdir(path)) > 0
+
+        if self.rest(1):
+            files = shlex.split(self.rest(1))
+            many_files = (len(files) > 1 or is_directory_with_files(files[0]))
+        else:
+            cwd = self.fm.thisdir
+            tfile = self.fm.thisfile
+            if not cwd or not tfile:
+                self.fm.notify("Error: no file selected for deletion!", bad=True)
+                return
+
+            # relative_path used for a user-friendly output in the confirmation.
+            files = [f.relative_path for f in self.fm.thistab.get_selection()]
+            many_files = (cwd.marked_items or is_directory_with_files(tfile.path))
+
+        confirm = self.fm.settings.confirm_on_delete
+        if confirm != 'never' and (confirm != 'multiple' or many_files):
+            self.fm.ui.console.ask(
+                "Confirm deletion of: %s (y/N)" % ', '.join(files),
+                partial(self._question_callback, files),
+                ('n', 'N', 'y', 'Y'),
+            )
+        else:
+            # no need for a confirmation, just delete
+            self.fm.execute_file(files, label='trash')
+
+    def tab(self, tabnum):
+        return self._tab_directory_content()
+
+    def _question_callback(self, files, answer):
+        if answer == 'y' or answer == 'Y':
+            self.fm.execute_file(files, label='trash')
+
+
 class jump_non(Command):
     """:jump_non [-FLAGS...]
 

--- a/ranger/config/rc.conf
+++ b/ranger/config/rc.conf
@@ -401,6 +401,7 @@ map <F5> copy
 map <F6> cut
 map <F7> console mkdir%space
 map <F8> console delete
+#map <F8> console trash
 map <F10> exit
 
 # In case you work on a keyboard with dvorak layout
@@ -488,6 +489,7 @@ map p`<any> paste dest=%any_path
 map p'<any> paste dest=%any_path
 
 map dD console delete
+map dT console trash
 
 map dd cut
 map ud uncut

--- a/ranger/config/rifle.conf
+++ b/ranger/config/rifle.conf
@@ -264,9 +264,14 @@ label wallpaper, number 14, mime ^image, has feh, X = feh --bg-fill "$1"
 label editor, !mime ^text, !ext xml|json|csv|tex|py|pl|rb|js|sh|php  = ${VISUAL:-$EDITOR} -- "$@"
 label pager,  !mime ^text, !ext xml|json|csv|tex|py|pl|rb|js|sh|php  = "$PAGER" -- "$@"
 
-# One of the last actions, so that it's never triggered accidentally, is to execute a program:
+
+######################################################################
+# The actions below are left so low down in this file on purpose, so #
+# they are never triggered accidentally.                             #
+######################################################################
+
+# Execute a file as program/script.
 mime application/x-executable = "$1"
 
-# Move the file to trash, available for all filetypes provided
-# trash-cli is available.
+# Move the file to trash using trash-cli.
 has trash-put = trash-put -- "$@"

--- a/ranger/config/rifle.conf
+++ b/ranger/config/rifle.conf
@@ -274,4 +274,5 @@ label pager,  !mime ^text, !ext xml|json|csv|tex|py|pl|rb|js|sh|php  = "$PAGER" 
 mime application/x-executable = "$1"
 
 # Move the file to trash using trash-cli.
-has trash-put = trash-put -- "$@"
+label trash, has trash-put = trash-put -- "$@"
+label trash = mkdir -p -- ${XDG_DATA_DIR:-$HOME/.ranger}/ranger-trash; mv -- "$@" ${XDG_DATA_DIR:-$HOME/.ranger}/ranger-trash

--- a/ranger/config/rifle.conf
+++ b/ranger/config/rifle.conf
@@ -264,5 +264,9 @@ label wallpaper, number 14, mime ^image, has feh, X = feh --bg-fill "$1"
 label editor, !mime ^text, !ext xml|json|csv|tex|py|pl|rb|js|sh|php  = ${VISUAL:-$EDITOR} -- "$@"
 label pager,  !mime ^text, !ext xml|json|csv|tex|py|pl|rb|js|sh|php  = "$PAGER" -- "$@"
 
-# The very last action, so that it's never triggered accidentally, is to execute a program:
+# One of the last actions, so that it's never triggered accidentally, is to execute a program:
 mime application/x-executable = "$1"
+
+# Move the file to trash, available for all filetypes provided
+# trash-cli is available.
+has trash-put = trash-put -- "$@"


### PR DESCRIPTION
`trash-cli` is usually used to remove file using a traditional "Trash bin" pattern with a possible undo and all these fancy whistles. Since some of our users would like such a support (#1699), let's add it.