### PR TITLE
Add extensions not previously covered by scope.sh

### DIFF
--- a/ranger/data/mime.types
+++ b/ranger/data/mime.types
@@ -23,7 +23,7 @@ audio/ogg               oga ogg spx opus
 audio/wavpack           wv wvc
 audio/webm              weba
 audio/x-ape             ape
-audio/x-dsdiff          dsf
+audio/x-dsdiff          dsf dff
 audio/x-flac            flac
 
 image/vnd.djvu          djvu

--- a/ranger/data/scope.sh
+++ b/ranger/data/scope.sh
@@ -95,8 +95,9 @@ handle_extension() {
             python -m json.tool -- "${FILE_PATH}" && exit 5
             ;;
 
-        ## Direct Stream Digital/Transfer (DSDIFF)
-        dsf)
+        ## Direct Stream Digital/Transfer (DSDIFF) and wavpack aren't detected
+        ## by file(1).
+        dff|dsf|wv|wvc)
             mediainfo "${FILE_PATH}" && exit 5
             exiftool "${FILE_PATH}" && exit 5
             ;; # Continue with next handler on failure


### PR DESCRIPTION
Add `.dff` extension to `mime.types`.

Add `dff|wv|wvc` to `handle_extension` because they're not caught by the
`audio/*)` clause in `handle_mime`.