### PR TITLE
improving! implementing moving command to first and last tabs

### DIFF
--- a/ranger/core/actions.py
+++ b/ranger/core/actions.py
@@ -1295,8 +1295,10 @@ class Actions(  # pylint: disable=too-many-instance-attributes,too-many-public-m
             return self.tab_open(narg)
         assert isinstance(offset, int)
         tablist = self.get_tab_list()
-        current_index = tablist.index(self.current_tab)
-        newtab = tablist[(current_index + offset) % len(tablist)]
+        tab_count = len(tablist)
+        go_index = tablist.index(self.current_tab) + offset if abs(
+            offset) <= tab_count else 0 if offset <= 0 else tab_count - 1
+        newtab = tablist[go_index % tab_count]
         if newtab != self.current_tab:
             self.tab_open(newtab)
         return None


### PR DESCRIPTION
<!-- Provide a descriptive summary of the changes in the title above -->
improving allows to move to first and last tab fastly
tab_move 1000 #last
tab_move -1000 #fist

#### ISSUE TYPE
<!-- Pick relevant types and delete the rest -->
- Improvement/feature implementation

#### RUNTIME ENVIRONMENT
<!-- Details of your runtime environment -->
<!-- Retrieve Python/ranger version and locale with `ranger -\-version` -->
- Operating system and version: 
- Terminal emulator and version: 
- Python version: 
- Ranger version/commit: 
- Locale: 

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [X] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [X] All changes follow the code style **[REQUIRED]**
- [X] All new and existing tests pass **[REQUIRED]**
- [X] Changes require config files to be updated
    - [ ] Config files have been updated
- [X] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [X] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
<!-- Describe the changes in detail -->
improve tab_move method in actions.py.
arg offset is must been big number (>> tab counts)

#### MOTIVATION AND CONTEXT
<!-- Why are these changes required? -->
optionly improv a navigation
<!-- What problems do these changes solve? -->
speed tabs moving
<!-- Link to relevant issues -->


#### TESTING
<!-- What tests have been run? -->
<!-- How does the changes affect other areas of the codebase? -->


#### IMAGES / VIDEOS<!-- Only if relevant -->
<!-- Link or embed images and videos of screenshots, sketches etc. -->
