### PR TITLE
Add Direct Stream Digital/Transfer to mime types

### DIFF
--- a/ranger/data/mime.types
+++ b/ranger/data/mime.types
@@ -23,6 +23,7 @@ audio/ogg               oga ogg spx opus
 audio/wavpack           wv wvc
 audio/webm              weba
 audio/x-ape             ape
+audio/x-dsdiff          dsf
 audio/x-flac            flac
 
 image/vnd.djvu          djvu

--- a/ranger/data/scope.sh
+++ b/ranger/data/scope.sh
@@ -87,12 +87,19 @@ handle_extension() {
             w3m -dump "${FILE_PATH}" && exit 5
             lynx -dump -- "${FILE_PATH}" && exit 5
             elinks -dump "${FILE_PATH}" && exit 5
-            ;; # Continue with next handler on failure
+            ;;
+
         ## JSON
         json)
             jq --color-output . "${FILE_PATH}" && exit 5
             python -m json.tool -- "${FILE_PATH}" && exit 5
             ;;
+
+        ## Direct Stream Digital/Transfer (DSDIFF)
+        dsf)
+            mediainfo "${FILE_PATH}" && exit 5
+            exiftool "${FILE_PATH}" && exit 5
+            ;; # Continue with next handler on failure
     esac
 }
 


### PR DESCRIPTION
Direct Stream Digital/Transfer (`.dsf`) files have MIME type
`application/octet-stream` but they're audio so `audio/something` is
more useful for rifle.

Scope also runs `mediainfo` and `exiftool` for miscellaneous `audio/*`
files but we can't match on MIME type here so I added a similar clause
in `handle_extension`.