### PR TITLE
Add list of optional deps to man page

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,22 +82,22 @@ For general usage:
 * `file` for determining file types
 * `chardet` (Python package) for improved encoding detection of text files
 * `sudo` to use the "run as root" feature
-* `python-bidi` to display right-to-left file names correctly (Hebrew, Arabic)
+* `python-bidi` (Python package) to display right-to-left file names correctly
+  (Hebrew, Arabic)
 
 For enhanced file previews (with `scope.sh`):
 
 * `img2txt` (from `caca-utils`) for ASCII-art image previews
-* `w3mimgdisplay`, `ueberzug`, `kitty`, `terminology` or `urxvt` for image
-  previews
+* `w3mimgdisplay`, `ueberzug`, `mpv`, `iTerm2`, `kitty`, `terminology` or `urxvt` for image previews
 * `convert` (from `imagemagick`) to auto-rotate images and for SVG previews
 * `ffmpegthumbnailer` for video thumbnails
 * `highlight`, `bat` or `pygmentize` for syntax highlighting of code
 * `atool`, `bsdtar`, `unrar` and/or `7z` to preview archives
-* `bsdtar`, `tar`, `unrar` and/or `unzip` to preview archives as their first
-  image
+* `bsdtar`, `tar`, `unrar`, `unzip` and/or `zipinfo` (and `sed`) to preview
+  archives as their first image
 * `lynx`, `w3m` or `elinks` to preview html pages
-* `pdftotext` or `mutool` for textual `pdf` previews, `pdftoppm` to preview as
-  image
+* `pdftotext` or `mutool` (and `fmt`) for textual `pdf` previews, `pdftoppm` to
+  preview as image
 * `djvutxt` for textual DjVu previews, `ddjvu` to preview as image
 * `calibre` or `epub-thumbnailer` for image previews of ebooks
 * `transmission-show` for viewing BitTorrent information

--- a/doc/ranger.1
+++ b/doc/ranger.1
@@ -278,10 +278,66 @@ By default, only text files are previewed, but you can enable external preview
 scripts by setting the option \f(CW\*(C`use_preview_script\*(C'\fR and \f(CW\*(C`preview_files\*(C'\fR to true.
 .PP
 This default script is \fI\f(CI%rangerdir\fI/data/scope.sh\fR. It contains more
-documentation and calls to the programs \fIlynx\fR and \fIelinks\fR for html,
-\&\fIhighlight\fR for text/code, \fIimg2txt\fR for images, \fIatool\fR for archives,
-\&\fIpdftotext\fR or \fImutool\fR for PDFs and \fImediainfo\fR for video and audio files
-and others.
+documentation and calls to many external programs to generate previews. They
+are automatically used when available but completely optional.
+.IP "For general usage:" 2
+.IX Item "For general usage:"
+.RS 2
+.PD 0
+.IP "\-" 2
+.PD
+\&\f(CW\*(C`file\*(C'\fR for determining file types
+.IP "\-" 2
+\&\f(CW\*(C`chardet\*(C'\fR (Python package) for improved encoding detection of text files
+.IP "\-" 2
+\&\f(CW\*(C`sudo\*(C'\fR to use the \*(L"run as root\*(R" feature
+.IP "\-" 2
+\&\f(CW\*(C`python\-bidi\*(C'\fR (Python package) to display right-to-left file names correctly
+(Hebrew, Arabic)
+.RE
+.RS 2
+.RE
+.IP "For enhanced file previews (with scope.sh):" 2
+.IX Item "For enhanced file previews (with scope.sh):"
+.RS 2
+.PD 0
+.IP "\-" 2
+.PD
+\&\f(CW\*(C`img2txt\*(C'\fR (from \f(CW\*(C`caca\-utils\*(C'\fR) for ASCII-art image previews
+.IP "\-" 2
+\&\f(CW\*(C`w3mimgdisplay\*(C'\fR, \f(CW\*(C`ueberzug\*(C'\fR, \f(CW\*(C`mpv\*(C'\fR, \f(CW\*(C`iTerm2\*(C'\fR, \f(CW\*(C`kitty\*(C'\fR, \f(CW\*(C`terminology\*(C'\fR or
+\&\f(CW\*(C`urxvt\*(C'\fR for image previews
+.IP "\-" 2
+\&\f(CW\*(C`convert\*(C'\fR (from \f(CW\*(C`imagemagick\*(C'\fR) to auto-rotate images and for \s-1SVG\s0 previews
+.IP "\-" 2
+\&\f(CW\*(C`ffmpegthumbnailer\*(C'\fR for video thumbnails
+.IP "\-" 2
+\&\f(CW\*(C`highlight\*(C'\fR, \f(CW\*(C`bat\*(C'\fR or \f(CW\*(C`pygmentize\*(C'\fR for syntax highlighting of code
+.IP "\-" 2
+\&\f(CW\*(C`atool\*(C'\fR, \f(CW\*(C`bsdtar\*(C'\fR, \f(CW\*(C`unrar\*(C'\fR and/or \f(CW\*(C`7z\*(C'\fR to preview archives
+.IP "\-" 2
+\&\f(CW\*(C`bsdtar\*(C'\fR, \f(CW\*(C`tar\*(C'\fR, \f(CW\*(C`unrar\*(C'\fR, \f(CW\*(C`unzip\*(C'\fR and/or \f(CW\*(C`zipinfo\*(C'\fR (and \f(CW\*(C`sed\*(C'\fR) to preview archives as their first image
+.IP "\-" 2
+\&\f(CW\*(C`lynx\*(C'\fR, \f(CW\*(C`w3m\*(C'\fR or \f(CW\*(C`elinks\*(C'\fR to preview html pages
+.IP "\-" 2
+\&\f(CW\*(C`pdftotext\*(C'\fR or \f(CW\*(C`mutool\*(C'\fR (and \f(CW\*(C`fmt\*(C'\fR) for textual pdf previews, \f(CW\*(C`pdftoppm\*(C'\fR to preview as image
+.IP "\-" 2
+\&\f(CW\*(C`djvutxt\*(C'\fR for textual DjVu previews, \f(CW\*(C`ddjvu\*(C'\fR to preview as image
+.IP "\-" 2
+\&\f(CW\*(C`calibre\*(C'\fR or \f(CW\*(C`epub\-thumbnailer\*(C'\fR for image previews of ebooks
+.IP "\-" 2
+\&\f(CW\*(C`transmission\-show\*(C'\fR for viewing BitTorrent information
+.IP "\-" 2
+\&\f(CW\*(C`mediainfo\*(C'\fR or \f(CW\*(C`exiftool\*(C'\fR for viewing information about media files
+.IP "\-" 2
+\&\f(CW\*(C`odt2txt\*(C'\fR for OpenDocument text files (odt, ods, odp and sxw)
+.IP "\-" 2
+\&\f(CW\*(C`python\*(C'\fR or \f(CW\*(C`jq\*(C'\fR for \s-1JSON\s0 files
+.IP "\-" 2
+\&\f(CW\*(C`fontimage\*(C'\fR for font previews
+.RE
+.RS 2
+.RE
 .PP
 Install these programs (just the ones you need) and scope.sh will automatically
 use them.

--- a/doc/ranger.pod
+++ b/doc/ranger.pod
@@ -191,10 +191,106 @@ By default, only text files are previewed, but you can enable external preview
 scripts by setting the option C<use_preview_script> and C<preview_files> to true.
 
 This default script is F<%rangerdir/data/scope.sh>. It contains more
-documentation and calls to the programs I<lynx> and I<elinks> for html,
-I<highlight> for text/code, I<img2txt> for images, I<atool> for archives,
-I<pdftotext> or I<mutool> for PDFs and I<mediainfo> for video and audio files
-and others.
+documentation and calls to many external programs to generate previews. They
+are automatically used when available but completely optional.
+
+=over 2
+
+=item For general usage:
+
+=over 2
+
+=item -
+
+C<file> for determining file types
+
+=item -
+
+C<chardet> (Python package) for improved encoding detection of text files
+
+=item -
+
+C<sudo> to use the "run as root" feature
+
+=item -
+
+C<python-bidi> (Python package) to display right-to-left file names correctly
+(Hebrew, Arabic)
+
+=back
+
+=item For enhanced file previews (with scope.sh):
+
+=over 2
+
+=item -
+
+C<img2txt> (from C<caca-utils>) for ASCII-art image previews
+
+=item -
+
+C<w3mimgdisplay>, C<ueberzug>, C<mpv>, C<iTerm2>, C<kitty>, C<terminology> or
+C<urxvt> for image previews
+
+=item -
+
+C<convert> (from C<imagemagick>) to auto-rotate images and for SVG previews
+
+=item -
+
+C<ffmpegthumbnailer> for video thumbnails
+
+=item -
+
+C<highlight>, C<bat> or C<pygmentize> for syntax highlighting of code
+
+=item -
+
+C<atool>, C<bsdtar>, C<unrar> and/or C<7z> to preview archives
+
+=item -
+
+C<bsdtar>, C<tar>, C<unrar>, C<unzip> and/or C<zipinfo> (and C<sed>) to preview archives as their first image
+
+=item -
+
+C<lynx>, C<w3m> or C<elinks> to preview html pages
+
+=item -
+
+C<pdftotext> or C<mutool> (and C<fmt>) for textual pdf previews, C<pdftoppm> to preview as image
+
+=item -
+
+C<djvutxt> for textual DjVu previews, C<ddjvu> to preview as image
+
+=item -
+
+C<calibre> or C<epub-thumbnailer> for image previews of ebooks
+
+=item -
+
+C<transmission-show> for viewing BitTorrent information
+
+=item -
+
+C<mediainfo> or C<exiftool> for viewing information about media files
+
+=item -
+
+C<odt2txt> for OpenDocument text files (odt, ods, odp and sxw)
+
+=item -
+
+C<python> or C<jq> for JSON files
+
+=item -
+
+C<fontimage> for font previews
+
+=back
+
+=back
 
 Install these programs (just the ones you need) and scope.sh will automatically
 use them.


### PR DESCRIPTION
The man page was missing the various optional dependencies for previews.
I revised and then copied the list from the `README.md`.

Fixes #1781