### PR TITLE
Add rust to programming languages for rifle

### DIFF
--- a/ranger/config/rifle.conf
+++ b/ranger/config/rifle.conf
@@ -87,8 +87,8 @@ ext x?html?, has w3m,               terminal = w3m "$@"
 # Define the "editor" for text files as first action
 mime ^text,  label editor = ${VISUAL:-$EDITOR} -- "$@"
 mime ^text,  label pager  = "$PAGER" -- "$@"
-!mime ^text, label editor, ext xml|json|csv|tex|py|pl|rb|js|sh|php = ${VISUAL:-$EDITOR} -- "$@"
-!mime ^text, label pager,  ext xml|json|csv|tex|py|pl|rb|js|sh|php = "$PAGER" -- "$@"
+!mime ^text, label editor, ext xml|json|csv|tex|py|pl|rb|rs|js|sh|php = ${VISUAL:-$EDITOR} -- "$@"
+!mime ^text, label pager,  ext xml|json|csv|tex|py|pl|rb|rs|js|sh|php = "$PAGER" -- "$@"
 
 ext 1                         = man "$1"
 ext s[wmf]c, has zsnes, X     = zsnes "$1"
@@ -266,9 +266,9 @@ label open, has xdg-open = xdg-open -- "$@"
 label open, has open     = open -- "$@"
 
 # Define the editor for non-text files + pager as last action
-              !mime ^text, !ext xml|json|csv|tex|py|pl|rb|js|sh|php  = ask
-label editor, !mime ^text, !ext xml|json|csv|tex|py|pl|rb|js|sh|php  = ${VISUAL:-$EDITOR} -- "$@"
-label pager,  !mime ^text, !ext xml|json|csv|tex|py|pl|rb|js|sh|php  = "$PAGER" -- "$@"
+              !mime ^text, !ext xml|json|csv|tex|py|pl|rb|rs|js|sh|php  = ask
+label editor, !mime ^text, !ext xml|json|csv|tex|py|pl|rb|rs|js|sh|php  = ${VISUAL:-$EDITOR} -- "$@"
+label pager,  !mime ^text, !ext xml|json|csv|tex|py|pl|rb|rs|js|sh|php  = "$PAGER" -- "$@"
 
 
 ######################################################################


### PR DESCRIPTION
Add the Rust extension `.rs` to the list of programming languages to
match editor and pager because it is erroneously guessed as being
`application/rls-services+xml`.