### PR TITLE
fixing issue 1673

### DIFF
--- a/ranger/container/fsobject.py
+++ b/ranger/container/fsobject.py
@@ -344,7 +344,7 @@ class FileSystemObject(  # pylint: disable=too-many-instance-attributes,too-many
 
         if self.is_directory and self.is_link:
             perms = ['l']
-        if self.is_directory:
+        elif self.is_directory:
             perms = ['d']
         elif self.is_link:
             perms = ['l']

--- a/ranger/container/fsobject.py
+++ b/ranger/container/fsobject.py
@@ -343,7 +343,7 @@ class FileSystemObject(  # pylint: disable=too-many-instance-attributes,too-many
             return self.permissions
 
         if self.is_directory and self.is_link:
-            persm = ['l']
+            perms = ['l']
         if self.is_directory:
             perms = ['d']
         elif self.is_link:

--- a/ranger/container/fsobject.py
+++ b/ranger/container/fsobject.py
@@ -342,6 +342,8 @@ class FileSystemObject(  # pylint: disable=too-many-instance-attributes,too-many
         if self.permissions is not None:
             return self.permissions
 
+        if self.is_directory and self.is_link:
+            persm = ['l']
         if self.is_directory:
             perms = ['d']
         elif self.is_link:

--- a/ranger/container/fsobject.py
+++ b/ranger/container/fsobject.py
@@ -342,12 +342,10 @@ class FileSystemObject(  # pylint: disable=too-many-instance-attributes,too-many
         if self.permissions is not None:
             return self.permissions
 
-        if self.is_directory and self.is_link:
+        if self.is_link:
             perms = ['l']
         elif self.is_directory:
             perms = ['d']
-        elif self.is_link:
-            perms = ['l']
         else:
             perms = ['-']
 


### PR DESCRIPTION
<!-- Provide a descriptive summary of the changes in the title above -->

#### ISSUE TYPE
<!-- Pick relevant types and delete the rest -->
- Bug fix


#### RUNTIME ENVIRONMENT
<!-- Details of your runtime environment -->
<!-- Retrieve Python/ranger version and locale with `ranger -\-version` -->
- Operating system and version: Manjaro Linux 5.2.21
- Terminal emulator and version: XTERM
- Python version: 3.7.4
- Ranger version/commit:  Ranger-Master 1.9.2
- Locale: de_DE.UTF8

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [X] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [X] All changes follow the code style **[REQUIRED]**
- [X] All new and existing tests pass **[REQUIRED]**
- [ ] Changes require config files to be updated
    - [ ] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
<!-- Describe the changes in detail -->
Made small changes to the get_permission_string() Method in fsobject.py. 
Changed the if-block so that if a directory which is also a link will be treated as a such and will get the 'l'-flag just like in a Terminal context.


#### MOTIVATION AND CONTEXT
Symlink directorys where shown as "d" in the permissions in the bottom left of Ranger.


#### TESTING
<!-- What tests have been run? -->
Changes were applied and Ranger 
<!-- How does the changes affect other areas of the codebase? -->
as far as I can tell, None.
