### PR TITLE
Add bookmark drawing to the paste to bookmark map

### DIFF
--- a/ranger/config/rc.conf
+++ b/ranger/config/rc.conf
@@ -620,7 +620,7 @@ map m<any>  set_bookmark %any
 map um<any> unset_bookmark %any
 
 map m<bg>   draw_bookmarks
-copymap m<bg>  um<bg> `<bg> '<bg>
+copymap m<bg>  um<bg> `<bg> '<bg> p`<bg> p'<bg>
 
 # Generate all the chmod bindings with some python help:
 eval for arg in "rwxXst": cmd("map +u{0} shell -f chmod u+{0} %s".format(arg))


### PR DESCRIPTION
Neglected to add drawing of bookmarks to the mapping that allows pasting
the contents of the copybuffer to a bookmark's path.

Brought to my attention by discussion in #1277.