### PR TITLE
Add .opus as extension for audio/ogg

### DIFF
--- a/ranger/data/mime.types
+++ b/ranger/data/mime.types
@@ -12,7 +12,7 @@
 
 audio/flac              flac
 audio/musepack          mpc mpp mp+
-audio/ogg               oga ogg spx
+audio/ogg               oga ogg spx opus
 audio/wavpack           wv wvc
 audio/webm              weba
 audio/x-ape             ape


### PR DESCRIPTION
Have some `.opus` files which aren't recognized by ranger as being media. `.opus` is one of the accepted extensions for opus encoded audio in an ogg container and seems to be the trend to distinguish it from vorbis encoded audio in an ogg container (`.ogg`).