### PR TITLE
adding inode/directory mime type to rifle

### DIFF
--- a/ranger/config/rifle.conf
+++ b/ranger/config/rifle.conf
@@ -262,8 +262,10 @@ label wallpaper, number 14, mime ^image, has feh, X = feh --bg-fill "$1"
 #-------------------------------------------
 # Generic file openers
 #-------------------------------------------
-label open, has xdg-open = xdg-open -- "$@"
-label open, has open     = open -- "$@"
+label open, has xdg-open = xdg-open "$@"
+label open, has open     = open "$@"
+mime ^inode/directory, has xdg-open = xdg-open "$@"
+mime ^inode/directory, has open = open "$@"
 
 # Define the editor for non-text files + pager as last action
               !mime ^text, !ext xml|json|csv|tex|py|pl|rb|js|sh|php  = ask


### PR DESCRIPTION
Open directory in system's default file manager with rifle.  
 Added mime type inode/directory to rifle.conf for the same

#### ISSUE TYPE
<!-- Pick relevant types and delete the rest -->
- Improvement/feature implementation


#### RUNTIME ENVIRONMENT
<!-- Details of your runtime environment -->
<!-- Retrieve Python/ranger version and locale with `ranger -\-version` -->
- Operating system and version: Ubuntu 18.04
- Terminal emulator and version: kitty
- Python version: 3.6.8 (default, Oct 7 2019, 12:59:55) [GCC 8.3.0]
- Ranger version/commit: ranger-master
- Locale: en_IN.ISO8859-1

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [X] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [X] All changes follow the code style **[REQUIRED]**
- [X] All new and existing tests pass **[REQUIRED]**
- [X] Changes require config files to be updated
    - [X] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
Added mime type inode/directory to rifle.conf


#### MOTIVATION AND CONTEXT
<!-- Why are these changes required? -->
<!-- What problems do these changes solve? -->
<!-- Link to relevant issues -->
Opening current directory from ranger in system's default file manager.
As suggested by @toonn in [PR1726](https://github.com/ranger/ranger/pull/1726#issuecomment-558738161)

#### TESTING
<!-- What tests have been run? -->
<!-- How does the changes affect other areas of the codebase? -->
ran `rifle ./` from terminal to open PWD in xdg-open  
ran `shell rifle %d` from ranger  
both work. Haven't tested for macOS's `open` command though

#### IMAGES / VIDEOS<!-- Only if relevant -->
<!-- Link or embed images and videos of screenshots, sketches etc. -->
