### PR TITLE
Fix crashes when deleting to trash (#1798)

### DIFF
--- a/ranger/config/commands.py
+++ b/ranger/config/commands.py
@@ -728,7 +728,7 @@ class trash(Command):
 
         if self.rest(1):
             file_names = shlex.split(self.rest(1))
-            files = self.paths_to_filesystem_objects(file_names)
+            files = self.fm.get_filesystem_objects(file_names)
             if files is None:
                 return
             many_files = (len(files) > 1 or is_directory_with_files(files[0].path))
@@ -754,43 +754,6 @@ class trash(Command):
         else:
             # no need for a confirmation, just delete
             self._trash_files_catch_arg_list_error(files)
-
-    @staticmethod
-    def group_paths_by_dirname(paths):
-        """
-        Groups the paths into a dictionary with their dirnames as keys and a set of
-        basenames as entries.
-        """
-        groups = dict()
-        for path in paths:
-            abspath = os.path.abspath(os.path.expanduser(path))
-            dirname, basename = os.path.split(abspath)
-            groups.setdefault(dirname, set()).add(basename)
-        return groups
-
-    def paths_to_filesystem_objects(self, paths):
-        """
-        Find FileSystemObjects corresponding to the paths if they are already in
-        memory and load those that are not.
-        """
-        result = []
-        # Grouping the files by dirname avoids the potentially quadratic running time of doing
-        # a linear search in the directory for each entry name that is supposed to be deleted.
-        groups = trash.group_paths_by_dirname(paths)
-        for dirname, basenames in groups.items():
-            directory = self.fm.get_directory(dirname)
-            directory.load_content_if_outdated()
-            for entry in directory.files_all:
-                if entry.basename in basenames:
-                    result.append(entry)
-                    basenames.remove(entry.basename)
-            if basenames != set():
-                # Abort the operation with an error message if there are entries
-                # that weren't found.
-                names = ', '.join(basenames)
-                self.fm.notify('Error: No such file or directory: {}'.format(names), bad=True)
-                return None
-        return result
 
     def tab(self, tabnum):
         return self._tab_directory_content()

--- a/ranger/config/commands.py
+++ b/ranger/config/commands.py
@@ -722,13 +722,15 @@ class trash(Command):
     def execute(self):
         import shlex
         from functools import partial
+        from ranger.container.file import File
 
         def is_directory_with_files(path):
             return os.path.isdir(path) and not os.path.islink(path) and len(os.listdir(path)) > 0
 
         if self.rest(1):
-            files = shlex.split(self.rest(1))
-            many_files = (len(files) > 1 or is_directory_with_files(files[0]))
+            file_names = shlex.split(self.rest(1))
+            files = [File(name) for name in file_names]
+            many_files = (len(files) > 1 or is_directory_with_files(files[0].path))
         else:
             cwd = self.fm.thisdir
             tfile = self.fm.thisfile
@@ -736,14 +738,15 @@ class trash(Command):
                 self.fm.notify("Error: no file selected for deletion!", bad=True)
                 return
 
+            files = self.fm.thistab.get_selection()
             # relative_path used for a user-friendly output in the confirmation.
-            files = [f.relative_path for f in self.fm.thistab.get_selection()]
+            file_names = [f.relative_path for f in files]
             many_files = (cwd.marked_items or is_directory_with_files(tfile.path))
 
         confirm = self.fm.settings.confirm_on_delete
         if confirm != 'never' and (confirm != 'multiple' or many_files):
             self.fm.ui.console.ask(
-                "Confirm deletion of: %s (y/N)" % ', '.join(files),
+                "Confirm deletion of: %s (y/N)" % ', '.join(file_names),
                 partial(self._question_callback, files),
                 ('n', 'N', 'y', 'Y'),
             )

--- a/ranger/config/commands.py
+++ b/ranger/config/commands.py
@@ -753,7 +753,7 @@ class trash(Command):
             )
         else:
             # no need for a confirmation, just delete
-            self.fm.execute_file(files, label='trash')
+            self._trash_files_catch_arg_list_error(files)
 
     @staticmethod
     def group_paths_by_dirname(paths):
@@ -797,7 +797,21 @@ class trash(Command):
 
     def _question_callback(self, files, answer):
         if answer == 'y' or answer == 'Y':
+            self._trash_files_catch_arg_list_error(files)
+
+    def _trash_files_catch_arg_list_error(self, files):
+        """
+        Executes the fm.execute_file method but catches the OSError ("Argument list too long")
+        that occurs when moving too many files to trash (and would otherwise crash ranger).
+        """
+        try:
             self.fm.execute_file(files, label='trash')
+        except OSError as err:
+            if err.errno == 7:
+                self.fm.notify("Error: Command too long (try passing less files at once)",
+                               bad=True)
+            else:
+                raise
 
 
 class jump_non(Command):

--- a/ranger/core/fm.py
+++ b/ranger/core/fm.py
@@ -362,7 +362,8 @@ class FM(Actions,  # pylint: disable=too-many-instance-attributes
                 # Abort the operation with an error message if there are entries
                 # that weren't found.
                 names = ', '.join(basenames)
-                self.fm.notify('Error: No such file or directory: {}'.format(names), bad=True)
+                self.fm.notify('Error: No such file or directory: {0}'.format(
+                    names), bad=True)
                 return None
         return result
 


### PR DESCRIPTION
#### ISSUE TYPE
<!-- Pick relevant types and delete the rest -->
- Bug fix: This fixes #1798.

#### RUNTIME ENVIRONMENT
<!-- Details of your runtime environment -->
<!-- Retrieve Python/ranger version and locale with `ranger -\-version` -->
- Operating system and version: `Arch Linux, kernel 5.4.23-1-lts, last full pacman update at: 2020-03-05T08:20:22`
- Terminal emulator and version: 
 ```
rxvt-unicode (urxvt) v9.22 - released: 2016-01-23
options: perl,xft,styles,combining,blink,iso14755,unicode3,encodings=eu+vn+jp+jp-ext+kr+zh+zh-ext,fade,transparent,tint,XIM,frills,selectionscrolling,wheel,slipwheel,cursorBlink,pointerBlank,scrollbars=plain+rxvt+NeXT+xterm
```
- Python version: `Python 3.8.1`
- Ranger version/commit: `v1.9.3-18-g081e7315` (output of `git describe HEAD`)
- Locale: `en_US.UTF-8`

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [x] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [x] All changes follow the code style **[REQUIRED]**
  (`make test_py` outputs is the same before and after the change)
- [x] All new and existing tests pass **[REQUIRED]**
  (`make test_py` output is the same before and after the change)
- [ ] Changes require config files to be updated
    - [ ] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
<!-- Describe the changes in detail -->
The `execute()` method of the trash command (in `ranger/config/commands.py`)
used to pass a list of file paths (as strings) to `fm.execute_file()`.
The documentation of the `execute_file()` method states that the 'files'
parameter must not be a list of strings:
>     [...]
>     files: a list of file objects (not strings!)
>     [...]
So I changed `files` to be a list of `File` objects and that seems to fix the issue.

*Note: I'm not sure if I need to pass any additional parameters to the `File` constructor.
Passing just the path seemed to work fine in my tests.*
(I'm talking about [this](https://github.com/5hir0kur0/ranger/commit/f65e6f08bcf63b7d915d2a2e98d1f6f891cd30de#diff-ac22d5c05a75c2e025c82cdfcbf695b1R732) line: `files = [File(name) for name in file_names]`).

#### MOTIVATION AND CONTEXT
<!-- Why are these changes required? -->
<!-- What problems do these changes solve? -->
<!-- Link to relevant issues -->
Relevant issue: #1798


#### TESTING
<!-- What tests have been run? -->
<!-- How does the changes affect other areas of the codebase? -->

I ran `make test_py` as I only changed a python file.
