### PR TITLE
adding nautilus as command to open current dir in ui file manager,

### DIFF
--- a/ranger/config/commands.py
+++ b/ranger/config/commands.py
@@ -641,6 +641,21 @@ class terminal(Command):
         from ranger.ext.get_executables import get_term
         self.fm.run(get_term(), flags='f')
 
+class nautilus(Command):
+    """:nautilus
+
+    open current directory in nautilus file manager, if it exists.
+    """
+
+    def execute(self):
+        from ranger.ext.get_executables import get_executables
+        if 'nautilus' in get_executables():
+            self.fm.run('nautilus '+self.fm.thisdir.path, flags='f')
+        # fallback to xdg-open if nautilus is not available
+        elif 'xdg-open' in get_executables():
+            self.fm.run('xdg-open '+self.fm.thisdir.path, flags='f')
+        else: self.fm.notify("nautilus is not available.")
+
 
 class delete(Command):
     """:delete


### PR DESCRIPTION
Adding `:nautilus` as command to open the current directory in nautilus file manager with fallback to `xdg-open`

#### ISSUE TYPE
- Improvement/feature implementation

#### RUNTIME ENVIRONMENT
<!-- Details of your runtime environment -->
<!-- Retrieve Python/ranger version and locale with `ranger -\-version` -->
- Operating system and version: Ubuntu 18.04
- Terminal emulator and version: kitty
ranger version: ranger 1.9.2
Python version: 3.6.8 (default, Oct  7 2019, 12:59:55) [GCC 8.3.0]
Locale: en_IN.ISO8859-1

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [X] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [X] All changes follow the code style **[REQUIRED]**
- [X] All new and existing tests pass **[REQUIRED]**
- [X] Changes require config files to be updated
    - [X] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
<!-- Describe the changes in detail -->


#### MOTIVATION AND CONTEXT
some use cases need a gui file manager like for grad and dropping files `browse` buttons directly.   
A simple `:nautilus` command to open file manager reduces the hustle.

#### TESTING
`make test` fails for `test_pylint` for already existing code, but has nothing to do with my commits.
Doesn't affect other areas of codebase.
<!-- What tests have been run? -->
<!-- How does the changes affect other areas of the codebase? -->