### PR TITLE
Fix `FileNotFoundError` on startup

### DIFF
--- a/ranger/gui/ui.py
+++ b/ranger/gui/ui.py
@@ -497,7 +497,7 @@ class UI(  # pylint: disable=too-many-instance-attributes,too-many-public-method
                 # gives out a warning if $TERM is not "screen"
                 try:
                     self._screen_title = check_output(
-                        ['screen', '-Q', 'title']).strip()
+                        ['screen', '-Q', 'title'], shell=True).strip()
                 except CalledProcessError:
                     self._screen_title = None
 

--- a/ranger/gui/ui.py
+++ b/ranger/gui/ui.py
@@ -9,6 +9,7 @@ import threading
 import curses
 from subprocess import CalledProcessError
 
+from ranger.ext.get_executables import get_executables
 from ranger.ext.keybinding_parser import KeyBuffer, KeyMaps, ALT_KEY
 from ranger.ext.lazy_property import lazy_property
 from ranger.ext.signals import Signal
@@ -49,6 +50,16 @@ def _setup_mouse(signal):
         curses.mousemask(0)
 
 
+def _in_tmux():
+    return ('TMUX' in os.environ
+            and 'tmux' in get_executables())
+
+
+def _in_screen():
+    return ('screen' in os.environ['TERM']
+            and 'screen' in get_executables())
+
+
 class UI(  # pylint: disable=too-many-instance-attributes,too-many-public-methods
         DisplayableContainer):
     ALLOWED_VIEWMODES = 'miller', 'multipane'
@@ -73,8 +84,8 @@ class UI(  # pylint: disable=too-many-instance-attributes,too-many-public-method
         self.multiplexer = None
         self._draw_title = None
         self._tmux_automatic_rename = None
-        self._tmux_title = None
-        self._screen_title = None
+        self._multiplexer_title = None
+        self._multiplexer_title = None
         self.browser = None
 
         if fm is not None:
@@ -469,58 +480,64 @@ class UI(  # pylint: disable=too-many-instance-attributes,too-many-public-method
     # Handles window renaming behaviour of the terminal multiplexers
     # GNU Screen and Tmux
     def handle_multiplexer(self):
-        if self.settings.update_tmux_title:
-            if 'TMUX' in os.environ:
-                # Stores the automatic-rename setting
-                # prints out a warning if the allow-rename in tmux is not set
-                tmux_allow_rename = check_output(
-                    ['tmux', 'show-window-options', '-v',
-                     'allow-rename']).strip()
-                if tmux_allow_rename == 'off':
-                    self.fm.notify('Warning: allow-rename not set in Tmux!',
-                                   bad=True)
-                elif self._tmux_title is None:
-                    self._tmux_title = check_output(
-                        ['tmux', 'display-message', '-p', '#W']).strip()
-                else:
+        if (self.settings.update_tmux_title and not self._multiplexer_title):
+            try:
+                if _in_tmux():
+                    # Stores the automatic-rename setting
+                    # prints out a warning if allow-rename isn't set in tmux
                     try:
+                        tmux_allow_rename = check_output(
+                            ['tmux', 'show-window-options', '-v',
+                             'allow-rename']).strip()
+                    except CalledProcessError:
+                        tmux_allow_rename = 'off'
+                    if tmux_allow_rename == 'off':
+                        self.fm.notify('Warning: allow-rename not set in Tmux!',
+                                       bad=True)
+                    else:
+                        self._multiplexer_title = check_output(
+                            ['tmux', 'display-message', '-p', '#W']).strip()
                         self._tmux_automatic_rename = check_output(
                             ['tmux', 'show-window-options', '-v',
                              'automatic-rename']).strip()
                         if self._tmux_automatic_rename == 'on':
                             check_output(['tmux', 'set-window-option',
                                           'automatic-rename', 'off'])
-                    except CalledProcessError:
-                        pass
-            elif 'screen' in os.environ['TERM'] and self._screen_title is None:
-                # Stores the screen window name before renaming it
-                # gives out a warning if $TERM is not "screen"
-                try:
-                    self._screen_title = check_output(
-                        ['screen', '-Q', 'title'], shell=True).strip()
-                except CalledProcessError:
-                    self._screen_title = None
+                elif _in_screen():
+                    # Stores the screen window name before renaming it
+                    # gives out a warning if $TERM is not "screen"
+                    self._multiplexer_title = check_output(
+                        ['screen', '-Q', 'title']).strip()
+            except CalledProcessError:
+                self.fm.notify("Couldn't access previous multiplexer window"
+                               " name, won't be able to restore.",
+                               bad=False)
+            if not self._multiplexer_title:
+                self._multiplexer_title = os.environ.get(
+                    "SHELL",
+                    "shell").split("/")[-1]
 
             sys.stdout.write("\033kranger\033\\")
             sys.stdout.flush()
 
     # Restore window name
     def restore_multiplexer_name(self):
-        try:
-            if 'TMUX' in os.environ:
-                if self._tmux_automatic_rename:
-                    check_output(['tmux', 'set-window-option',
-                                  'automatic-rename',
-                                  self._tmux_automatic_rename])
-                else:
-                    check_output(['tmux', 'set-window-option', '-u',
-                                  'automatic-rename'])
-                if self._tmux_title:
-                    check_output(['tmux', 'rename-window', self._tmux_title])
-            elif 'screen' in os.environ['TERM'] and self._screen_title:
-                check_output(['screen', '-X', 'title', self._screen_title])
-        except CalledProcessError:
-            self.fm.notify("Could not restore window-name!", bad=True)
+        if self._multiplexer_title:
+            try:
+                if _in_tmux():
+                    if self._tmux_automatic_rename:
+                        check_output(['tmux', 'set-window-option',
+                                      'automatic-rename',
+                                      self._tmux_automatic_rename])
+                    else:
+                        check_output(['tmux', 'set-window-option', '-u',
+                                      'automatic-rename'])
+            except CalledProcessError:
+                self.fm.notify("Could not restore multiplexer window name!",
+                               bad=True)
+
+            sys.stdout.write("\033k{}\033\\".format(self._multiplexer_title))
+            sys.stdout.flush()
 
     def hint(self, text=None):
         self.status.hint = text

--- a/ranger/gui/ui.py
+++ b/ranger/gui/ui.py
@@ -85,7 +85,6 @@ class UI(  # pylint: disable=too-many-instance-attributes,too-many-public-method
         self._draw_title = None
         self._tmux_automatic_rename = None
         self._multiplexer_title = None
-        self._multiplexer_title = None
         self.browser = None
 
         if fm is not None:
@@ -513,9 +512,8 @@ class UI(  # pylint: disable=too-many-instance-attributes,too-many-public-method
                                " name, won't be able to restore.",
                                bad=False)
             if not self._multiplexer_title:
-                self._multiplexer_title = os.environ.get(
-                    "SHELL",
-                    "shell").split("/")[-1]
+                self._multiplexer_title = os.path.basename(
+                    os.environ.get("SHELL", "shell"))
 
             sys.stdout.write("\033kranger\033\\")
             sys.stdout.flush()


### PR DESCRIPTION
Fixes 'FileNotFound' if `screen` is not available on the system.

#### ISSUE TYPE
- Bug fix

#### RUNTIME ENVIRONMENT
<!-- Details of your runtime environment -->
<!-- Retrieve Python/ranger version and locale with `ranger -\-version` -->
- Operating system and version: Arch
- Terminal emulator and version: Fish 3.0.2
- Python version: 3.8.1
- Ranger version/commit: ranger 1.9.3
- Locale: en_US.UTF-8

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [x] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [x] All changes follow the code style **[REQUIRED]**
- [x] All new and existing tests pass **[REQUIRED]**
- [ ] Changes require config files to be updated
    - [ ] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
Change `screen` to be invoked via a shell so it doesn't raise unexpected error type. 

#### MOTIVATION AND CONTEXT
https://github.com/ranger/ranger/issues/1805
