### PR TITLE
add wl-clipboard support

### DIFF
--- a/ranger/config/commands.py
+++ b/ranger/config/commands.py
@@ -1924,11 +1924,14 @@ class yank(Command):
                     ['xsel'],
                     ['xsel', '-b'],
                 ],
+                'wl-copy': [
+                    ['wl-copy'],
+                ],
                 'pbcopy': [
                     ['pbcopy'],
                 ],
             }
-            ordered_managers = ['pbcopy', 'xclip', 'xsel']
+            ordered_managers = ['pbcopy', 'wl-copy', 'xclip', 'xsel']
             executables = get_executables()
             for manager in ordered_managers:
                 if manager in executables:


### PR DESCRIPTION
This adds wl-copy to the list of executables checked for clipboard support.

#### ISSUE TYPE

- Improvement/feature implementation


#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [x] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [x] All changes follow the code style **[REQUIRED]**
- [x] All new and existing tests pass **[REQUIRED]**
- [ ] Changes require config files to be updated
    - [ ] Config files have been updated
- [ ] Changes require documentation to be updated (possibly?)
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION

This adds `wl-copy` to the list of clipboard executables checked. It is checked before xsel/xclip under the assumption that if it is installed, then the user is running wayland. (A better check could include checking for WAYLAND_DISPLAY as well before using it; can add that if reviewers would prefer.)


#### MOTIVATION AND CONTEXT

This is required to use the copy-to-clipboard functionality in ranger under wayland.


#### TESTING



