### PR TITLE
Fix memory allocation issue with `identify`.

### DIFF
--- a/ranger/data/scope.sh
+++ b/ranger/data/scope.sh
@@ -139,9 +139,17 @@ handle_image() {
         #           && exit 6 || exit 1;;
 
         ## Image
-        image/*)
+        image/jpeg|image/png)
+            local filesize=$(($(stat -c%s "${FILE_PATH}")/1024)) # filesize in kb
+            local limit=$(ulimit -v) # address size limit in kb
+            local timeout=$(ulimit -t) # cpu time limit in sec
+            # set address size limit to 100MB + filesize
+            ulimit -v $((100*1024 + $filesize))
+            ulimit -t 3 # limit cpu time to 3 sec
             local orientation
             orientation="$( identify -format '%[EXIF:Orientation]\n' -- "${FILE_PATH}" )"
+            ulimit -v $limit # restore address size afterward
+            ulimit -v $timeout # restore cpu time
             ## If orientation data is present and the image actually
             ## needs rotating ("1" means no rotation)...
             if [[ -n "$orientation" && "$orientation" != 1 ]]; then


### PR DESCRIPTION
Use `ulimit` to bound `identify` in
- space: 100MB + filesize 
- time: 3 seconds

<!-- Provide a descriptive summary of the changes in the title above -->

#### ISSUE TYPE
<!-- Pick relevant types and delete the rest -->
- Bug fix

#### RUNTIME ENVIRONMENT
<!-- Details of your runtime environment -->
<!-- Retrieve Python/ranger version and locale with `ranger -\-version` -->
- Operating system and version: Ubuntu 19.04 x86_64
- Terminal emulator and version: XTerm(330) and termit 3.0.0
- ranger version: ranger 1.9.2
- Python version: 3.7.3 (default, Oct 7 2019, 12:56:13) [GCC 8.3.0]
- Locale: en_US.UTF-8

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [X] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [X] All changes follow the code style **[REQUIRED]**
- [X] All new and existing tests pass **[REQUIRED]**
- [ ] Changes require config files to be updated
    - [ ] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
There is an excessive memory allocation issue when `ranger` is using `identify` in `scope.sh`  
to query the orientation of the file of mimetype `image/*`.  (See #1815 #1929 #1946). 

I suggest to bound `identify` resources both in time and space (100MB + filesize and 3 seconds) and recover this limitation later. Moreover, since the mimetype of `djvu`  is categorized under `image`, I suggest to exclude it and only match `jpeg` and `png`. 

#### MOTIVATION AND CONTEXT
<!-- Why are these changes required? -->
<!-- What problems do these changes solve? -->
<!-- Link to relevant issues -->

Bug: #1815 #1929 #1946 

#### TESTING
<!-- What tests have been run? -->
<!-- How does the changes affect other areas of the codebase? -->
- No python code modified (all tests passed).
- `.png`, `.jpeg`, `.pdf` are still correctly displayed. `.djvu` is exclude.  
