### PR TITLE
Add generic openers for linux and mac

### DIFF
--- a/ranger/config/rifle.conf
+++ b/ranger/config/rifle.conf
@@ -259,6 +259,12 @@ label wallpaper, number 12, mime ^image, has feh, X = feh --bg-tile "$1"
 label wallpaper, number 13, mime ^image, has feh, X = feh --bg-center "$1"
 label wallpaper, number 14, mime ^image, has feh, X = feh --bg-fill "$1"
 
+#-------------------------------------------
+# Generic file openers
+#-------------------------------------------
+label open, has xdg-open = xdg-open -- "$@"
+label open, has open     = open -- "$@"
+
 # Define the editor for non-text files + pager as last action
               !mime ^text, !ext xml|json|csv|tex|py|pl|rb|js|sh|php  = ask
 label editor, !mime ^text, !ext xml|json|csv|tex|py|pl|rb|js|sh|php  = ${VISUAL:-$EDITOR} -- "$@"


### PR DESCRIPTION
Rifle serves a similar purpose to `xdg-open` on Linux and `open` on
macOS. We fall back to those so users can enjoy their xdg and other
configuration from rifle.