### PR TITLE
Added a confirm command.

### DIFF
--- a/ranger/config/commands.py
+++ b/ranger/config/commands.py
@@ -2000,38 +2000,33 @@ class confirm(Command):
     given command.
     """
 
-
     def execute(self):
-        from functools import partial
-
         command = ''
         if len(self.args) > 1 and self.arg(1) != 'chain':
             for index in range(1, len(self.args)):
                 if index != len(self.args):
                     command += self.args[index] + ' '
-            self.fm.ui.console.ask(
-                "Confirm execution of: %s (y/N)" % ''.join(command),
-                partial(self._question_callback, command),
-                ('n', 'N', 'y', 'Y'),
-            )
+            self._ask_for_confirmation(command)
         else:
-            arguments = self.rest(2).split(';')
-            for item in range(0, len(arguments)):
-                arguments[item] = arguments[item].lstrip()
+            arguments = [arg.lstrip() for arg in self.rest(2).split(';')]
+            for index, item in enumerate(arguments):
+                arguments[index] = item
             self._chaining(len(arguments) - 1, arguments)
 
     def _question_callback(self, command, answer):
         if answer == 'y' or answer == 'Y':
             self.fm.execute_console(command)
 
-    def _chaining(self, recursion_count, commands):
+    def _ask_for_confirmation(self, command):
         from functools import partial
-        if recursion_count >= 0:
-            command = commands[recursion_count]
-            self.fm.ui.console.ask(
-                "Confirm execution of: %s (y/N)" % ''.join(command),
-                partial(self._question_callback, command),
-                ('n', 'N', 'y', 'Y'),
-            )
+        self.fm.ui.console.ask(
+            "Confirm execution of: %s (y/N)" %
+            ''.join(command),
+            partial(self._question_callback, command),
+            ('n', 'N', 'y', 'Y'),
+        )
 
+    def _chaining(self, recursion_count, commands):
+        if recursion_count >= 0:
+            self._ask_for_confirmation(commands[recursion_count])
             self._chaining(recursion_count - 1, commands)

--- a/ranger/config/commands.py
+++ b/ranger/config/commands.py
@@ -2004,13 +2004,14 @@ class confirm(Command):
         command = ''
         if len(self.args) > 1 and self.arg(1) != 'chain':
             for index in range(1, len(self.args)):
-                if index != len(self.args):
+                if index != len(self.args) - 1:
                     command += self.args[index] + ' '
+                else:
+                    # avoid adding that white space if it is the last arg
+                    command += self.args[index]
             self._ask_for_confirmation(command)
         else:
             arguments = [arg.lstrip() for arg in self.rest(2).split(';')]
-            for index, item in enumerate(arguments):
-                arguments[index] = item
             self._chaining(len(arguments) - 1, arguments)
 
     def _question_callback(self, command, answer):

--- a/ranger/config/commands.py
+++ b/ranger/config/commands.py
@@ -2003,15 +2003,11 @@ class confirm(Command):
     def execute(self):
         if len(self.args) <= 1:
             self.fm.notify("Nothing to confirm.")
-        elif self.arg(1) == 'chain':
-            # TODO: This doesn't work for chained chain commands.
-            for command in [arg.lstrip() for arg in self.rest(2).split(';')]:
-                self._ask_for_confirmation(command)
         else:
             self._ask_for_confirmation(self.rest(1))
 
     def _question_callback(self, command, answer):
-        if answer in ('y', 'Y'):
+        if answer.lower() == 'y':
             self.fm.execute_console(command)
 
     def _ask_for_confirmation(self, command):

--- a/ranger/config/commands.py
+++ b/ranger/config/commands.py
@@ -2000,10 +2000,40 @@ class confirm(Command):
     given command.
     """
 
-    def execute(self):
 
+    def execute(self):
         from functools import partial
-        command = self.arg(1)
+        selection_cmd = [
+            'bulkrename', 'chmod', 'delete', 'grep',
+            'meta', 'narrow', 'stage', 'trash', 'unstage'
+        ]
+
+        # Maps the arguments of a command to said command.
+        command_argument_mapping = {}
+        for index in range(1, len(self.args)):
+            if self.args[index] in self.fm.commands.commands:
+                command_argument_mapping[self.args[index]] = ''
+            else:
+                command_argument_mapping[self.args[index-1]] = self.args[index]
+
+        if self.fm.thistab.get_selection():
+            selection = ''
+            for fobj in self.fm.thistab.get_selection():
+                selection += fobj.relative_path + ' '
+
+        # Make sure the selection only gets shown if the command has no
+        # arguments.
+        for argument in range(1, len(self.args)):
+            if self.arg(argument) in self.fm.commands.commands:
+                if self.arg(argument) in selection_cmd:
+                    if command_argument_mapping[self.arg(argument)] == '':
+                        self.args.insert(argument+1, selection)
+
+        # Finally build the command to be shown.
+        command = ''
+        for element in range(1, len(self.args)):
+            command += self.args[element] + ' '
+
         self.fm.ui.console.ask(
             "Confirm execution of: %s (y/N)" % ''.join(command),
             partial(self._question_callback),

--- a/ranger/config/commands.py
+++ b/ranger/config/commands.py
@@ -680,8 +680,8 @@ class delete(Command):
             files = [f.relative_path for f in self.fm.thistab.get_selection()]
             many_files = (cwd.marked_items or is_directory_with_files(tfile.path))
 
-        confirm = self.fm.settings.confirm_on_delete
-        if confirm != 'never' and (confirm != 'multiple' or many_files):
+        confirm_setting = self.fm.settings.confirm_on_delete
+        if confirm_setting != 'never' and (confirm_setting != 'multiple' or many_files):
             self.fm.ui.console.ask(
                 "Confirm deletion of: %s (y/N)" % ', '.join(files),
                 partial(self._question_callback, files),
@@ -738,8 +738,8 @@ class trash(Command):
             files = [f.relative_path for f in self.fm.thistab.get_selection()]
             many_files = (cwd.marked_items or is_directory_with_files(tfile.path))
 
-        confirm = self.fm.settings.confirm_on_delete
-        if confirm != 'never' and (confirm != 'multiple' or many_files):
+        confirm_setting = self.fm.settings.confirm_on_delete
+        if confirm_setting != 'never' and (confirm_setting != 'multiple' or many_files):
             self.fm.ui.console.ask(
                 "Confirm deletion of: %s (y/N)" % ', '.join(files),
                 partial(self._question_callback, files),
@@ -1990,3 +1990,26 @@ class paste_ext(Command):
 
     def execute(self):
         return self.fm.paste(make_safe_path=paste_ext.make_safe_path)
+
+
+class confirm(Command):
+    """
+    :confirm <command> [ARGS...]
+
+    Can be used with any command. Ranger will ask if it should execute the
+    given command.
+    """
+
+    def execute(self):
+
+        from functools import partial
+        command = self.arg(1)
+        self.fm.ui.console.ask(
+            "Confirm execution of: %s (y/N)" % ''.join(command),
+            partial(self._question_callback),
+            ('n', 'N', 'y', 'Y'),
+        )
+
+    def _question_callback(self, answer):
+        if answer == 'y' or answer == 'Y':
+            self.fm.execute_console(self.arg(1) + ' ' + self.rest(2))


### PR DESCRIPTION

#### ISSUE TYPE

- Improvement/feature implementation

#### RUNTIME ENVIRONMENT
<!-- Details of your runtime environment -->
<!-- Retrieve Python/ranger version and locale with `ranger -\-version` -->
- Operating system and version: Manjaro Linux 5.3.12-1 
- Terminal emulator and version: Termite v15
- Python version: 3.7.4
- Ranger version/commit: Ranger 1.9.2 4ff19f6
- Locale: de_DE.UTF8

#### CHECKLIST

- [X] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [X] All changes follow the code style **[REQUIRED]**
- [X] All new and existing tests pass **[REQUIRED]**
- [ ] Changes require config files to be updated
    - [ ] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
This PR adds a Command which can be used for any Ranger command and asks the user for confirmation if the command shall be executed.


#### MOTIVATION AND CONTEXT
User requested to possibilty to be asked for confirmation before any command in Issue #1620


#### TESTING
Make test has been run.
So far I tested the following commands:
- delete (if confirmation is a activated ranger correctly asks for conformation twice) 
- cd
- set
- chain with different commands. Worked, although chaining delete with cd can be risky. 



