### PR TITLE
Separate progress tracking; show copy speed in TaskView

### DIFF
--- a/ranger/container/directory.py
+++ b/ranger/container/directory.py
@@ -13,7 +13,7 @@ from time import time
 
 from ranger.container.fsobject import BAD_INFO, FileSystemObject
 from ranger.core.loader import Loadable
-from ranger.core.progress_tracker import ProgressTracker
+from ranger.core.progress_tracker import DirectoryProgressTracker
 from ranger.ext.mount_path import mount_path
 from ranger.container.file import File
 from ranger.ext.accumulator import Accumulator
@@ -108,7 +108,7 @@ class Directory(  # pylint: disable=too-many-instance-attributes,too-many-public
     cycle_list = None
     loading = False
     progressbar_supported = True
-    progress = ProgressTracker()
+    progress = DirectoryProgressTracker()
     flat = 0
 
     filenames = None

--- a/ranger/core/loader.py
+++ b/ranger/core/loader.py
@@ -19,7 +19,7 @@ except ImportError:
     HAVE_CHARDET = False
 
 from ranger.core.shared import FileManagerAware
-from ranger.core.progress_tracker import ProgressTracker
+from ranger.core.progress_tracker import FileProgressTracker
 from ranger.ext.safe_path import get_safe_path
 from ranger.ext.signals import SignalDispatcher
 from ranger.ext.human_readable import human_readable
@@ -29,7 +29,7 @@ class Loadable(object):
     paused = False
     progressbar_supported = False
 
-    def __init__(self, gen, descr, progress=ProgressTracker(0)):
+    def __init__(self, gen, descr, progress=FileProgressTracker(0)):
         self.load_generator = gen
         self.description = descr
         self.progress = progress
@@ -61,7 +61,7 @@ class CopyLoader(Loadable, FileManagerAware):  # pylint: disable=too-many-instan
         self.original_path = dest if dest is not None else self.fm.thistab.path
         self.overwrite = overwrite
         self.make_safe_path = make_safe_path
-        self.progress = ProgressTracker(self._calculate_size(1))
+        self.progress = FileProgressTracker(self._calculate_size(1))
         if self.copy_buffer:
             self.one_file = self.copy_buffer[0]
         Loadable.__init__(self, self.generate(), 'Calculating size...', self.progress)

--- a/ranger/core/progress_tracker.py
+++ b/ranger/core/progress_tracker.py
@@ -25,3 +25,16 @@ class ProgressTracker(object):
         if self.total_items == 0:
             return 0
         return (self.done / self.total_items) * 100
+
+    def get_status_text(self):
+        raise NotImplementedError('Please Implement this method')
+
+
+class DirectoryProgressTracker(ProgressTracker):
+    def get_status_text(self):
+        return '{:3.2f}%'.format(self.percent)
+
+
+class FileProgressTracker(ProgressTracker):
+    def get_status_text(self):
+        return '{:3.2f}%'.format(self.percent)

--- a/ranger/core/progress_tracker.py
+++ b/ranger/core/progress_tracker.py
@@ -4,11 +4,12 @@
 """
 A Progress Tracker of any Loadable that manages all the progress
 related statistics.
-
-Currently, only percent reporting is implemented.
 """
 
 from __future__ import division
+
+import time
+from ranger.ext.human_readable import human_readable
 
 
 class ProgressTracker(object):
@@ -16,6 +17,7 @@ class ProgressTracker(object):
     def __init__(self, total_items=0):
         self.total_items = total_items
         self.done = 0
+        self.start_time = time.time()
 
     def step(self, stepsize=1):
         self.done += stepsize
@@ -25,6 +27,12 @@ class ProgressTracker(object):
         if self.total_items == 0:
             return 0
         return (self.done / self.total_items) * 100
+
+    @property
+    def average_rate(self):
+        time_diff = time.time() - self.start_time
+        rate = self.done / time_diff
+        return rate
 
     def get_status_text(self):
         raise NotImplementedError('Please Implement this method')
@@ -37,4 +45,5 @@ class DirectoryProgressTracker(ProgressTracker):
 
 class FileProgressTracker(ProgressTracker):
     def get_status_text(self):
-        return '{:3.2f}%'.format(self.percent)
+        average_rate = human_readable(self.average_rate, '') + '/s'
+        return '{:3.2f}% {:>7}'.format(self.percent, average_rate)

--- a/ranger/core/progress_tracker.py
+++ b/ranger/core/progress_tracker.py
@@ -1,0 +1,27 @@
+# This file is part of ranger, the console file manager.
+# License: GNU GPL version 3, see the file "AUTHORS" for details.
+
+"""
+A Progress Tracker of any Loadable that manages all the progress
+related statistics.
+
+Currently, only percent reporting is implemented.
+"""
+
+from __future__ import division
+
+
+class ProgressTracker(object):
+
+    def __init__(self, total_items=0):
+        self.total_items = total_items
+        self.done = 0
+
+    def step(self, stepsize=1):
+        self.done += stepsize
+
+    @property
+    def percent(self):
+        if self.total_items == 0:
+            return 0
+        return (self.done / self.total_items) * 100

--- a/ranger/gui/widgets/statusbar.py
+++ b/ranger/gui/widgets/statusbar.py
@@ -327,7 +327,7 @@ class StatusBar(Widget):  # pylint: disable=too-many-instance-attributes
             states = []
             for item in queue:
                 if item.progressbar_supported:
-                    states.append(item.percent)
+                    states.append(item.progress.percent)
             if states:
                 state = sum(states) / len(states)
                 barwidth = (state / 100) * self.wid

--- a/ranger/gui/widgets/taskview.py
+++ b/ranger/gui/widgets/taskview.py
@@ -53,9 +53,9 @@ class TaskView(Widget, Accumulator):
                         clr.append('selected')
 
                     descr = obj.get_description()
-                    if obj.progressbar_supported and obj.percent >= 0 and obj.percent <= 100:
-                        self.addstr(y, 0, "%3.2f%% - %s" % (obj.percent, descr), self.wid)
-                        wid = int((self.wid / 100) * obj.percent)
+                    if obj.progressbar_supported and 0 <= obj.progress.percent <= 100:
+                        self.addstr(y, 0, "%3.2f%% - %s" % (obj.progress.percent, descr), self.wid)
+                        wid = int((self.wid / 100) * obj.progress.percent)
                         self.color_at(y, 0, self.wid, tuple(clr))
                         self.color_at(y, 0, wid, tuple(clr), 'loaded')
                     else:

--- a/ranger/gui/widgets/taskview.py
+++ b/ranger/gui/widgets/taskview.py
@@ -54,7 +54,7 @@ class TaskView(Widget, Accumulator):
 
                     descr = obj.get_description()
                     if obj.progressbar_supported and 0 <= obj.progress.percent <= 100:
-                        status = '{:3.2f}% - {:s}'.format(obj.progress.percent, descr)
+                        status = '{:s} - {:s}'.format(obj.progress.get_status_text(), descr)
                         self.addstr(y, 0, status, self.wid)
                         wid = int((self.wid / 100) * obj.progress.percent)
                         self.color_at(y, 0, self.wid, tuple(clr))

--- a/ranger/gui/widgets/taskview.py
+++ b/ranger/gui/widgets/taskview.py
@@ -54,7 +54,8 @@ class TaskView(Widget, Accumulator):
 
                     descr = obj.get_description()
                     if obj.progressbar_supported and 0 <= obj.progress.percent <= 100:
-                        self.addstr(y, 0, "%3.2f%% - %s" % (obj.progress.percent, descr), self.wid)
+                        status = '{:3.2f}% - {:s}'.format(obj.progress.percent, descr)
+                        self.addstr(y, 0, status, self.wid)
                         wid = int((self.wid / 100) * obj.progress.percent)
                         self.color_at(y, 0, self.wid, tuple(clr))
                         self.color_at(y, 0, wid, tuple(clr), 'loaded')


### PR DESCRIPTION
#### ISSUE TYPE
- Improvement/feature implementation

#### RUNTIME ENVIRONMENT
<!-- Details of your runtime environment -->
<!-- Retrieve Python/ranger version and locale with `ranger -\-version` -->
- Operating system and version: Arch Linux, kernel 5.4.15-arch1-1
- Terminal emulator and version: termite v15
- Python version: 3.8.1
- Ranger version/commit: v1.9.3
- Locale: en_US.UTF-8

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [X] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [X] All changes follow the code style **[REQUIRED]**
- [X] All new and existing tests pass **[REQUIRED]**
- [ ] Changes require config files to be updated
    - [ ] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
<!-- Describe the changes in detail -->
A bunch of users wished to be able to know the copy/move speed of a task. The only statistic tracked was progress percent and it was done in place. The percent tracking was separated into a ProgressTracker class which allowed clean implementation of copy/move speed calculation. 


#### MOTIVATION AND CONTEXT
<!-- Why are these changes required? -->
<!-- What problems do these changes solve? -->
<!-- Link to relevant issues -->
#738
Although the issue specifically mentions status line, I believe this satisfies the request. 

#### TESTING
<!-- What tests have been run? -->
<!-- How does the changes affect other areas of the codebase? -->
Testing was done manually on a single drive (move was immediate). I used one complex directory with many small files (`node_modules`) and a second directory containing one big (~600MB) binary file. I duplicated one of the directories each time to test the progress indication. During the copying I switched to TaskView (W key) and observed the progress. I tested both of these task running at the same time. Switching does work, but the speed is not calculated correctly when the task is paused. Testing was only done on ext4 partitions.

Directory loading (which also has progress) was also tested. Running a high disk IO operation (`dd if=/dev/zero of=./test1.img bs=1G count=10 oflag=dsync`) allowed me to simulate a slow IO storage. This was crucial for testing of directory loading. 

The one slight problem is the copy speed is being displayed for directory loading as well and the units happen to be in bytes.

The impact on CPU utilization or actual copy speed was not tested in any way.