### PR TITLE
Issue 1478

### DIFF
--- a/ranger/config/commands.py
+++ b/ranger/config/commands.py
@@ -1506,7 +1506,6 @@ class scout(Command):
         # clean up:
         self.cancel()
 
-
         if self.OPEN_ON_ENTER in flags or \
                 (self.AUTO_OPEN in flags and count == 1):
             if pattern == '..':

--- a/ranger/config/commands.py
+++ b/ranger/config/commands.py
@@ -1513,8 +1513,8 @@ class scout(Command):
             else:
                 if count != 0:
                     self.fm.move(right=1)
-                if self.quickly_executed:
-                    self.fm.block_input(0.5)
+                    if self.quickly_executed:
+                        self.fm.block_input(0.5)
 
         if self.KEEP_OPEN in flags and thisdir != self.fm.thisdir:
             # reopen the console:

--- a/ranger/config/commands.py
+++ b/ranger/config/commands.py
@@ -1506,12 +1506,14 @@ class scout(Command):
         # clean up:
         self.cancel()
 
+
         if self.OPEN_ON_ENTER in flags or \
                 (self.AUTO_OPEN in flags and count == 1):
             if pattern == '..':
                 self.fm.cd(pattern)
             else:
-                self.fm.move(right=1)
+                if count != 0:
+                    self.fm.move(right=1)
                 if self.quickly_executed:
                     self.fm.block_input(0.5)
 


### PR DESCRIPTION
<!-- Provide a descriptive summary of the changes in the title above -->

#### ISSUE TYPE
<!-- Pick relevant types and delete the rest -->
- Bug fix

#### RUNTIME ENVIRONMENT
<!-- Details of your runtime environment -->
<!-- Retrieve Python/ranger version and locale with `ranger -\-version` -->
- Operating system and version: 
Ubuntu 18.04
- Terminal emulator and version: 
GNOME Terminal 3.28.2
- Python version: 
3.6.7 (default, Oct 22 2018, 11:32:17) [GCC 8.2.0]
- Ranger version/commit: 
ranger-master v1.9.3-15-g12a22927
- Locale: 
en_US.UTF-8

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [X] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [X] All changes follow the code style **[REQUIRED]**
- [X] All new and existing tests pass **[REQUIRED]**
- [ ] Changes require config files to be updated
    - [ ] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
<!-- Describe the changes in detail -->
I've implemented this small change so ranger not open/enter first file/directory automatically if scout command result is 'empty'.

#### MOTIVATION AND CONTEXT
<!-- Link to relevant issues -->
#1478 