### PR TITLE
Run image previews in a separate thread

### DIFF
--- a/doc/ranger.1
+++ b/doc/ranger.1
@@ -133,7 +133,7 @@
 .\" ========================================================================
 .\"
 .IX Title "RANGER 1"
-.TH RANGER 1 "ranger-1.9.3" "2020-02-22" "ranger manual"
+.TH RANGER 1 "ranger-1.9.3" "2020-05-01" "ranger manual"
 .\" For nroff, turn off justification.  Always turn off hyphenation; it makes
 .\" way too many mistakes in technical documents.
 .if n .ad l
@@ -1091,6 +1091,10 @@ Draw images inside the console with the external program w3mimgpreview?
 .IX Item "preview_images_method [string]"
 Set the preview image method. Supported methods: w3m, iterm2, urxvt,
 urxvt-full, terminology.  See \fI\s-1PREVIEWS\s0\fR section.
+.IP "preview_images_delay [int]" 4
+.IX Item "preview_images_delay [int]"
+Waits for the specified delay, in milliseconds, before trying to preview an
+image.
 .IP "preview_max_size [int]" 4
 .IX Item "preview_max_size [int]"
 Avoid previewing files that exceed a certain size, in bytes.  Use a value of 0

--- a/doc/ranger.pod
+++ b/doc/ranger.pod
@@ -1159,6 +1159,11 @@ Draw images inside the console with the external program w3mimgpreview?
 Set the preview image method. Supported methods: w3m, iterm2, urxvt,
 urxvt-full, terminology.  See I<PREVIEWS> section.
 
+=item preview_images_delay [int]
+
+Waits for the specified delay, in milliseconds, before trying to preview an
+image.
+
 =item preview_max_size [int]
 
 Avoid previewing files that exceed a certain size, in bytes.  Use a value of 0

--- a/ranger/config/rc.conf
+++ b/ranger/config/rc.conf
@@ -73,6 +73,9 @@ set vcs_msg_length 50
 # Use one of the supported image preview protocols
 set preview_images false
 
+# Preview selected image after specified delay in miliseconds.
+set preview_images_delay 0
+
 # Set the preview image method. Supported methods:
 #
 # * w3m (default):

--- a/ranger/container/settings.py
+++ b/ranger/container/settings.py
@@ -66,6 +66,7 @@ ALLOWED_SETTINGS = {
     'preview_files': bool,
     'preview_images': bool,
     'preview_images_method': str,
+    'preview_images_delay': int,
     'preview_max_size': int,
     'preview_script': (str, type(None)),
     'relative_current_zero': bool,

--- a/ranger/ext/img_display.py
+++ b/ranger/ext/img_display.py
@@ -22,6 +22,10 @@ import sys
 import warnings
 import json
 import threading
+try:
+    from queue import Queue, Empty
+except ImportError:
+    from Queue import Queue, Empty
 from subprocess import Popen, PIPE
 from collections import defaultdict
 
@@ -97,7 +101,7 @@ def register_image_displayer(nickname=None):
 
 def get_image_displayer(registry_key):
     image_displayer_class = IMAGE_DISPLAYER_REGISTRY[registry_key]
-    return image_displayer_class()
+    return ImageDisplayerThreadWrapper(image_displayer_class)
 
 
 class ImageDisplayer(object):
@@ -685,9 +689,7 @@ class KittyImageDisplayer(ImageDisplayer, FileManagerAware):
         self.stdbout.flush()
         # kitty doesn't seem to reply on deletes, checking like we do in draw()
         # will slows down scrolling with timeouts from select
-        self.image_id -= 1
-        self.fm.ui.win.redrawwin()
-        self.fm.ui.win.refresh()
+        self.image_id = max(0, self.image_id - 1)
 
     def _format_cmd_str(self, cmd, payload=None, max_slice_len=2048):
         central_blk = ','.join(["{}={}".format(k, v) for k, v in cmd.items()]).encode('ascii')
@@ -767,3 +769,82 @@ class UeberzugImageDisplayer(ImageDisplayer):
                 self.process.communicate()
             finally:
                 timer_kill.cancel()
+
+
+class ImageDisplayerThreadWrapper(FileManagerAware):
+    is_initialized = False
+
+    def __init__(self, image_displayer_class):
+        self.image_displayer_class = image_displayer_class
+        self.queue = None
+        self.thread = None
+
+    def initialize(self):
+        self.queue = Queue()
+        self.thread = ImageDisplayerThread(self.image_displayer_class,
+                                           self.queue)
+        self.thread.start()
+        self.is_initialized = True
+
+    def draw(self, path, start_x, start_y, width, height):
+        """Draw an image at the given coordinates."""
+        if not self.is_initialized:
+            self.initialize()
+        self.queue.put((ImageDisplayerThread.DRAW,
+                        (path, start_x, start_y, width, height)))
+
+    def clear(self, start_x, start_y, width, height):
+        """Clear a part of terminal display."""
+        if not self.is_initialized:
+            self.initialize()
+        self.queue.put((ImageDisplayerThread.CLEAR,
+                        (start_x, start_y, width, height)))
+
+    def quit(self):
+        if self.is_initialized:
+            self.is_initialized = False
+            self.queue.put((ImageDisplayerThread.QUIT, ()))
+            # Join the queue to be sure that it is empty so all
+            # requests have been processed (mainly the clear request).
+            self.queue.join()
+
+
+class ImageDisplayerThread(threading.Thread, FileManagerAware):
+    QUIT = 0
+    DRAW = 1
+    CLEAR = 2
+
+    def __init__(self, image_displayer_class, queue):
+        threading.Thread.__init__(self)
+        self.daemon = True
+        self.queue = queue
+        self.image_displayer = image_displayer_class()
+
+    def run(self):
+        timeout = None
+        running = True
+
+        while running:
+            # We only draw once the queue is empty to avoid multiple draws when
+            # scrolling quickly (assuming preview_images_delay is big enough).
+            try:
+                (cmd, param) = self.queue.get(True, timeout)
+                if cmd == self.CLEAR:
+                    timeout = None
+                    (c_start_x, c_start_y, c_width, c_height) = param
+                    self.image_displayer.clear(c_start_x, c_start_y, c_width,
+                                               c_height)
+                elif cmd == self.QUIT:
+                    self.image_displayer.quit()
+                    running = False
+                elif cmd == self.DRAW:
+                    if timeout is None:
+                        timeout = self.fm.settings.preview_images_delay or 0
+                        timeout = timeout / 1000
+                self.queue.task_done()
+            except Empty:
+                timeout = None
+                if cmd == self.DRAW:
+                    (path, start_x, start_y, width, height) = param
+                    self.image_displayer.draw(path, start_x, start_y, width,
+                                              height)

--- a/ranger/gui/widgets/browsercolumn.py
+++ b/ranger/gui/widgets/browsercolumn.py
@@ -234,6 +234,10 @@ class BrowserColumn(Pager):  # pylint: disable=too-many-instance-attributes
             self.image = None
             self.need_clear_image = True
             Pager.clear_image(self)
+            if (self.fm.settings.preview_images_method == "w3m"
+                    and self.fm.settings.w3m_delay > 0):
+                from time import sleep
+                sleep(self.fm.settings.w3m_delay)
 
         if self.level > 0 and not self.settings.preview_directories:
             return

--- a/ranger/gui/widgets/pager.py
+++ b/ranger/gui/widgets/pager.py
@@ -101,6 +101,10 @@ class Pager(Widget):  # pylint: disable=too-many-instance-attributes
             self.clear_image()
 
             if not self.image:
+                if (self.fm.settings.preview_images_method == "w3m"
+                        and self.fm.settings.w3m_delay > 0):
+                    from time import sleep
+                    sleep(self.fm.settings.w3m_delay)
                 scroll_pos = self.scroll_begin + self.scroll_extra
                 line_gen = self._generate_lines(
                     starty=scroll_pos, startx=self.startx)


### PR DESCRIPTION
#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [X] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [X] All changes follow the code style **[REQUIRED]**
- [X] All new and existing tests pass **[REQUIRED]**
- [X] Changes require config files to be updated
    - [X] Config files have been updated
- [X] Changes require documentation to be updated
    - [X] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
Run image previews in a separate thread. Based on #1442.


#### MOTIVATION AND CONTEXT
<!-- Why are these changes required? -->
<!-- What problems do these changes solve? -->
<!-- Link to relevant issues -->
Image previews can make ranger extremely slow, especially when scrolling. Existing PRs seem to be outdated/restricted (e.g. #1442) or do not work well in some cases/use a delay instead of being asynchronous (e.g. #192).

#### TESTING

I have tested the following configurations and compared the behavior to `master`. While this requires further testing (as I am not testing all possible terminal/preview method combinations) and I may have missed something, it does seem to work well.

| terminal | preview method | py2 | py3 | notes |
|----------|----------------|-----|-----|-------|
| kitty    | kitty          | ✔   | ✔   |       |
|      | w3m            | ✔   | ✔   |       |
|      | ueberzug       | ✔   | ✔   |       |
| urxvt    | urxvt          | ✔   | ✔   |       |
|      | w3m            | ✔   | ✔   |       |
|      | ueberzug       | ✔   | ✔   |       |
| xterm    | w3m            | ✔   | ✔   |       |
|      | ueberzug       | ✔   | ✔   |       |
| termite  | w3m            | ✔   | ✔   |       |
|    | ueberzug       | ✔   | ✔   |       |
