### PR TITLE
cd: append sep to results of tab matching also for multiple results

### DIFF
--- a/ranger/config/commands.py
+++ b/ranger/config/commands.py
@@ -275,7 +275,7 @@ class cd(Command):
             return None
         if len(paths) == 1:
             return start + paths[0] + sep
-        return [start + dirname for dirname in paths]
+        return [start + dirname + sep for dirname in paths]
 
 
 class chain(Command):


### PR DESCRIPTION
Currently, the separator is appended to the tab matching result only if exactly one matching directory has been found.
If multiple matching directories have been found, the separator is omitted.
This makes quick multi-level tab completion a bit complicated if multiple matches are present because one has to enter the separator manually after cycling through the matches before typing the match pattern for the next directory level.

This pull request proposes to append the separator also for multiple results.
The drawback, however, is that the following scenario is not possible anymore:
1. Use autocompletion with multiple results, for example `cd /l` + `tab`
2. choose directory by entering `/`
3. Press tab in order to cycle through directories in the chosen directory without a pattern

Hence, this pull request makes tab completion over multiple directory levels with a search pattern easier, but results in more effort with tab completion over multiple directory levels without a seach pattern.
I guess this depends on the actual use case. What do you think about this?