### PR TITLE
Introduce Zstandard support

### DIFF
--- a/ranger/config/rifle.conf
+++ b/ranger/config/rifle.conf
@@ -208,8 +208,8 @@ ext 7z|ace|ar|arc|bz2?|cab|cpio|cpt|deb|dgc|dmg|gz,  has atool = atool --extract
 ext iso|jar|msi|pkg|rar|shar|tar|tgz|xar|xpi|xz|zip, has atool = atool --extract --each -- "$@"
 
 # Listing and extracting archives without atool:
-ext tar|gz|bz2|xz, has tar = tar vvtf "$1" | "$PAGER"
-ext tar|gz|bz2|xz, has tar = for file in "$@"; do tar vvxf "$file"; done
+ext tar|gz|bz2|xz|zst, has tar = tar vvtf "$1" | "$PAGER"
+ext tar|gz|bz2|xz|zst, has tar = for file in "$@"; do tar vvxf "$file"; done
 ext bz2, has bzip2 = for file in "$@"; do bzip2 -dk "$file"; done
 ext zip, has unzip = unzip -l "$1" | less
 ext zip, has unzip = for file in "$@"; do unzip -d "${file%.*}" "$file"; done

--- a/ranger/container/fsobject.py
+++ b/ranger/container/fsobject.py
@@ -31,7 +31,7 @@ except AttributeError:
 CONTAINER_EXTENSIONS = ('7z', 'ace', 'ar', 'arc', 'bz', 'bz2', 'cab', 'cpio',
                         'cpt', 'deb', 'dgc', 'dmg', 'gz', 'iso', 'jar', 'msi',
                         'pkg', 'rar', 'shar', 'tar', 'tbz', 'tgz', 'txz',
-                        'xar', 'xpi', 'xz', 'zip')
+                        'tzst', 'xar', 'xpi', 'xz', 'zip', 'zst')
 DOCUMENT_EXTENSIONS = ('cbr', 'cbz', 'cfg', 'css', 'cvs', 'djvu', 'doc',
                        'docx', 'gnm', 'gnumeric', 'htm', 'html', 'md', 'odf',
                        'odg', 'odp', 'ods', 'odt', 'pdf', 'pod', 'ps', 'rtf',

--- a/ranger/data/scope.sh
+++ b/ranger/data/scope.sh
@@ -51,7 +51,7 @@ handle_extension() {
     case "${FILE_EXTENSION_LOWER}" in
         ## Archive
         a|ace|alz|arc|arj|bz|bz2|cab|cpio|deb|gz|jar|lha|lz|lzh|lzma|lzo|\
-        rpm|rz|t7z|tar|tbz|tbz2|tgz|tlz|txz|tZ|tzo|war|xpi|xz|Z|zip)
+        rpm|rz|t7z|tar|tbz|tbz2|tgz|tlz|txz|tZ|tzo|tzst|war|xpi|xz|Z|zip|zst)
             atool --list -- "${FILE_PATH}" && exit 5
             bsdtar --list --file "${FILE_PATH}" && exit 5
             exit 1;;


### PR DESCRIPTION
#### ISSUE TYPE
- Improvement/feature implementation

#### CHECKLIST
- [X] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [X] All changes follow the code style **[REQUIRED]**
- [X] All new and existing tests pass **[REQUIRED]**
- [X] Changes require config files to be updated
    - [X] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
<!-- Describe the changes in detail -->
It became quite widely adopted during the last few years, e.g. by Arch Linux as
_the_ compression format for its official packages. GNU tar has also supported it for
about two years[1] now and I guess it's safe to say zstd is here to stay for another
couple of years at least.

This patch attempts to bring zst(d) files handling to feature parity with other
compression formats such as xz - besides atool, of course, as its last release
happened before Zstandard was born ;]

[1] https://git.savannah.gnu.org/cgit/tar.git/commit/?id=3d45373d3b192d7342d49524193497598818d36d