### PR TITLE
Fixed issue with W3MImgPreview not clearing previous image

### DIFF
--- a/ranger/ext/img_display.py
+++ b/ranger/ext/img_display.py
@@ -208,6 +208,7 @@ class W3MImageDisplayer(ImageDisplayer, FileManagerAware):
         )
 
         try:
+            self.fm.ui.win.redrawwin()
             self.process.stdin.write(cmd)
         except IOError as ex:
             if ex.errno == errno.EPIPE:


### PR DESCRIPTION
<!-- Provide a descriptive summary of the changes in the title above -->

#### ISSUE TYPE
<!-- Pick relevant types and delete the rest -->
- Bug fix

#### RUNTIME ENVIRONMENT
<!-- Details of your runtime environment -->
<!-- Retrieve Python/ranger version and locale with `ranger -\-version` -->
- Operating system and version: Arch Linux x86_64
- Terminal emulator and version: terminator 1.91
- Python version: 3.7.4
- Ranger version/commit: ranger-master v1.9.2-390-g482fced9
- Locale: None.None

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [X] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [X] All changes follow the code style **[REQUIRED]**
- [X] All new and existing tests pass **[REQUIRED]**

#### DESCRIPTION
<!-- Describe the changes in detail -->
W3MImageDisplayer now redraws the window using `self.fm.ui.win.redrawwin()` when clearing the preview. 

#### MOTIVATION AND CONTEXT
<!-- Why are these changes required? -->
<!-- What problems do these changes solve? -->
<!-- Link to relevant issues -->
Users with terminal emulators based off of GNOME Terminal (such as terminator) will encounter an issue when using W3MImagePreview (#1071, #859) that results in a previous preview being drawn over rather than replaced as intended.

#### TESTING
<!-- What tests have been run? -->
<!-- How does the changes affect other areas of the codebase? -->
TravisCI build passed, pylint passed with 9.87/10 (no change). Does not seem to affect other areas of the codebase.
