### PR TITLE
Fixing freezing ranger when press Ctrl-s

### DIFF
--- a/ranger/core/main.py
+++ b/ranger/core/main.py
@@ -15,8 +15,9 @@ import tempfile
 
 from ranger import VERSION
 
-
 LOG = getLogger(__name__)
+
+os.system("stty -ixon")
 
 VERSION_MSG = [
     'ranger version: {0}'.format(VERSION),

--- a/ranger/core/main.py
+++ b/ranger/core/main.py
@@ -15,6 +15,7 @@ import tempfile
 
 from ranger import VERSION
 
+
 LOG = getLogger(__name__)
 
 os.system("stty -ixon")


### PR DESCRIPTION
<!-- Provide a descriptive summary of the changes in the title above -->
Disable usage of XON/XOFF on termianl

#### ISSUE TYPE
<!-- Pick relevant types and delete the rest -->
- Bug fix

#### RUNTIME ENVIRONMENT
<!-- Details of your runtime environment -->
<!-- Retrieve Python/ranger version and locale with `ranger -\-version` -->
- Operating system and version: 4.19.0-5-amd64 #1 SMP Debian 4.19.37-5+deb10u2 (2019-08-08) x86_64 GNU/Linux
- Terminal emulator and version: any (practical used and checked: urxvt, lxterminal)
- Python version: Python 2.7.16
- Ranger qversion/commit: any (practical used: 1.9.2-4)
- Locale: ru_UA.UTF-8

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [X] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [X] All changes follow the code style **[REQUIRED]**
- [X] All new and existing tests pass **[REQUIRED]**
- [] Changes require config files to be updated
    - [] Config files have been updated
- [] Changes require documentation to be updated
    - [] Documentation has been updated
- [] Changes require tests to be updated
    - [] Tests have been updated

#### DESCRIPTION
<!-- Describe the changes in detail -->
add one row code, not very deeply

#### MOTIVATION AND CONTEXT
<!-- Why are these changes required? -->
<!-- What problems do these changes solve? -->
<!-- Link to relevant issues -->
normal usage when start ranger by terminal and out comands DE (on hotkey for example)

#### TESTING
<!-- What tests have been run? -->
<!-- How does the changes affect other areas of the codebase? -->
start ranger by it comands and press Ctrl-s and usage next

#### IMAGES / VIDEOS<!-- Only if relevant -->
<!-- Link or embed images and videos of screenshots, sketches etc. -->
no any influence