### PR TITLE
Fix trash location

### DIFF
--- a/doc/ranger.1
+++ b/doc/ranger.1
@@ -133,7 +133,7 @@
 .\" ========================================================================
 .\"
 .IX Title "RANGER 1"
-.TH RANGER 1 "ranger-1.9.3" "2019-12-31" "ranger manual"
+.TH RANGER 1 "ranger-1.9.3" "2020-02-22" "ranger manual"
 .\" For nroff, turn off justification.  Always turn off hyphenation; it makes
 .\" way too many mistakes in technical documents.
 .if n .ad l
@@ -1731,9 +1731,9 @@ Creates an empty file with the name \fIfilename\fR, unless it already exists.
 .IX Item "trash"
 Move all files in the selection to the trash using rifle. Rifle tries to use a
 trash manager like \fItrash-cli\fR if available but will fall back to moving files
-to either \fI\f(CI$XDG_DATA_HOME\fI/ranger\-trash\fR or \fI~/.ranger/ranger\-trash\fR. This is
-a less permanent version of \fIdelete\fR, relying on the user to clear out the
-trash whenever it's convenient. While having the possibility of restoring
+to either \fI\f(CI$XDG_DATA_HOME\fI/ranger/trash\fR or \fI~/.local/share/ranger/trash\fR.
+This is a less permanent version of \fIdelete\fR, relying on the user to clear out
+the trash whenever it's convenient. While having the possibility of restoring
 trashed files until this happens. ranger will ask for a confirmation if you
 attempt to trash multiple (marked) files or non-empty directories. This can be
 changed by modifying the setting \*(L"confirm_on_delete\*(R".

--- a/doc/ranger.pod
+++ b/doc/ranger.pod
@@ -1879,9 +1879,9 @@ Creates an empty file with the name I<filename>, unless it already exists.
 
 Move all files in the selection to the trash using rifle. Rifle tries to use a
 trash manager like I<trash-cli> if available but will fall back to moving files
-to either F<$XDG_DATA_HOME/ranger-trash> or F<~/.ranger/ranger-trash>. This is
-a less permanent version of I<delete>, relying on the user to clear out the
-trash whenever it's convenient. While having the possibility of restoring
+to either F<$XDG_DATA_HOME/ranger/trash> or F<~/.local/share/ranger/trash>.
+This is a less permanent version of I<delete>, relying on the user to clear out
+the trash whenever it's convenient. While having the possibility of restoring
 trashed files until this happens. ranger will ask for a confirmation if you
 attempt to trash multiple (marked) files or non-empty directories. This can be
 changed by modifying the setting "confirm_on_delete".

--- a/ranger/config/rifle.conf
+++ b/ranger/config/rifle.conf
@@ -281,4 +281,4 @@ mime application/x-executable = "$1"
 
 # Move the file to trash using trash-cli.
 label trash, has trash-put = trash-put -- "$@"
-label trash = mkdir -p -- ${XDG_DATA_DIR:-$HOME/.ranger}/ranger-trash; mv -- "$@" ${XDG_DATA_DIR:-$HOME/.ranger}/ranger-trash
+label trash = mkdir -p -- "${XDG_DATA_HOME:-$HOME/.local/share}/ranger/trash"; mv -- "$@" "${XDG_DATA_HOME:-$HOME/.local/share}/ranger/trash"


### PR DESCRIPTION
#### ISSUE TYPE

- Improvement

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [X] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [X] All changes follow the code style **[REQUIRED]**
- [ ] All new and existing tests pass **[REQUIRED]**
- [X] Changes require config files to be updated
    - [X] Config files have been updated
- [X] Changes require documentation to be updated
    - [X] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION

Change the fallback trash location to use the correct environment variable and
ranger's default data directory. Update the man page to reflect the change.

#### MOTIVATION AND CONTEXT

Fixes #1848

#### TESTING

I can't get the tests to run properly. I only manually changed `rifle.conf` and `ranger.pod` and ran `make man`.