### PR TITLE
Fix white text on white background in titlebar

### DIFF
--- a/ranger/colorschemes/default.py
+++ b/ranger/colorschemes/default.py
@@ -101,7 +101,6 @@ class Default(ColorScheme):
             elif context.link:
                 fg = cyan
             attr |= bold
-            fg += BRIGHT
 
         elif context.in_statusbar:
             if context.permissions:


### PR DESCRIPTION
We were doubling up bold and BRIGHT for the name of the selected file in
the titlebar.