### PR TITLE
Add note in rifle manpage of  rifle.conf reading behavior

### DIFF
--- a/doc/rifle.pod
+++ b/doc/rifle.pod
@@ -71,7 +71,7 @@ Print a list of options and exit.
 rifle shares configuration files with ranger, though ranger is not required in
 order to use rifle. The default configuration file F<rifle.conf> is expected
 to be at F<~/.config/ranger/rifle.conf>. However, this can be overridden with
-the B<-c> option.
+the B<-c> option. Note that rifle will only read one F<rifle.conf> file. 
 
 This file specifies patterns for determining the commands to open files with.
 The syntax is described in the comments of the default F<rifle.conf> that ships


### PR DESCRIPTION

#### ISSUE TYPE
- Improvement/feature implementation

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [X] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [X] All changes follow the code style **[REQUIRED]**
- [ ] All new and existing tests pass **[REQUIRED]**
- [ ] Changes require documentation to be updated **Nope**
    - [ ] Documentation has been updated

#### DESCRIPTION
Add note to rifle manpage that it will only read one config file. In response to #1825.

 - Open to rewording the sentence/adding more information.
 - Also, not sure how to update the manpage itself from the `.pod` file.

#### MOTIVATION AND CONTEXT
My original issue  #1825 came about because I assumed that `rifle.conf` behaved exactly like `ranger.conf`. I assumed I'd only need to add settings that differ from the default `rifle.conf` rather than needing my `~/.config/ranger/rifle.conf` to contain *all* the rules required. 
