### PR TITLE
Preview files under /sys/

### DIFF
--- a/ranger/data/scope.sh
+++ b/ranger/data/scope.sh
@@ -330,6 +330,14 @@ handle_mime() {
             mediainfo "${FILE_PATH}" && exit 5
             exiftool "${FILE_PATH}" && exit 5
             exit 1;;
+
+        ## Preview files under /sys/
+        inode/x-empty)
+            content="$(cat "${FILE_PATH}")"
+            if [[ -n "$content" ]]; then
+                echo "$content" && exit 5
+                exit 1
+            fi;;
     esac
 }
 


### PR DESCRIPTION
Use `cat` to preview files with MIME type `inode/x-empty`.

<!-- Provide a descriptive summary of the changes in the title above -->

#### ISSUE TYPE
- Improvement/feature implementation

#### RUNTIME ENVIRONMENT
<!-- Details of your runtime environment -->
<!-- Retrieve Python/ranger version and locale with `ranger -\-version` -->
- Operating system and version: Arch Linux
- Terminal emulator and version: xfce4-terminal 0.8.9.2 (Xfce 4.14)
- Python version: Python 3.8.2
- Ranger version/commit: ranger 1.9.3
- Locale: en_US.UTF-8

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [x] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [x] All changes follow the code style **[REQUIRED]**
- [x] All new and existing tests pass **[REQUIRED]**
- [ ] Changes require config files to be updated
    - [ ] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
<!-- Describe the changes in detail -->
Added a new entry under `handle_mime()` for `inode/x-empty`.

#### MOTIVATION AND CONTEXT
<!-- Why are these changes required? -->
<!-- What problems do these changes solve? -->
<!-- Link to relevant issues -->
Many of the "empty" files under `/sys/` are actually interfaces to information from the kernel. For example, the files related to cgroups have a size of 0 but return data when accessed. Without this change, ranger fails to preview this information.

#### TESTING
<!-- What tests have been run? -->
<!-- How does the changes affect other areas of the codebase? -->
`shellcheck` doesn't return any errors related to the change.