### PR TITLE
cd: fix parsing relative paths with '../' to absolute

### DIFF
--- a/ranger/config/commands.py
+++ b/ranger/config/commands.py
@@ -169,7 +169,7 @@ class cd(Command):
                 dest_exp = tail
         else:
             dest_exp = ''
-        return (start, dest_exp, os.path.join(self.fm.thisdir.path, dest_exp),
+        return (start, dest_exp, os.path.abspath(os.path.join(self.fm.thisdir.path, dest_exp)),
                 dest.endswith(os.path.sep))
 
     @staticmethod


### PR DESCRIPTION
#### CHECKLIST
- [x] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [x] All changes follow the code style **[REQUIRED]**
- [x] All new and existing tests pass **[REQUIRED]**
- [ ] Changes require config files to be updated
    - [ ] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
This pull request implements parsing the absolute path constructed from `self.fm.thisdir.path` and `dest_exp` in `_tab_args()` using `os.path.abspath()`. 
This is necessary because otherwise, if the user types relative navigation tokens in `cd`, like `../myDir` or `./myDir`, tab completion will not work, contrary to the usual shell's tab completion.