### PR TITLE
scope.sh: add preview support based on `file` description

### DIFF
--- a/ranger/data/scope.sh
+++ b/ranger/data/scope.sh
@@ -47,6 +47,20 @@ PYGMENTIZE_STYLE=${PYGMENTIZE_STYLE:-autumn}
 OPENSCAD_IMGSIZE=${RNGR_OPENSCAD_IMGSIZE:-1000,1000}
 OPENSCAD_COLORSCHEME=${RNGR_OPENSCAD_COLORSCHEME:-Tomorrow Night}
 
+handle_desc() {
+	file_desc="$1"
+
+	case "${file_desc}" in
+		## OpenSSL
+		"PEM certificate")
+			openssl x509 -in "${FILE_PATH}" -text && exit 0
+			;;
+		"PEM certificate request")
+			openssl req -in "${FILE_PATH}" -text && exit 0
+			;;
+	esac
+}
+
 handle_extension() {
     case "${FILE_EXTENSION_LOWER}" in
         ## Archive
@@ -338,11 +352,12 @@ handle_fallback() {
     exit 1
 }
 
-
+FILEDESC="$( file --dereference --brief -- "${FILE_PATH}" )"
 MIMETYPE="$( file --dereference --brief --mime-type -- "${FILE_PATH}" )"
 if [[ "${PV_IMAGE_ENABLED}" == 'True' ]]; then
     handle_image "${MIMETYPE}"
 fi
+handle_desc "${FILEDESC}"
 handle_extension
 handle_mime "${MIMETYPE}"
 handle_fallback


### PR DESCRIPTION
<!-- Provide a descriptive summary of the changes in the title above -->

#### ISSUE TYPE
- Improvement/feature implementation

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [X] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [X] All changes follow the code style **[REQUIRED]**
- [ ] All new and existing tests pass **[REQUIRED]**
- [ ] Changes require config files to be updated
    - [ ] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
Add support for previewing files based on their description returned by `file --dereference --brief`. Let’s start with OpenSSL certificate and CSR files.