### PR TITLE
Hotfix for an off-by-one in rifle

### DIFF
--- a/ranger/ext/rifle.py
+++ b/ranger/ext/rifle.py
@@ -293,6 +293,9 @@ class Rifle(object):  # pylint: disable=too-many-instance-attributes
             self._app_flags = ''
             self._app_label = None
             if skip_ask and cmd == ASK_COMMAND:
+                # TODO(vifon): Fix properly, see
+                # https://github.com/ranger/ranger/pull/1341#issuecomment-537264495
+                count += 1
                 continue
             for test in tests:
                 if not self._eval_condition(test, files, None):


### PR DESCRIPTION
After #1341 the action IDs displayed by the UI were inconsistent with the actual numbers used by rifle.  It was caused by the `ask` action being skipped entirely (including incrementing the ID) but only in the UI.

This is a hotfix that makes the hidden `ask` action to still take up a number (usually (always?) 0) and thus keeping the numbering consistent.  Bad side effect: sometimes the counting starts with 1 instead of 0 but for a time being let's choose a small inconsistency over a BIG one.