### PR TITLE
Allow equal mtime for cached previews

### DIFF
--- a/ranger/core/actions.py
+++ b/ranger/core/actions.py
@@ -37,8 +37,6 @@ from ranger.container.settings import ALLOWED_SETTINGS, ALLOWED_VALUES
 
 MACRO_FAIL = "<\x01\x01MACRO_HAS_NO_VALUE\x01\01>"
 
-PY3 = version_info[0] >= 3
-
 LOG = getLogger(__name__)
 
 
@@ -1052,13 +1050,10 @@ class Actions(  # pylint: disable=too-many-instance-attributes,too-many-public-m
     @staticmethod
     def sha1_encode(path):
         stat_ = stat(path)
-        if PY3:
-            path = path.encode('utf-8', 'backslashreplace')
         sha = sha1(stat_.st_dev)
         sha.update(stat_.st_ino)
         sha.update(stat_.st_mtime)
-        hashpath = os.path.join(ranger.args.cachedir, sha.hexdigest())
-        return '{0}.jpg'.format(hashpath)
+        return '{0}.jpg'.format(sha.hexdigest())
 
     def get_preview(self, fobj, width, height):  # pylint: disable=too-many-return-statements
         pager = self.ui.get_pager()

--- a/ranger/core/actions.py
+++ b/ranger/core/actions.py
@@ -35,8 +35,9 @@ from ranger.container.file import File
 from ranger.core.loader import CommandLoader, CopyLoader
 from ranger.container.settings import ALLOWED_SETTINGS, ALLOWED_VALUES
 
-
 MACRO_FAIL = "<\x01\x01MACRO_HAS_NO_VALUE\x01\01>"
+
+PY3 = version_info[0] >= 3
 
 LOG = getLogger(__name__)
 
@@ -1050,10 +1051,15 @@ class Actions(  # pylint: disable=too-many-instance-attributes,too-many-public-m
 
     @staticmethod
     def sha1_encode(path):
-        if version_info[0] < 3:
-            return os.path.join(ranger.args.cachedir, sha1(path).hexdigest()) + '.jpg'
-        return os.path.join(ranger.args.cachedir,
-                            sha1(path.encode('utf-8', 'backslashreplace')).hexdigest()) + '.jpg'
+        stat_ = stat(path)
+        if PY3:
+            path = path.encode('utf-8', 'backslashreplace')
+        sha = sha1(path)
+        sha.update(stat_.st_dev)
+        sha.update(stat_.st_ino)
+        sha.update(stat_.st_mtime)
+        hashpath = os.path.join(ranger.args.cachedir, sha.hexdigest())
+        return '{0}.jpg'.format(hashpath)
 
     def get_preview(self, fobj, width, height):  # pylint: disable=too-many-return-statements
         pager = self.ui.get_pager()
@@ -1123,8 +1129,7 @@ class Actions(  # pylint: disable=too-many-instance-attributes,too-many-public-m
             os.makedirs(ranger.args.cachedir)
         cacheimg = os.path.join(ranger.args.cachedir, self.sha1_encode(path))
         if self.settings.preview_images and \
-                os.path.isfile(cacheimg) and \
-                os.path.getmtime(cacheimg) >= os.path.getmtime(path):
+                os.path.isfile(cacheimg):
             data['foundpreview'] = True
             data['imagepreview'] = True
             pager.set_image(cacheimg)

--- a/ranger/core/actions.py
+++ b/ranger/core/actions.py
@@ -1054,8 +1054,7 @@ class Actions(  # pylint: disable=too-many-instance-attributes,too-many-public-m
         stat_ = stat(path)
         if PY3:
             path = path.encode('utf-8', 'backslashreplace')
-        sha = sha1(path)
-        sha.update(stat_.st_dev)
+        sha = sha1(stat_.st_dev)
         sha.update(stat_.st_ino)
         sha.update(stat_.st_mtime)
         hashpath = os.path.join(ranger.args.cachedir, sha.hexdigest())

--- a/ranger/core/actions.py
+++ b/ranger/core/actions.py
@@ -1124,7 +1124,7 @@ class Actions(  # pylint: disable=too-many-instance-attributes,too-many-public-m
         cacheimg = os.path.join(ranger.args.cachedir, self.sha1_encode(path))
         if self.settings.preview_images and \
                 os.path.isfile(cacheimg) and \
-                os.path.getmtime(cacheimg) > os.path.getmtime(path):
+                os.path.getmtime(cacheimg) >= os.path.getmtime(path):
             data['foundpreview'] = True
             data['imagepreview'] = True
             pager.set_image(cacheimg)


### PR DESCRIPTION
This allows the use of symlinks to prevent copying files to the cache.

Fixes #1837