### PR TITLE
Add support for more apps in rifle default config

### DIFF
--- a/ranger/config/rifle.conf
+++ b/ranger/config/rifle.conf
@@ -94,7 +94,7 @@ ext 1                         = man "$1"
 ext s[wmf]c, has zsnes, X     = zsnes "$1"
 ext s[wmf]c, has snes9x-gtk,X = snes9x-gtk "$1"
 ext nes, has fceux, X         = fceux "$1"
-ext exe                       = wine "$1"
+ext exe, has wine             = wine "$1"
 name ^[mM]akefile$            = make
 
 #--------------------------------------------
@@ -118,17 +118,19 @@ ext midi?,        terminal, has wildmidi = wildmidi -- "$@"
 #--------------------------------------------
 # Video/Audio with a GUI
 #-------------------------------------------
-mime ^video|audio, has gmplayer, X, flag f = gmplayer -- "$@"
-mime ^video|audio, has smplayer, X, flag f = smplayer "$@"
+mime ^video|^audio, has gmplayer, X, flag f = gmplayer -- "$@"
+mime ^video|^audio, has smplayer, X, flag f = smplayer "$@"
 mime ^video,       has mpv,      X, flag f = mpv -- "$@"
 mime ^video,       has mpv,      X, flag f = mpv --fs -- "$@"
 mime ^video,       has mplayer2, X, flag f = mplayer2 -- "$@"
 mime ^video,       has mplayer2, X, flag f = mplayer2 -fs -- "$@"
 mime ^video,       has mplayer,  X, flag f = mplayer -- "$@"
 mime ^video,       has mplayer,  X, flag f = mplayer -fs -- "$@"
-mime ^video|audio, has vlc,      X, flag f = vlc -- "$@"
-mime ^video|audio, has totem,    X, flag f = totem -- "$@"
-mime ^video|audio, has totem,    X, flag f = totem --fullscreen -- "$@"
+mime ^video|^audio, has vlc,      X, flag f = vlc -- "$@"
+mime ^video|^audio, has totem,    X, flag f = totem -- "$@"
+mime ^video|^audio, has totem,    X, flag f = totem --fullscreen -- "$@"
+mime ^audio,  has audacity, X, flag f = audacity -- "$@"
+ext aup,           has audacity, X, flag f = audacity -- "$@"
 
 #--------------------------------------------
 # Video without X
@@ -153,6 +155,7 @@ ext pdf, has epdfview, X, flag f = epdfview -- "$@"
 ext pdf, has qpdfview, X, flag f = qpdfview "$@"
 ext pdf, has open,     X, flag f = open "$@"
 
+ext sc,    has sc,                    = sc -- "$@"
 ext docx?, has catdoc,       terminal = catdoc -- "$@" | "$PAGER"
 
 ext                        sxc|xlsx?|xlt|xlw|gnm|gnumeric, has gnumeric,    X, flag f = gnumeric -- "$@"
@@ -174,6 +177,8 @@ ext mobi, has ebook-viewer, X, flag f = ebook-viewer -- "$@"
 ext cbr,  has zathura,      X, flag f = zathura -- "$@"
 ext cbz,  has zathura,      X, flag f = zathura -- "$@"
 
+ext sla, has scribus,       X, flag f = scribus -- "$@"
+
 #-------------------------------------------
 # Images
 #-------------------------------------------
@@ -193,7 +198,9 @@ mime ^image, has geeqie,    X, flag f = geeqie -- "$@"
 mime ^image, has gpicview,  X, flag f = gpicview -- "$@"
 mime ^image, has gwenview,  X, flag f = gwenview -- "$@"
 mime ^image, has gimp,      X, flag f = gimp -- "$@"
+mime ^image, has krita,     X, flag f = krita -- "$@"
 ext xcf,                    X, flag f = gimp -- "$@"
+ext kra,     has krita,     X, flag f = krita -- "$@"
 
 #-------------------------------------------
 # Archives

--- a/ranger/config/rifle.conf
+++ b/ranger/config/rifle.conf
@@ -120,17 +120,17 @@ ext midi?,        terminal, has wildmidi = wildmidi -- "$@"
 #-------------------------------------------
 mime ^video|^audio, has gmplayer, X, flag f = gmplayer -- "$@"
 mime ^video|^audio, has smplayer, X, flag f = smplayer "$@"
-mime ^video,       has mpv,      X, flag f = mpv -- "$@"
-mime ^video,       has mpv,      X, flag f = mpv --fs -- "$@"
-mime ^video,       has mplayer2, X, flag f = mplayer2 -- "$@"
-mime ^video,       has mplayer2, X, flag f = mplayer2 -fs -- "$@"
-mime ^video,       has mplayer,  X, flag f = mplayer -- "$@"
-mime ^video,       has mplayer,  X, flag f = mplayer -fs -- "$@"
+mime ^video,        has mpv,      X, flag f = mpv -- "$@"
+mime ^video,        has mpv,      X, flag f = mpv --fs -- "$@"
+mime ^video,        has mplayer2, X, flag f = mplayer2 -- "$@"
+mime ^video,        has mplayer2, X, flag f = mplayer2 -fs -- "$@"
+mime ^video,        has mplayer,  X, flag f = mplayer -- "$@"
+mime ^video,        has mplayer,  X, flag f = mplayer -fs -- "$@"
 mime ^video|^audio, has vlc,      X, flag f = vlc -- "$@"
 mime ^video|^audio, has totem,    X, flag f = totem -- "$@"
 mime ^video|^audio, has totem,    X, flag f = totem --fullscreen -- "$@"
-mime ^audio,  has audacity, X, flag f = audacity -- "$@"
-ext aup,           has audacity, X, flag f = audacity -- "$@"
+mime ^audio,        has audacity, X, flag f = audacity -- "$@"
+ext aup,            has audacity, X, flag f = audacity -- "$@"
 
 #--------------------------------------------
 # Video without X
@@ -177,7 +177,7 @@ ext mobi, has ebook-viewer, X, flag f = ebook-viewer -- "$@"
 ext cbr,  has zathura,      X, flag f = zathura -- "$@"
 ext cbz,  has zathura,      X, flag f = zathura -- "$@"
 
-ext sla, has scribus,       X, flag f = scribus -- "$@"
+ext sla,  has scribus,      X, flag f = scribus -- "$@"
 
 #-------------------------------------------
 # Images
@@ -199,8 +199,8 @@ mime ^image, has gpicview,  X, flag f = gpicview -- "$@"
 mime ^image, has gwenview,  X, flag f = gwenview -- "$@"
 mime ^image, has gimp,      X, flag f = gimp -- "$@"
 mime ^image, has krita,     X, flag f = krita -- "$@"
-ext xcf,                    X, flag f = gimp -- "$@"
 ext kra,     has krita,     X, flag f = krita -- "$@"
+ext xcf,                    X, flag f = gimp -- "$@"
 
 #-------------------------------------------
 # Archives


### PR DESCRIPTION
#### ISSUE TYPE

- Improvement/feature implementation


#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [x] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [x] All changes follow the code style **[REQUIRED]**
- [x] All new and existing tests pass **[REQUIRED]**
- [ ] Changes require config files to be updated
    - [x] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION

Adds support for more filetypes/apps in the rifle default config. These are things I use in my own config that I felt could be useful to others too. Found them while merging new changes from the upstream rifle.conf into mine ( https://github.com/swalladge/dotfiles/commit/e4b62ed6c277a94ae28cef3f54d1cf7f6fb73e65 ). Summary of changes:

- audacity
- firefox dev edition
- scribus projects
- sc (cli spreadsheet editor)
- krita image editor
- fix bug where wine is erroneously displayed if not installed


#### MOTIVATION AND CONTEXT

These are simple config additions to support more filetypes out-of-the-box for rifle. Simply convenience.


#### TESTING

Does not affect the codebase. The added rules in rifle.conf should be inspected to ensure they don't conflict or clobber existing rules.