### PR TITLE
Restore access to a preview cache in clean mode

### DIFF
--- a/ranger/core/actions.py
+++ b/ranger/core/actions.py
@@ -1118,10 +1118,6 @@ class Actions(  # pylint: disable=too-many-instance-attributes,too-many-public-m
             data['loading'] = False
             return path
 
-        if ranger.args.clean:
-            # Don't access args.cachedir in clean mode
-            return None
-
         if not os.path.exists(ranger.args.cachedir):
             os.makedirs(ranger.args.cachedir)
         cacheimg = os.path.join(ranger.args.cachedir, self.sha1_encode(path))

--- a/ranger/core/main.py
+++ b/ranger/core/main.py
@@ -333,7 +333,8 @@ def parse_arguments():
         return path
 
     if args.clean:
-        args.cachedir = None
+        from tempfile import mkdtemp
+        args.cachedir = mkdtemp(suffix='.ranger-cache')
         args.confdir = None
         args.datadir = None
     else:


### PR DESCRIPTION
`--clean` is incredibly useful when testing contributions to `scope.sh`
among other things but some (most?) previews require the cache to
function.

As a compromise every invocation using `--clean` will create a temporary
cache directory.

Fixes #1783