### PR TITLE
support italic for ansi

### DIFF
--- a/ranger/gui/ansi.py
+++ b/ranger/gui/ansi.py
@@ -63,6 +63,8 @@ def text_with_fg_bg_attr(ansi_text):  # pylint: disable=too-many-branches,too-ma
 
                 elif n == 1:         # enable attribute
                     attr |= color.bold
+                elif n == 3:
+                    attr |= color.italic
                 elif n == 4:
                     attr |= color.underline
                 elif n == 5:

--- a/ranger/gui/color.py
+++ b/ranger/gui/color.py
@@ -15,6 +15,7 @@ bool(attr & reverse) # => False
 
 from __future__ import (absolute_import, division, print_function)
 
+import sys
 import curses
 
 DEFAULT_FOREGROUND = curses.COLOR_WHITE
@@ -71,6 +72,7 @@ default = -1
 
 normal = curses.A_NORMAL
 bold = curses.A_BOLD
+italic = curses.A_ITALIC if sys.version_info >= (3, 7) else normal
 blink = curses.A_BLINK
 reverse = curses.A_REVERSE
 underline = curses.A_UNDERLINE

--- a/ranger/gui/color.py
+++ b/ranger/gui/color.py
@@ -15,7 +15,6 @@ bool(attr & reverse) # => False
 
 from __future__ import (absolute_import, division, print_function)
 
-import sys
 import curses
 
 DEFAULT_FOREGROUND = curses.COLOR_WHITE
@@ -72,12 +71,15 @@ default = -1
 
 normal = curses.A_NORMAL
 bold = curses.A_BOLD
-italic = curses.A_ITALIC if sys.version_info >= (3, 7) else normal
 blink = curses.A_BLINK
 reverse = curses.A_REVERSE
 underline = curses.A_UNDERLINE
 invisible = curses.A_INVIS
 dim = curses.A_DIM
+try:
+    italic = curses.A_ITALIC
+except AttributeError:
+    italic = curses.A_NORMAL
 
 default_colors = (default, default, normal)
 # pylint: enable=invalid-name


### PR DESCRIPTION
<!-- Provide a descriptive summary of the changes in the title above -->

#### ISSUE TYPE
<!-- Pick relevant types and delete the rest -->
- Improvement/feature implementation

#### RUNTIME ENVIRONMENT
<!-- Details of your runtime environment -->
<!-- Retrieve Python/ranger version and locale with `ranger -\-version` -->
- Operating system and version: 
- Terminal emulator and version: 
- Python version: 
- Ranger version/commit: 
- Locale: 

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [x] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [x] All changes follow the code style **[REQUIRED]**
- [x] All new and existing tests pass **[REQUIRED]**
- [ ] Changes require config files to be updated
    - [ ] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
<!-- Describe the changes in detail -->
According to the [curses lib](https://docs.python.org/3/library/curses.html#window-objects), italic was supported since 3.7 version.

#### MOTIVATION AND CONTEXT
<!-- Why are these changes required? -->
<!-- What problems do these changes solve? -->
<!-- Link to relevant issues -->
Preview italic text.

#### TESTING
<!-- What tests have been run? -->
<!-- How does the changes affect other areas of the codebase? -->
Run under python version of 3.6.10 and 3.8.2.

#### IMAGES / VIDEOS<!-- Only if relevant -->
<!-- Link or embed images and videos of screenshots, sketches etc. -->
3.8.2 vs 3.6.10
![2020-04-13_14-01](https://user-images.githubusercontent.com/17562139/79096767-982bee80-7d90-11ea-9bf2-5dcf729dcf16.png)
