### PR TITLE
Fix fuzzy tab completion when prefix is valid dir

### DIFF
--- a/ranger/config/commands.py
+++ b/ranger/config/commands.py
@@ -243,8 +243,9 @@ class cd(Command):
 
         paths = self._tab_fuzzy_match(basepath, tokens)
         if not os.path.isabs(dest):
-            paths_rel = basepath
-            paths = [os.path.relpath(path, paths_rel) for path in paths]
+            paths_rel = self.fm.thisdir.path
+            paths = [os.path.relpath(os.path.join(basepath, path), paths_rel)
+                     for path in paths]
         else:
             paths_rel = ''
         return paths, paths_rel


### PR DESCRIPTION
Fuzzy tab completion was dropping the entire valid prefix instead of
showing the path relative to the current directory.

```
/ $ cd usr/sh<tab>
/ $ cd share/      # `usr/` is dropped because it's already a valid
                   # directory.
/ $ cd usr/share/  # Proper result with the fix.
```

Fixes #1792