### PR TITLE
Implementing yanking the contents of a file

### DIFF
--- a/doc/ranger.pod
+++ b/doc/ranger.pod
@@ -531,6 +531,10 @@ Copy (yank) the selection, like pressing Ctrl+C in modern GUI programs.  (You
 can also type "ya" to add files to the copy buffer, "yr" to remove files again,
 or "yt" for toggling.)
 
+=item yc
+
+Copy (yank) the contents of the selected file.
+
 =item dd
 
 Cut the selection, like pressing Ctrl+X in modern GUI programs.  (There are

--- a/ranger/config/rc.conf
+++ b/ranger/config/rc.conf
@@ -470,6 +470,7 @@ map yp yank path
 map yd yank dir
 map yn yank name
 map y. yank name_without_extension
+map yc yank content
 
 # Filesystem Operations
 map =  chmod

--- a/ranger/ext/clipboard_util.py
+++ b/ranger/ext/clipboard_util.py
@@ -1,0 +1,39 @@
+# This file is part of ranger, the console file manager.
+# License: GNU GPL version 3, see the file "AUTHORS" for details.
+
+
+def clipboards():
+    """Return a list of commands that can be executed by subprocess.Popen
+to copy some content into the system clipboard and proamry X
+selection. The spawn processes will read the contents from the
+standard input.
+
+    >>> new_clipboard_contents = 'some string'
+    >>> for command in clipboards():
+            process = subprocess.Popen(command, universal_newlines=True,
+                                       stdin=subprocess.PIPE)
+            process.communicate(input=new_clipboard_contents)
+"""
+    from ranger.ext.get_executables import get_executables
+    clipboard_managers = {
+        'xclip': [
+            ['xclip'],
+            ['xclip', '-selection', 'clipboard'],
+        ],
+        'xsel': [
+            ['xsel'],
+            ['xsel', '-b'],
+        ],
+        'wl-copy': [
+            ['wl-copy'],
+        ],
+        'pbcopy': [
+            ['pbcopy'],
+        ],
+    }
+    ordered_managers = ['pbcopy', 'wl-copy', 'xclip', 'xsel']
+    executables = get_executables()
+    for manager in ordered_managers:
+        if manager in executables:
+            return clipboard_managers[manager]
+    return []


### PR DESCRIPTION
Added functionality to yank the contents of a file without opening it. This partiality has to do with #1525. 

#### ISSUE TYPE
- Improvement/feature implementation

#### RUNTIME ENVIRONMENT
- Operating system and version: Debian 10
- Terminal emulator and version: Urxvt 9.22
- Python version: python3.7
- Ranger version/commit: v1.9.2-390-gbae8f00f
- Locale: en_US.UTF-8

#### CHECKLIST
- [x] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [x] All changes follow the code style **[REQUIRED]**
- [x] All new and existing tests pass **[REQUIRED]**
- [x] Changes require config files to be updated
    - [x] Config files have been updated
- [x] Changes require documentation to be updated
    - [x] Documentation has been updated
- [] Changes require tests to be updated
    - [] Tests have been updated

