### PR TITLE
Task. Translate kb from en in ogther(ua ru)

### DIFF
--- a/ranger/config/rc.conf
+++ b/ranger/config/rc.conf
@@ -321,6 +321,18 @@ set nested_ranger_warning true
 # setlocal path=~/downloads sort mtime
 
 # ===================================================================
+# == Command description
+# ===================================================================
+# You can add description on command or group command use next syntax
+# map KEY [chain echo YOUR_NAME_GROUP_COMMAND::[YOUR_NAME_COMMAND];] commands
+# where commands is/are comand1[; command2][; ...commandN]
+
+# ===================================================================
+# == Uses multiple selected files %s, %p, %S, %P
+# ===================================================================
+# Need use these qualificators without including in '' for correct handling of shell
+
+# ===================================================================
 # == Command Aliases in the Console
 # ===================================================================
 

--- a/ranger/core/actions.py
+++ b/ranger/core/actions.py
@@ -1295,8 +1295,10 @@ class Actions(  # pylint: disable=too-many-instance-attributes,too-many-public-m
             return self.tab_open(narg)
         assert isinstance(offset, int)
         tablist = self.get_tab_list()
-        current_index = tablist.index(self.current_tab)
-        newtab = tablist[(current_index + offset) % len(tablist)]
+        tab_count = len(tablist)
+        go_index = tablist.index(self.current_tab) + offset if abs(
+            offset) <= tab_count else 0 if offset <= 0 else tab_count - 1
+        newtab = tablist[go_index % tab_count]
         if newtab != self.current_tab:
             self.tab_open(newtab)
         return None

--- a/ranger/gui/ui.py
+++ b/ranger/gui/ui.py
@@ -277,7 +277,7 @@ class UI(  # pylint: disable=too-many-instance-attributes,too-many-public-method
             elif keys[0] == 27:
                 keys[0] = ALT_KEY
                 tkeys = key_translate(keys[1:])
-                if tkeys: keys = keys[0:1] + tkeys + keys[2:]
+                if tkeys: keys = keys[0:1] + tkeys
             if self.settings.xterm_alt_key:
                 if len(keys) == 2 and keys[1] in range(127, 256):
                     if keys[0] == 195:

--- a/ranger/gui/ui.py
+++ b/ranger/gui/ui.py
@@ -69,8 +69,9 @@ class UI(  # pylint: disable=too-many-instance-attributes,too-many-public-method
     is_on = False
     termsize = None
 
-    ru ="фисвуапршолдьтщзйкыіегмцчнябю.хъїжэєё'" +'ФИСВУАПРШОЛДЬТЩЗЙКЫІЕГМЦЧНЯБЮ,ХЪЇЖЭЄЁʼ' + '"№;:?'
-    en ="abcdefghijklmnopqrsstuvwxyz,./[]];''``" +'ABCDEFGHIJKLMNOPQRSSTUVWXYZ<>?{}}:""~~' + '@#$^&'
+    ru = "фисвуапршолдьтщзйкыіегмцчнябю.хъїжэєё'" + 'ФИСВУАПРШОЛДЬТЩЗЙКЫІЕГМЦЧНЯБЮ,ХЪЇЖЭЄЁʼ'
+    ru_mm = '"№;%:?'
+    en = "abcdefghijklmnopqrsstuvwxyz,./[]];''``" + 'ABCDEFGHIJKLMNOPQRSSTUVWXYZ<>?{}}:""~~' + '@#$%^&'
 
     def __init__(self, env=None, fm=None):  # pylint: disable=super-init-not-called
         self.keybuffer = KeyBuffer()
@@ -259,8 +260,8 @@ class UI(  # pylint: disable=too-many-instance-attributes,too-many-public-method
                     self.update_size()
                 else:
                     if not self.fm.input_is_blocked():
-                        if chr(key) in self.ru:  # translate S-[0-9], etc from ua or ru into en as simple key
-                            key = ord(self.en[self.ru.index(chr(key))])
+                        if chr(key) in self.ru_mm:  # translate S-[0-9], etc from ua or ru into en as simple key
+                            key = ord(self.en[len(self.ru)+self.ru_mm.index(chr(key))])
                         self.handle_key(key)
             elif key == -1 and not os.isatty(sys.stdin.fileno()):
                 self.fm.exit()  # STDIN has been closed

--- a/ranger/gui/ui.py
+++ b/ranger/gui/ui.py
@@ -262,7 +262,7 @@ class UI(  # pylint: disable=too-many-instance-attributes,too-many-public-method
                     self.update_size()
                 else:
                     if not self.fm.input_is_blocked():
-                        if chr(key) in self.ru_mm:
+                        if chr(key) in self.ru_mm and not self.console.visible or self.console.question_queue:
                             key = _key_is_merge_getter(chr(key))
                         self.handle_key(key)
             elif key == -1 and not os.isatty(sys.stdin.fileno()):

--- a/ranger/gui/ui.py
+++ b/ranger/gui/ui.py
@@ -240,13 +240,15 @@ class UI(  # pylint: disable=too-many-instance-attributes,too-many-public-method
             self.handle_key(key)
 
     def handle_input(self):
+        def _key_is_merge_getter(ch):  # Handle keys S-[ 0-9]
+            return ord(self.en[len(self.ru) + self.ru_mm.index(ch)])
+
         def key_translate(keys):  # translate key from ua or ru into en
             if not self.console.visible or self.console.question_queue:
                 ch = b''.join([bytes.fromhex('{0:X}'.format(i)) for i in keys]).decode('utf-8')
                 if not ch: return []
                 if ch in self.ru:
-                    if ch == chr(keys[0]): return [keys[0]]  # Handle keys S-[0-9], etc as special key (universally,
-                    # will not never executed here for ua,ru)
+                    if ch in self.ru_mm: return [_key_is_merge_getter(ch)]
                     ch = self.en[self.ru.index(ch)]
                     return [ord(ch)]
 
@@ -260,8 +262,8 @@ class UI(  # pylint: disable=too-many-instance-attributes,too-many-public-method
                     self.update_size()
                 else:
                     if not self.fm.input_is_blocked():
-                        if chr(key) in self.ru_mm:  # translate S-[0-9], etc from ua or ru into en as simple key
-                            key = ord(self.en[len(self.ru)+self.ru_mm.index(chr(key))])
+                        if chr(key) in self.ru_mm:
+                            key = _key_is_merge_getter(chr(key))
                         self.handle_key(key)
             elif key == -1 and not os.isatty(sys.stdin.fileno()):
                 self.fm.exit()  # STDIN has been closed

--- a/ranger/gui/widgets/view_base.py
+++ b/ranger/gui/widgets/view_base.py
@@ -154,10 +154,12 @@ class ViewBase(Widget, DisplayableContainer):  # pylint: disable=too-many-instan
             if len(hints) > self.fm.settings.hint_collapse_threshold:
                 def first_key_in_group(group):
                     return group[0][0][0]
+                def get_descr_hint(a):
+                    return "..." + ", ".join({
+                        s[1].replace("chain echo", "").strip().split("::")[0]
+                        if "::" in s[1] else s[1].strip() for s in a})
                 grouped_hints = (
-                    [(first_key_in_group(hint_group), "...")]
-                    if len(hint_group) > 1
-                    else hint_group
+                    [(first_key_in_group(hint_group), get_descr_hint(hint_group))]
                     for hint_group in grouped_hints
                 )
 
@@ -179,7 +181,12 @@ class ViewBase(Widget, DisplayableContainer):  # pylint: disable=too-many-instan
         whitespace = " " * self.wid
         i = ystart
         for key, cmd in hints:
-            string = " " + key.ljust(11) + " " + cmd
+            if "::" in cmd:
+                str_command = cmd.split("::")[-1].split(";")
+                str_command = str_command[0] if str_command[0] != "" else str_command[-1]
+            else:
+                str_command = cmd
+            string = " " + key.ljust(11) + " " + str_command.strip()
             self.addstr(i, 0, whitespace)
             self.addnstr(i, 0, string, self.wid)
             i += 1


### PR DESCRIPTION
<!-- Provide a descriptive summary of the changes in the title above -->
TASK to keyboard translation key bindings
Inputs key bindings commands only Latin with any language-type of keyboards

#### ISSUE TYPE
<!-- Pick relevant types and delete the rest -->
- Improvement/feature implementation

#### RUNTIME ENVIRONMENT
<!-- Details of your runtime environment -->
no matter
<!-- Retrieve Python/ranger version and locale with `ranger -\-version` -->
no matter
- Operating system and version: no matter
- Terminal emulator and version: no matter
- Python version: 
- Ranger version/commit: 
- Locale: ALL

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [X] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [X] All changes follow the code style **[REQUIRED]**
- [X] All new and existing tests pass **[REQUIRED]**
- [X] Changes require config files to be updated
    - [ ] Config files have been updated
- [X] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [X] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
<!-- Describe the changes in detail -->
!This text mayby changes or|and updated. Do watch for it desctiption fo to be competent in this task
2020-04-29::4

DEVELOPMENT TASK
REORGANISATION

1. planning option setting-value 'en-keys' and 'other_keys' as string: For example see code
2. planed create pyton module with name keyboards.py
   • It containe a code to handling of mapped pressed key onto Latin ascii.
   • (not actual) If need to correct file name in shell operation, it prepares base to do it
   ‣ This module will be imported in ui.py
   ‣ This module wiil be check existing 'en-keys' and 'other_keys' in rc.conf
   ‣ This module maybe adding source code "os.system("stty -ixon")" ... Now it is unknown

Base ending result: Translate input key bindings for hot keys commands (only for hot-key commands and only) without swith keyboard for any language KB

EXAMPLE: user pressed hot keys ss(find) to find directory name "Фильмы" (ru) without it
----------------------------------------------------------------------
user action1; user controll curren KB. If curren KB not EN, user selected KB=EN
user action2; pressed-> ss
user action3; user selected KB=RU
user action4; input-> Фильмы
user action5(1); if need command next, user selected KB=EN

Next: User can do it on KB=EN | KB=RU | KB=AU selected himself languages KB of marke uppered

EXAMPLE: user pressed hot keys ss(find) to find directory name "Фильмы" (ru) with it
----------------------------------------------------------------------
user action1; pressed-> ss
user action2; user controll curren KB. If curren KB not RU -> user selected KB=RU
user action3; input-> Фильмы

User of Ukraine often use three languge keyboards: EN RU UA
It will be useful too else languages. Example for Germany user where use umlauts. And it like...
It making any file.conf universl. It will be work in else users of different countries, for it enough remap keys bindings fillint two strings in your rc.conf.

en_keys - keys on English (Latin)
other_keys - keys of user mapping on en (now is 'ru' in it)

other_keys for default contain "" and|or is comment. User need userself input these string
en_keys for default contain alphabetic latin [a-zA-Z] and|or is comment.
For enable supprot userself keyboards, need uncomment it and fill it

mapping next symbols:
`abcdefghijklmnopqrstuvwxyz,./[];''`ABCDEFGHIJKLMNOPQRSTUVWXYZ<>?{}:"~@#$^&`

other_keys mayby contain two and more KB for one letter
----------------------------------------------------------------------
Example key 'r' for RU and UA (ruusina and ukrain 'к' and more else for ukrain and russian are identical)
en_keys = "rR"
other = "кК"

Example key 's' for RU and UA
en_keys = "ssSS"
other = "ыіЫІ"

Example key 's' for RU only
en_keys = "sS"
other = "ыЫ"

Example key 's' for UA only
en_keys = "sS"
other = "іІ"

String-values 'en_keys' and 'other-keys' will be existing in single existens instance. User maybe to use it, for adding suport userself keys with userself languages. See code it (Russian and Ukraine mapping to English)

Example for Cyrillic:
en ="abcdefghijklmnopqrsstuvwxyz,./[]];''``" \
    'ABCDEFGHIJKLMNOPQRSSTUVWXYZ<>?{}}:""~~' \
    '@#$^&'
other ="фисвуапршолдьтщзйкыіегмцчнябю.хъїжэєё'" \
    'ФИСВУАПРШОЛДЬТЩЗЙКЫІЕГМЦЧНЯБЮ,ХЪЇЖЭЄЁʼ'	\
ru_mm ='"№;%:?'

Not translated symbols
----------------------------------------------------------------------
There are special keyboard layout keys/symbols for certain languages that are not included in the “other_keys”, which like “+” do not participate in the translation (ru,ua exactly). They pass as is.
For example: '=' or '+' (Shift-=) for russian, ukrain and english is identical.

Duplication|Conflict of some up-digital keyboard shortcuts in Cyrillic languages (for converting only)
----------------------------------------------------------------------
Usually users of languages from the Cyrillic group do not use the S-6 key and similar at all. For the reason that they are duplicated on an alphabetic keyboard. There is two way solve it small problem. See down next.
Theory:
For example RU: S-6 (EN) duplicate S -; (RU). Whay that is problem? This is that because pressed it hotkey (S-6) for these languages give two different symbols, where one from it is be in bouth languages — it is ':' for this hotkey.
```
|----+-----+----+----+-------------------------------------------|
| KB | KEY | CH | IN | DESCRIPTION                               |
|----+-----+----+----+-------------------------------------------|
| EN | S-6 | ^  | :  | has intersection S-; at alphabetic block  |
| RU | S-6 | :  |    | 'Ж' at on pressed S-; at alphabetic block |
|----+-----+----+----+-------------------------------------------|
| EN | S-4 | $  | ;  | has intersection  ;  at alphabetic block  |
| RU | S-4 | ;  |    |                                           |
|----+-----+----+----+-------------------------------------------|
| EN | S-2 | @  | "  | has intersection S-' at alphabetic block  |
| RU | S-2 | "  |    | 'Э' at on pressed S-' at alphabetic block |
|----+-----+----+----+-------------------------------------------|
```

The user expects the same command to press S-6 on EN and on RU (UA). But he gets two different command on press it keybinding. Or comands works only in EN. The user is in shock. No, advanced users know this fact, and do not use these keyboard shortcuts at all. But ...

Possible
1 - do not use these hotkey at all
2 - merge these hotkeys on bouth keyboards
For to marge hotkeys used strings in en_key and other_keys
other_keys_mm = '"№;:?'

If used mergin method (MM) then applied hotkey on key bindings of EN only, keybindings of other KB will be ignored.
If used different commands method (DCM) then applied keybindings all keyboards.

MM: Indeed even it maybe bring in of user in a shock. Now two hotkeys are works at equals - the one command.

DCM: One hotkey -> two commands
MM: Two hotkeys -> one command


Public custom generation string 'en' and 'other' ranger user
----------------------------------------------------------------------
It can implement on web-site, where will be select userneeded language kayboards. It allow easy update data base and public access for anybody.
• multiple choice kayboard layouts
• public access for anybody
• ability selecting of translate method DCM/MM (for two of many selected languages if ability)

General information
----------------------------------------------------------------------
For hieroglyphic-languages it need to be remade appreciably. It demand hard deep thinking in a process of Unicode

#### MOTIVATION AND CONTEXT
<!-- Why are these changes required? -->
useful
<!-- What problems do these changes solve? -->
useful
<!-- Link to relevant issues -->


#### TESTING
<!-- What tests have been run? -->
Simple TEST
<!-- How does the changes affect other areas of the codebase? -->
Marginal changes and margin in the fature


#### IMAGES / VIDEOS<!-- Only if relevant -->
<!-- Link or embed images and videos of screenshots, sketches etc. -->
