### PR TITLE
Add tag filter to filter_stack

### DIFF
--- a/doc/ranger.1
+++ b/doc/ranger.1
@@ -1451,6 +1451,9 @@ Filter files so only files with the same hash as \s-1PATH\s0 are shown.
 .IP "mimetype \s-1TYPE\s0" 2
 .IX Item "mimetype TYPE"
 Filter files of a certain \s-1MIME\s0 type, regular expression syntax is allowed.
+.IP "tag [\s-1TAG\s0]" 2
+.IX Item "tag [TAG]"
+Filter tagged files with tag matching \s-1TAG\s0, if given.
 .IP "typefilter [d|f|l]" 2
 .IX Item "typefilter [d|f|l]"
 Filter files of a certain type, \f(CW\*(C`d\*(C'\fR for directories, \f(CW\*(C`f\*(C'\fR for files and \f(CW\*(C`l\*(C'\fR

--- a/doc/ranger.1
+++ b/doc/ranger.1
@@ -1453,7 +1453,7 @@ Filter files so only files with the same hash as \s-1PATH\s0 are shown.
 Filter files of a certain \s-1MIME\s0 type, regular expression syntax is allowed.
 .IP "tag [\s-1TAG\s0]" 2
 .IX Item "tag [TAG]"
-Filter tagged files with tag matching \s-1TAG\s0, if given.
+Filter tagged files with tag matching \s-1TAG\s0. If \s-1TAG\s0 is not specified, include all tags.
 .IP "typefilter [d|f|l]" 2
 .IX Item "typefilter [d|f|l]"
 Filter files of a certain type, \f(CW\*(C`d\*(C'\fR for directories, \f(CW\*(C`f\*(C'\fR for files and \f(CW\*(C`l\*(C'\fR

--- a/doc/ranger.pod
+++ b/doc/ranger.pod
@@ -1571,7 +1571,7 @@ Filter files of a certain MIME type, regular expression syntax is allowed.
 
 =item tag [TAG]
 
-Filter tagged files with tag matching TAG, if given.
+Filter tagged files with tag matching TAG. If TAG is not specified, include all tags.
 
 =item typefilter [d|f|l]
 

--- a/doc/ranger.pod
+++ b/doc/ranger.pod
@@ -1569,6 +1569,10 @@ Filter files so only files with the same hash as PATH are shown.
 
 Filter files of a certain MIME type, regular expression syntax is allowed.
 
+=item tag [TAG]
+
+Filter tagged files with tag matching TAG, if given.
+
 =item typefilter [d|f|l]
 
 Filter files of a certain type, C<d> for directories, C<f> for files and C<l>

--- a/ranger/config/rc.conf
+++ b/ranger/config/rc.conf
@@ -602,6 +602,7 @@ map .l filter_stack add type l
 map .m console filter_stack add mime%space
 map .n console filter_stack add name%space
 map .# console filter_stack add hash%space
+map .t console filter_stack add tag%space
 map ." filter_stack add duplicate
 map .' filter_stack add unique
 map .| filter_stack add or

--- a/ranger/core/filter_stack.py
+++ b/ranger/core/filter_stack.py
@@ -76,7 +76,7 @@ class MimeFilter(BaseFilter):
 
 @stack_filter("tag")
 class TagFilter(BaseFilter, FileManagerAware):
-    def __init__(self, tag):
+    def __init__(self, tag=None):
         self.tag = tag
 
     def __call__(self, fobj):

--- a/ranger/core/filter_stack.py
+++ b/ranger/core/filter_stack.py
@@ -89,7 +89,7 @@ class TagFilter(BaseFilter, FileManagerAware):
         return not self.tag or self.tag == tag
 
     def __str__(self):
-        return "<Filter: tag {}>".format(self.tag)
+        return "<Filter: tag {tag}>".format(tag=self.tag)
 
 
 @stack_filter("hash")

--- a/ranger/core/filter_stack.py
+++ b/ranger/core/filter_stack.py
@@ -74,6 +74,24 @@ class MimeFilter(BaseFilter):
         return "<Filter: mimetype =~ /{pat}/>".format(pat=self.pattern)
 
 
+@stack_filter("tag")
+class TagFilter(BaseFilter, FileManagerAware):
+    def __init__(self, tag):
+        self.tag = tag
+
+    def __call__(self, fobj):
+        if not self.fm.tags:
+            return False
+        try:
+            tag = self.fm.tags.tags[fobj.realpath]
+        except KeyError:
+            return False
+        return not self.tag or self.tag == tag
+
+    def __str__(self):
+        return "<Filter: tag {}>".format(self.tag)
+
+
 @stack_filter("hash")
 class HashFilter(BaseFilter, FileManagerAware):
     def __init__(self, filepath=None):


### PR DESCRIPTION
This adds a tag filter to show only files tagged (with a specific tag, if given)..
Only after finishing implementation it did I stumble over https://github.com/ranger/ranger/pull/1760 though, sorry xD

#### ISSUE TYPE
- Improvement/feature implementation

#### CHECKLIST
- [X] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [X] All changes follow the code style **[REQUIRED]**
- [X] All new and existing tests pass **[REQUIRED]**
- [X] Changes require config files to be updated
    - [X] Config files have been updated
- [X] Changes require documentation to be updated
    - [X] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### TESTING
Did try around tagging fs objects with different tags, combining and inverting tag filters. To reapply the filter after changing tags, a `:reload_cwd` command has to be issued however..