### PR TITLE
Drop the update_icon_title setting

### DIFF
--- a/ranger/config/rc.conf
+++ b/ranger/config/rc.conf
@@ -179,12 +179,8 @@ set display_free_space_in_status_bar true
 # Display files tags in all columns or only in main column?
 set display_tags_in_all_columns true
 
-# Set a title for the window?
-set update_title false
-
 # Set a title for the window? Updates both `WM_NAME` and `WM_ICON_NAME`
-# properties.
-set update_icon_title false
+set update_title false
 
 # Set the tmux window-name to "ranger"?
 set update_tmux_title true


### PR DESCRIPTION
I forgot to remove the setting from `rc.conf` when I merged the behavior
into the `update_title` setting.