### PR TITLE
Move draw() warning processing from img_display.py to pager.py

### DIFF
--- a/ranger/ext/img_display.py
+++ b/ranger/ext/img_display.py
@@ -19,7 +19,6 @@ import imghdr
 import os
 import struct
 import sys
-import warnings
 import json
 import threading
 from subprocess import Popen, PIPE
@@ -611,6 +610,7 @@ class KittyImageDisplayer(ImageDisplayer, FileManagerAware):
         self.needs_late_init = False
 
     def draw(self, path, start_x, start_y, width, height):
+        
         self.image_id += 1
         # dictionary to store the command arguments for kitty
         # a is the display command, with T going for immediate output
@@ -622,13 +622,7 @@ class KittyImageDisplayer(ImageDisplayer, FileManagerAware):
         if self.needs_late_init:
             self._late_init()
 
-        with warnings.catch_warnings(record=True):  # as warn:
-            warnings.simplefilter('ignore', self.backend.DecompressionBombWarning)
-            image = self.backend.open(path)
-            # TODO: find a way to send a message to the user that
-            # doesn't stop the image from displaying
-            # if warn:
-            #     raise ImageDisplayError(str(warn[-1].message))
+        image = self.backend.open(path)
         box = (width * self.pix_row, height * self.pix_col)
 
         if image.width > box[0] or image.height > box[1]:

--- a/ranger/ext/img_display.py
+++ b/ranger/ext/img_display.py
@@ -610,7 +610,6 @@ class KittyImageDisplayer(ImageDisplayer, FileManagerAware):
         self.needs_late_init = False
 
     def draw(self, path, start_x, start_y, width, height):
-        
         self.image_id += 1
         # dictionary to store the command arguments for kitty
         # a is the display command, with T going for immediate output

--- a/ranger/gui/widgets/pager.py
+++ b/ranger/gui/widgets/pager.py
@@ -7,6 +7,7 @@ from __future__ import (absolute_import, division, print_function)
 
 import curses
 import logging
+import warnings
 
 from ranger.gui import ansi
 from ranger.ext.direction import Direction
@@ -115,8 +116,14 @@ class Pager(Widget):  # pylint: disable=too-many-instance-attributes
             self.source = None
             self.need_redraw_image = False
             try:
-                self.fm.image_displayer.draw(self.image, self.x, self.y,
-                                             self.wid, self.hei)
+                with warnings.catch_warnings(record=True) as image_displayer_warnings:
+                    self.fm.image_displayer.draw(self.image, self.x, self.y,
+                                                 self.wid, self.hei)
+                if image_displayer_warnings:
+                    for warning in image_displayer_warnings:
+                        LOG.warning(warning.message)
+                    self.fm.notify('See image displaying warnings in ranger\'s log')
+
             except ImgDisplayUnsupportedException as ex:
                 self.fm.settings.preview_images = False
                 self.fm.notify(ex, bad=True)


### PR DESCRIPTION
#### ISSUE TYPE
- Bug fix

#### RUNTIME ENVIRONMENT
- Operating system and version: 
Ubuntu 18.04.2
- Terminal emulator and version: 
GNOME Terminal 3.28.2
- Python version: 
3.8.2 (default, Mar 15 2020, 13:26:29) [GCC 7.4.0]
2.7.17 (default, Nov 7 2019, 10:07:09) [GCC 7.4.0]
- Ranger version/commit: v1.9.3-20-g498c2453
- Locale: en_US.UTF-8

#### CHECKLIST
- [X] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [X] All changes follow the code style **[REQUIRED]**
- [X] All new and existing tests pass **[REQUIRED]**
- [ ] Changes require config files to be updated
    - [ ] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
In current img_display.py implementation draw() function warnings are not processed properly, which may lead to problems like #1884. In this PR i'm proposing movement of warning processing to pager.py, to place it near exceptions processing. When warnings occurs status bar info message is displayed and all warnings are written to ranger's log. So image displaying is not interrupted or cluttered and if you are really interested in detailes - you can look at log.

#### MOTIVATION AND CONTEXT
#1884