### PR TITLE
Fix ranger freeze after shell command during kitty preview

### DIFF
--- a/ranger/ext/img_display.py
+++ b/ranger/ext/img_display.py
@@ -683,7 +683,7 @@ class KittyImageDisplayer(ImageDisplayer, FileManagerAware):
         self.stdbout.flush()
         # kitty doesn't seem to reply on deletes, checking like we do in draw()
         # will slows down scrolling with timeouts from select
-        self.image_id = (0, self.image_id)
+        self.image_id = max(0, self.image_id)
         self.fm.ui.win.redrawwin()
         self.fm.ui.win.refresh()
 

--- a/ranger/ext/img_display.py
+++ b/ranger/ext/img_display.py
@@ -683,7 +683,7 @@ class KittyImageDisplayer(ImageDisplayer, FileManagerAware):
         self.stdbout.flush()
         # kitty doesn't seem to reply on deletes, checking like we do in draw()
         # will slows down scrolling with timeouts from select
-        self.image_id -= 1
+        self.image_id = (0, self.image_id)
         self.fm.ui.win.redrawwin()
         self.fm.ui.win.refresh()
 

--- a/ranger/ext/img_display.py
+++ b/ranger/ext/img_display.py
@@ -683,7 +683,7 @@ class KittyImageDisplayer(ImageDisplayer, FileManagerAware):
         self.stdbout.flush()
         # kitty doesn't seem to reply on deletes, checking like we do in draw()
         # will slows down scrolling with timeouts from select
-        self.image_id = max(0, self.image_id)
+        self.image_id = max(0, self.image_id - 1)
         self.fm.ui.win.redrawwin()
         self.fm.ui.win.refresh()
 


### PR DESCRIPTION
<!-- Provide a descriptive summary of the changes in the title above -->

#### ISSUE TYPE
<!-- Pick relevant types and delete the rest -->
- Bug fix

#### RUNTIME ENVIRONMENT
<!-- Details of your runtime environment -->
<!-- Retrieve Python/ranger version and locale with `ranger -\-version` -->
- Operating system and version: Arch Linux x86_64
- Terminal emulator and version: kitty 0.14.6
- Python version: Python 3.8.0
- Ranger version/commit: 1.9.2.389.g28f3d014-1
- Locale: en_US.UTF-8

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [x] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [x] All changes follow the code style **[REQUIRED]**
- [x] All new and existing tests pass **[REQUIRED]**
- [ ] Changes require config files to be updated
    - [ ] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
<!-- Describe the changes in detail -->
preview_id was assigned negative id, which is not valid kitty id

#### MOTIVATION AND CONTEXT
<!-- Why are these changes required? -->
<!-- What problems do these changes solve? -->
<!-- Link to relevant issues -->
#1603 