### PR TITLE
Implement a line_number context for colorschemes

### DIFF
--- a/ranger/colorschemes/default.py
+++ b/ranger/colorschemes/default.py
@@ -64,6 +64,9 @@ class Default(ColorScheme):
                 else:
                     fg = red
                 fg += BRIGHT
+            if context.line_number and not context.selected:
+                fg = default
+                attr &= ~bold
             if not context.selected and (context.cut or context.copied):
                 attr |= bold
                 fg = black

--- a/ranger/colorschemes/jungle.py
+++ b/ranger/colorschemes/jungle.py
@@ -4,7 +4,7 @@
 from __future__ import (absolute_import, division, print_function)
 
 from ranger.colorschemes.default import Default
-from ranger.gui.color import green, red, blue
+from ranger.gui.color import green, red, blue, bold
 
 
 class Scheme(Default):
@@ -16,6 +16,10 @@ class Scheme(Default):
         if context.directory and not context.marked and not context.link \
                 and not context.inactive_pane:
             fg = self.progress_bar_color
+
+        if context.line_number and not context.selected:
+            fg = self.progress_bar_color
+            attr &= ~bold
 
         if context.in_titlebar and context.hostname:
             fg = red if context.bad else blue

--- a/ranger/colorschemes/snow.py
+++ b/ranger/colorschemes/snow.py
@@ -21,6 +21,9 @@ class Snow(ColorScheme):
             if context.directory:
                 attr |= bold
                 fg += BRIGHT
+            if context.line_number and not context.selected:
+                attr |= bold
+                fg += BRIGHT
 
         elif context.highlight:
             attr |= reverse

--- a/ranger/gui/context.py
+++ b/ranger/gui/context.py
@@ -16,7 +16,8 @@ CONTEXT_KEYS = [
     'good', 'bad',
     'space', 'permissions', 'owner', 'group', 'mtime', 'nlink',
     'scroll', 'all', 'bot', 'top', 'percentage', 'filter',
-    'flat', 'marked', 'tagged', 'tag_marker', 'cut', 'copied', 'frozen',
+    'flat', 'marked', 'tagged', 'tag_marker', 'line_number',
+    'cut', 'copied', 'frozen',
     'help_markup',  # COMPAT
     'seperator', 'key', 'special', 'border',  # COMPAT
     'title', 'text', 'highlight', 'bars', 'quotes', 'tab', 'loaded',

--- a/ranger/gui/widgets/browsercolumn.py
+++ b/ranger/gui/widgets/browsercolumn.py
@@ -280,8 +280,6 @@ class BrowserColumn(Pager):  # pylint: disable=too-many-instance-attributes
         # visible files in directory.
         linum_text_len = len(str(self.scroll_begin + self.hei))
         linum_format = "{0:>" + str(linum_text_len) + "}"
-        # add separator between line number and tag
-        linum_format += " "
 
         selected_i = self._get_index_of_selected_file()
         for line in range(self.hei):
@@ -347,12 +345,14 @@ class BrowserColumn(Pager):  # pylint: disable=too-many-instance-attributes
                     line_number_text = self._format_line_number(linum_format,
                                                                 i,
                                                                 selected_i)
-                    predisplay_left.append([line_number_text, []])
+                    predisplay_left.append([line_number_text, ['line_number']])
                     space -= linum_text_len
 
                     # Delete one additional character for space separator
                     # between the line number and the tag
                     space -= 1
+                    # add separator between line number and tag
+                    predisplay_left.append([' ', []])
 
             # selection mark
             tagmark = self._draw_tagged_display(tagged, tagged_marker)


### PR DESCRIPTION
Changes the default color for line numbers to differ from the file's
color to the terminal's base foreground color in the default theme.
Green in the jungle theme and bold and/or bright in the snow theme.

Fixes #1906

This means people can customize the color for line numbers in their colorschemes now.
I wasn't sure whether and how the solarized colorscheme should be updated.