### PR TITLE
applying proposed tmux renaming fix

### DIFF
--- a/doc/ranger.1
+++ b/doc/ranger.1
@@ -133,7 +133,7 @@
 .\" ========================================================================
 .\"
 .IX Title "RANGER 1"
-.TH RANGER 1 "ranger-1.9.2" "2019-12-30" "ranger manual"
+.TH RANGER 1 "ranger-1.9.2" "2019-12-31" "ranger manual"
 .\" For nroff, turn off justification.  Always turn off hyphenation; it makes
 .\" way too many mistakes in technical documents.
 .if n .ad l
@@ -1176,7 +1176,7 @@ Requires the python-bidi pip package.
 Set a window title? Updates both the \fI\s-1WM_NAME\s0\fR and \fI\s-1WM_ICON_NAME\s0\fR properties.
 .IP "update_tmux_title [bool]" 4
 .IX Item "update_tmux_title [bool]"
-Set the tmux \fIwindow-name\fR to \*(L"ranger\*(R"?
+Set the tmux/screen \fIwindow-name\fR to \*(L"ranger\*(R"?
 .IP "use_preview_script [bool] <zv>" 4
 .IX Item "use_preview_script [bool] <zv>"
 Use the preview script defined in the setting \fIpreview_script\fR?

--- a/doc/ranger.pod
+++ b/doc/ranger.pod
@@ -1268,6 +1268,10 @@ Set a window title? Updates both the I<WM_NAME> and I<WM_ICON_NAME> properties.
 
 Set the tmux I<window-name> to "ranger"?
 
+=item update_screen_title [bool]
+
+Set the title to "ranger" in the screen program?
+
 =item use_preview_script [bool] <zv>
 
 Use the preview script defined in the setting I<preview_script>?

--- a/doc/ranger.pod
+++ b/doc/ranger.pod
@@ -1266,11 +1266,7 @@ Set a window title? Updates both the I<WM_NAME> and I<WM_ICON_NAME> properties.
 
 =item update_tmux_title [bool]
 
-Set the tmux I<window-name> to "ranger"?
-
-=item update_screen_title [bool]
-
-Set the title to "ranger" in the screen program?
+Set the tmux/screen I<window-name> to "ranger"?
 
 =item use_preview_script [bool] <zv>
 

--- a/ranger/config/rc.conf
+++ b/ranger/config/rc.conf
@@ -188,6 +188,10 @@ set update_title false
 # Set the tmux window-name to "ranger"?
 set update_tmux_title true
 
+# Set the title to "ranger" in the screen program?
+
+set update_screen_title true
+
 # Shorten the title if it gets long?  The number defines how many
 # directories are displayed at once, 0 turns off this feature.
 set shorten_title 3

--- a/ranger/config/rc.conf
+++ b/ranger/config/rc.conf
@@ -185,12 +185,8 @@ set display_tags_in_all_columns true
 # Set a title for the window? Updates both `WM_NAME` and `WM_ICON_NAME`
 set update_title false
 
-# Set the tmux window-name to "ranger"?
+# Set the tmux/screen window-name to "ranger"?
 set update_tmux_title true
-
-# Set the title to "ranger" in the screen program?
-
-set update_screen_title true
 
 # Shorten the title if it gets long?  The number defines how many
 # directories are displayed at once, 0 turns off this feature.

--- a/ranger/container/settings.py
+++ b/ranger/container/settings.py
@@ -88,7 +88,6 @@ ALLOWED_SETTINGS = {
     'unicode_ellipsis': bool,
     'update_title': bool,
     'update_tmux_title': bool,
-    'update_screen_title': bool,
     'use_preview_script': bool,
     'vcs_aware': bool,
     'vcs_backend_bzr': str,

--- a/ranger/container/settings.py
+++ b/ranger/container/settings.py
@@ -88,6 +88,7 @@ ALLOWED_SETTINGS = {
     'unicode_ellipsis': bool,
     'update_title': bool,
     'update_tmux_title': bool,
+    'update_screen_title': bool,
     'use_preview_script': bool,
     'vcs_aware': bool,
     'vcs_backend_bzr': str,

--- a/ranger/gui/ui.py
+++ b/ranger/gui/ui.py
@@ -122,7 +122,9 @@ class UI(  # pylint: disable=too-many-instance-attributes,too-many-public-method
             if self.settings.update_tmux_title and 'TMUX' in os.environ:
                 try:
                     self._tmux_automatic_rename = check_output(
-                        ['tmux', 'show-window-options', '-v', 'automatic-rename']).strip()
+                        ['tmux', 'show-window-option', '-v', 'automatic-rename']).strip()
+                    if self._tmux_automatic_rename == 'off':
+                        self._tmux_automatic_rename = 'on'
                 except CalledProcessError:
                     self._tmux_automatic_rename = None
 
@@ -130,6 +132,7 @@ class UI(  # pylint: disable=too-many-instance-attributes,too-many-public-method
         self.is_on = True
 
         if self.settings.update_tmux_title and 'TMUX' in os.environ:
+            check_output(['tmux', 'rename-window', 'Ranger'])
             sys.stdout.write("\033kranger\033\\")
             sys.stdout.flush()
 
@@ -186,11 +189,6 @@ class UI(  # pylint: disable=too-many-instance-attributes,too-many-public-method
                 try:
                     check_output(['tmux', 'set-window-option',
                                   'automatic-rename', self._tmux_automatic_rename])
-                except CalledProcessError:
-                    pass
-            else:
-                try:
-                    check_output(['tmux', 'set-window-option', '-u', 'automatic-rename'])
                 except CalledProcessError:
                     pass
 


### PR DESCRIPTION
<!-- Provide a descriptive summary of the changes in the title above -->

#### ISSUE TYPE
<!-- Pick relevant types and delete the rest -->
- Bug fix


#### RUNTIME ENVIRONMENT
<!-- Details of your runtime environment -->
<!-- Retrieve Python/ranger version and locale with `ranger -\-version` -->
- Operating system and version: Manjaro Linux 5.2.21-1
- Terminal emulator and version: urxvt
- Python version: Python 3.7.4
- Ranger version/commit: 1.9.20 Master
- Locale: de_DE-UTF.8

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [X] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [X] All changes follow the code style **[REQUIRED]**
- [X] All new and existing tests pass **[REQUIRED]**
- [ ] Changes require config files to be updated
    - [ ] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
Applying the proposed Tmux renaming window fix from issue #1739.


#### MOTIVATION AND CONTEXT
Change fixes a problem that the current Tmux window does not get rename even if the option is set.


#### TESTING
Tests have been run. Very small changes to the codebase.


