### PR TITLE
Refactor human_readable() from template strings to format function

### DIFF
--- a/ranger/ext/human_readable.py
+++ b/ranger/ext/human_readable.py
@@ -8,7 +8,7 @@ from datetime import datetime
 from ranger.core.shared import SettingsAware
 
 
-def human_readable(byte, separator=' '):  # pylint: disable=too-many-return-statements
+def human_readable(byte_count, separator=' '):  # pylint: disable=too-many-return-statements
     """Convert a large number of bytes to an easily readable format.
 
     >>> human_readable(54)
@@ -22,19 +22,19 @@ def human_readable(byte, separator=' '):  # pylint: disable=too-many-return-stat
     units = ['B', 'K', 'M', 'G', 'T', 'P']
 
     # handle automatically_count_files false
-    if byte is None:
+    if byte_count is None:
         return ''
 
     if SettingsAware.settings.size_in_bytes:
-        return format(byte, 'n')  # 'n' = locale-aware separator.
+        return format(byte_count, 'n')  # 'n' = locale-aware separator.
 
-    [formatted_number, unit_index] = _preformat_bytes(byte)
+    [formatted_number, unit_index] = _preformat_number(byte_count)
     if unit_index is None:
         return formatted_number
     return '{0:s}{1:s}{2:s}'.format(formatted_number, separator, units[unit_index])
 
 
-def _preformat_bytes(byte):  # pylint: disable=too-many-return-statements
+def _preformat_number(n):  # pylint: disable=too-many-return-statements
     # I know this can be written much shorter, but this long version
     # performs much better than what I had before.  If you attempt to
     # shorten this code, take performance into consideration.
@@ -50,30 +50,30 @@ def _preformat_bytes(byte):  # pylint: disable=too-many-return-statements
     # was not perceptible. I think we did our best to take
     # performance into consideration.
 
-    if byte <= 0:
+    if n <= 0:
         return ('0', None)
-    if byte < 2**10:
-        return ('{0:d}'.format(byte), 0)
-    if byte < 2**10 * 999:
-        return ('{0:.3g}'.format(byte / 2**10), 1)
-    if byte < 2**20:
-        return ('{0:.4g}'.format(byte / 2**10), 1)
-    if byte < 2**20 * 999:
-        return ('{0:.3g}'.format(byte / 2**20), 2)
-    if byte < 2**30:
-        return ('{0:.4g}'.format(byte / 2**20), 2)
-    if byte < 2**30 * 999:
-        return ('{0:.3g}'.format(byte / 2**30), 3)
-    if byte < 2**40:
-        return ('{0:.4g}'.format(byte / 2**30), 3)
-    if byte < 2**40 * 999:
-        return ('{0:.3g}'.format(byte / 2**40), 4)
-    if byte < 2**50:
-        return ('{0:.4g}'.format(byte / 2**40), 4)
-    if byte < 2**50 * 999:
-        return ('{0:.3g}'.format(byte / 2**50), 5)
-    if byte < 2**60:
-        return ('{0:.4g}'.format(byte / 2**50), 5)
+    if n < 2**10:
+        return ('{0:d}'.format(n), 0)
+    if n < 2**10 * 999:
+        return ('{0:.3g}'.format(n / 2**10), 1)
+    if n < 2**20:
+        return ('{0:.4g}'.format(n / 2**10), 1)
+    if n < 2**20 * 999:
+        return ('{0:.3g}'.format(n / 2**20), 2)
+    if n < 2**30:
+        return ('{0:.4g}'.format(n / 2**20), 2)
+    if n < 2**30 * 999:
+        return ('{0:.3g}'.format(n / 2**30), 3)
+    if n < 2**40:
+        return ('{0:.4g}'.format(n / 2**30), 3)
+    if n < 2**40 * 999:
+        return ('{0:.3g}'.format(n / 2**40), 4)
+    if n < 2**50:
+        return ('{0:.4g}'.format(n / 2**40), 4)
+    if n < 2**50 * 999:
+        return ('{0:.3g}'.format(n / 2**50), 5)
+    if n < 2**60:
+        return ('{0:.4g}'.format(n / 2**50), 5)
     return ('>9000', None)
 
 

--- a/ranger/ext/human_readable.py
+++ b/ranger/ext/human_readable.py
@@ -29,30 +29,42 @@ def human_readable(byte, separator=' '):  # pylint: disable=too-many-return-stat
     # I know this can be written much shorter, but this long version
     # performs much better than what I had before.  If you attempt to
     # shorten this code, take performance into consideration.
+    #
+    # Revisit of 2020: In order to implement file copy speed with
+    # correct units, this had to be refactored. While we are at it,
+    # let's use format functions. It now has about 2 times worse
+    # performance than the original solution using %-formatting. The
+    # justification here is this function doesn't account for much
+    # execution time in the overall rendering time of Ranger. The
+    # function was benchmarked and profiled. Ranger as a whole was
+    # tested on a weak hardware and a user experience degradation
+    # was not perceptible. I think we did our best to take
+    # performance into consideration.
+
     if byte <= 0:
         return '0'
     if byte < 2**10:
-        return '%d%sB' % (byte, separator)
+        return '{0:d}{1:s}B'.format(byte, separator)
     if byte < 2**10 * 999:
-        return '%.3g%sK' % ((byte / 2**10), separator)
+        return '{0:.3g}{1:s}K'.format((byte / 2**10), separator)
     if byte < 2**20:
-        return '%.4g%sK' % ((byte / 2**10), separator)
+        return '{0:.4g}{1:s}K'.format((byte / 2**10), separator)
     if byte < 2**20 * 999:
-        return '%.3g%sM' % ((byte / 2**20), separator)
+        return '{0:.3g}{1:s}M'.format((byte / 2**20), separator)
     if byte < 2**30:
-        return '%.4g%sM' % ((byte / 2**20), separator)
+        return '{0:.4g}{1:s}M'.format((byte / 2**20), separator)
     if byte < 2**30 * 999:
-        return '%.3g%sG' % ((byte / 2**30), separator)
+        return '{0:.3g}{1:s}G'.format((byte / 2**30), separator)
     if byte < 2**40:
-        return '%.4g%sG' % ((byte / 2**30), separator)
+        return '{0:.4g}{1:s}G'.format((byte / 2**30), separator)
     if byte < 2**40 * 999:
-        return '%.3g%sT' % ((byte / 2**40), separator)
+        return '{0:.3g}{1:s}T'.format((byte / 2**40), separator)
     if byte < 2**50:
-        return '%.4g%sT' % ((byte / 2**40), separator)
+        return '{0:.4g}{1:s}T'.format((byte / 2**40), separator)
     if byte < 2**50 * 999:
-        return '%.3g%sP' % ((byte / 2**50), separator)
+        return '{0:.3g}{1:s}P'.format((byte / 2**50), separator)
     if byte < 2**60:
-        return '%.4g%sP' % ((byte / 2**50), separator)
+        return '{0:.4g}{1:s}P'.format((byte / 2**50), separator)
     return '>9000'
 
 

--- a/ranger/ext/human_readable.py
+++ b/ranger/ext/human_readable.py
@@ -19,6 +19,8 @@ def human_readable(byte, separator=' '):  # pylint: disable=too-many-return-stat
     '1023 M'
     """
 
+    units = ['B', 'K', 'M', 'G', 'T', 'P']
+
     # handle automatically_count_files false
     if byte is None:
         return ''
@@ -26,13 +28,20 @@ def human_readable(byte, separator=' '):  # pylint: disable=too-many-return-stat
     if SettingsAware.settings.size_in_bytes:
         return format(byte, 'n')  # 'n' = locale-aware separator.
 
+    [formatted_number, unit_index] = _preformat_bytes(byte)
+    if unit_index is None:
+        return formatted_number
+    return '{0:s}{1:s}{2:s}'.format(formatted_number, separator, units[unit_index])
+
+
+def _preformat_bytes(byte):  # pylint: disable=too-many-return-statements
     # I know this can be written much shorter, but this long version
     # performs much better than what I had before.  If you attempt to
     # shorten this code, take performance into consideration.
     #
     # Revisit of 2020: In order to implement file copy speed with
     # correct units, this had to be refactored. While we are at it,
-    # let's use format functions. It now has about 2 times worse
+    # let's use format functions. It now has about 3 times worse
     # performance than the original solution using %-formatting. The
     # justification here is this function doesn't account for much
     # execution time in the overall rendering time of Ranger. The
@@ -42,30 +51,30 @@ def human_readable(byte, separator=' '):  # pylint: disable=too-many-return-stat
     # performance into consideration.
 
     if byte <= 0:
-        return '0'
+        return ('0', None)
     if byte < 2**10:
-        return '{0:d}{1:s}B'.format(byte, separator)
+        return ('{0:d}'.format(byte), 0)
     if byte < 2**10 * 999:
-        return '{0:.3g}{1:s}K'.format((byte / 2**10), separator)
+        return ('{0:.3g}'.format(byte / 2**10), 1)
     if byte < 2**20:
-        return '{0:.4g}{1:s}K'.format((byte / 2**10), separator)
+        return ('{0:.4g}'.format(byte / 2**10), 1)
     if byte < 2**20 * 999:
-        return '{0:.3g}{1:s}M'.format((byte / 2**20), separator)
+        return ('{0:.3g}'.format(byte / 2**20), 2)
     if byte < 2**30:
-        return '{0:.4g}{1:s}M'.format((byte / 2**20), separator)
+        return ('{0:.4g}'.format(byte / 2**20), 2)
     if byte < 2**30 * 999:
-        return '{0:.3g}{1:s}G'.format((byte / 2**30), separator)
+        return ('{0:.3g}'.format(byte / 2**30), 3)
     if byte < 2**40:
-        return '{0:.4g}{1:s}G'.format((byte / 2**30), separator)
+        return ('{0:.4g}'.format(byte / 2**30), 3)
     if byte < 2**40 * 999:
-        return '{0:.3g}{1:s}T'.format((byte / 2**40), separator)
+        return ('{0:.3g}'.format(byte / 2**40), 4)
     if byte < 2**50:
-        return '{0:.4g}{1:s}T'.format((byte / 2**40), separator)
+        return ('{0:.4g}'.format(byte / 2**40), 4)
     if byte < 2**50 * 999:
-        return '{0:.3g}{1:s}P'.format((byte / 2**50), separator)
+        return ('{0:.3g}'.format(byte / 2**50), 5)
     if byte < 2**60:
-        return '{0:.4g}{1:s}P'.format((byte / 2**50), separator)
-    return '>9000'
+        return ('{0:.4g}'.format(byte / 2**50), 5)
+    return ('>9000', None)
 
 
 def human_readable_time(timestamp):


### PR DESCRIPTION
While adding a copy speed and other stats to the TaskView in #1840, the code of the `human_readable()` was about to be refactored when I saw the old string formatting syntax. This syntax should be avoided in favor of the `.format()`. This does the refactoring.

#### ISSUE TYPE
- Improvement/feature implementation

#### RUNTIME ENVIRONMENT
- Operating system and version: Arch Linux, kernel 5.4.15-arch1-1
- Terminal emulator and version: termite v15
- Python version: 3.8.1
- Ranger version/commit: v1.9.3
- Locale: en_US.UTF-8

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [x] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [x] All changes follow the code style **[REQUIRED]**
- [x] All new and existing tests pass **[REQUIRED]**
- [ ] Changes require config files to be updated
    - [ ] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
Refactoring this should be done carefully because there apparently were some performance issues with this function. See 7bc8b3f. Also see [this](https://github.com/ranger/ranger/blob/master/ranger/ext/human_readable.py#L29) comment.

The conclusion is the performance of the `human_readable()` is not critical and not noticeable on a RaspberryPi 1 even if it had 20 times worse performance. See the research in https://github.com/ranger/ranger/pull/1891#issuecomment-622968812.

#### TESTING
<!-- What tests have been run? -->
<!-- How does the changes affect other areas of the codebase? -->
 I created simple tests myself (the first commit of the chain) and these are the results (the units are seconds):

Performance was tested using 8b64be4877446af630665884a906a0dd24a655de.
| method | asb diff | rel diff | avg | avg (pypy2) | run1 | run2 | run3 | run4 | run5 | run6 | run7 | run8 | run9 | run10 |
| - | - | - | - | - | - | - | - | - | - | - | - | - | - | - |
| original | 0 | 0% | 6.60 | 2.40 | 6.30 | 6.41 | 8.32 | 6.45 | 6.38 | 6.44 | 6.43 | 6.43 | 6.43 | 6.45 | 
| `format()` python 2.6 incompatible | +1.42 | +21% | 8.02 |   | 7.96 | 7.99 | 7.92 | 7.94 | 8.01 | 7.99 | 7.98 | 8.06 | 8.29 | 8.06 | 
| `format()` | +1.72 | +26% | 8.32 |  3.35 | 8.27 | 8.24 | 8.36 | 8.25 | 8.24 | 8.32 | 8.27 | 8.53 | 8.30 | 8.45 | 
| `format()` without separator | +0.62 | +9% | 7.22 |   | 7.23 | 7.17 | 7.36 | 7.15 | 7.22 | 7.18 | 7.21 | 7.22 | 7.22 | 7.32 | 
| custom float format (see snippet) |  |  |  | 2.91  |  |  |  |  |  |  |  |  |  |  | 
| external [1] python2 incompatible? | +3.25 | +49% | 9.85 |   | 9.86 | 9.85 | 9.87 | 9.80 | 9.90 |  |  |  |  |  | 
| external [2] | a lot more | a lot more | 21.24 | 9.86  | 21.28 | 21.21 | 21.23 |  |  |  |  |  |  |  | 
| external [3] | +2.60 | +39% | 9.20 | 3.24  | 9.00 | 8.94 | 8.98 | 9.20 | 9.20 | 9.06 | 10.28 | 9.20 | 9.12 | 9.15 | 
| `humanize` library (python 2.x incompatible) | a lot more | a lot more | about 25 |   | 28.08 | 25.21 | 25.74 |  |  |  |  |  |  |  | 
| external [4] skips decimals | +1.54 | +23% | 8.14(WTH? how is this possible?) | 0.89  | 8.45 | 8.33 | 8.68 | 8.27 | 8.35 |  |  |  |  |  | 
| `hurry.filesize` library | +2.63 | +39% | 9.23 |   | 9.19 | 9.44 | 9.07 |  |  |  |  |  |  |  | 
| external [5] | +1.68 | +25% | 8.28 | 3.15 | 8.21 | 8.22 | 8.41 | 8.33 | 8.25 |  |  |  |  |  | 



Ranger itself was not tested yet and the functionality test I created is failing with current implementation. Let's not worry about that now, I will eventually fix the issues. The performance impact is what should be solved first.

#### Custom float formatting and string array concat using `join` ####
```
if byte < 2**20:
  # return '{0:.3f}{1:s}K'.format((byte / 2**10), separator)
  return ''.join([str(int(((byte / 2**10) * 100) + 0.5) / 100.0), separator, "K"])
```

#### Useful resources for optimizing speed ####
- https://wiki.python.org/moin/PythonSpeed/PerformanceTips#String_Concatenation
- https://github.com/rkern/line_profiler
- Somebody having a similar string formatting performance problems, algouth ab bit old thread. https://stackoverflow.com/a/2638807/5951116
- [1] Mathematical take on formatting the file size. https://stackoverflow.com/a/25613067/5951116
- [2] Another Mathematical take on formatting the file size. https://stackoverflow.com/a/10171475/5951116
- [3] Yet another mathematical approach. https://stackoverflow.com/a/1094933/5951116
- [4] Using recursion. https://stackoverflow.com/a/43750422/5951116
- [5] Simple and perspective yet relatively fast. https://stackoverflow.com/a/27094657/5951116