### PR TITLE
Cleanup the temporary cache directory in the --clean mode

### DIFF
--- a/ranger/core/main.py
+++ b/ranger/core/main.py
@@ -6,8 +6,10 @@
 from __future__ import (absolute_import, division, print_function)
 
 from logging import getLogger
+import atexit
 import locale
 import os.path
+import shutil
 import sys
 import tempfile
 
@@ -337,6 +339,17 @@ def parse_arguments():
         args.cachedir = mkdtemp(suffix='.ranger-cache')
         args.confdir = None
         args.datadir = None
+
+        @atexit.register
+        def cleanup_cachedir():  # pylint: disable=unused-variable
+            try:
+                shutil.rmtree(args.cachedir)
+            except Exception as ex:  # pylint: disable=broad-except
+                sys.stderr.write(
+                    "Error during the temporary cache directory cleanup: "
+                    "{}\n".format(ex)
+                )
+
     else:
         args.cachedir = path_init('cachedir')
         args.confdir = path_init('confdir')

--- a/ranger/core/main.py
+++ b/ranger/core/main.py
@@ -346,7 +346,7 @@ def parse_arguments():
                 shutil.rmtree(args.cachedir)
             except Exception as ex:  # pylint: disable=broad-except
                 sys.stderr.write(
-                    "Error during the temporary cache directory cleanup: "
+                    "Error during the temporary cache directory cleanup:\n"
                     "{}\n".format(ex)
                 )
 


### PR DESCRIPTION
#### ISSUE TYPE
<!-- Pick relevant types and delete the rest -->
- Improvement/feature implementation

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [X] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [X] All changes follow the code style **[REQUIRED]**
- [X] All new and existing tests pass **[REQUIRED]**
- [ ] Changes require config files to be updated
    - [ ] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### MOTIVATION AND CONTEXT
<!-- Why are these changes required? -->
<!-- What problems do these changes solve? -->
<!-- Link to relevant issues -->

The `--clean` mode was leaving semi-temporary traces in /tmp. On long-lived systems it could easily clutter /tmp and didn't feel nice in general.