### PR TITLE
Fully migrate from distutils to setuptools

### DIFF
--- a/doc/howto-publish-a-release.md
+++ b/doc/howto-publish-a-release.md
@@ -62,7 +62,7 @@ Update the website
 Make a PyPI release
 -------------------
 * [ ] `git clean --force -d -x`
-* [ ] `SETUPTOOLS_USE=1 python setup.py sdist`
+* [ ] `python setup.py sdist`
 * [ ] `gpg --local-user 0x00000000 --detach-sign --armor dist/*`
 * [ ] `twine upload dist/*`
 

--- a/setup.py
+++ b/setup.py
@@ -4,26 +4,18 @@
 
 from __future__ import (absolute_import, division, print_function)
 
-from distutils import log  # pylint: disable=import-error,no-name-in-module
 from hashlib import sha512
 import os
 import shutil
+
+from setuptools import setup
+from setuptools.command.install_lib import install_lib
 
 import ranger
 
 
 SCRIPTS_PATH = 'build_scripts'
 EXECUTABLES_PATHS = ['/ranger/data/scope.sh']
-
-
-# pylint: disable=import-error,no-name-in-module,ungrouped-imports
-if os.environ.get('SETUPTOOLS_USE'):
-    from setuptools import setup
-    from setuptools.command.install_lib import install_lib
-else:
-    from distutils.core import setup
-    from distutils.command.install_lib import install_lib
-# pylint: enable=import-error,no-name-in-module,ungrouped-imports
 
 
 def findall(directory):
@@ -59,7 +51,7 @@ class InstallLib(install_lib):
             for exe_path in EXECUTABLES_PATHS:
                 if path.endswith(exe_path):
                     mode = ((os.stat(path).st_mode) | 0o555) & 0o7777
-                    log.info('changing mode of %s to %o', path, mode)
+                    print('changing mode of %s to %o' % (path, mode))
                     os.chmod(path, mode)
 
 


### PR DESCRIPTION
After years of supporting both, I think it'll be wise to let the venerable distutils rest.  Even the Python docs recommend setuptools over using distutils directly.


<!-- Provide a descriptive summary of the changes in the title above -->

#### ISSUE TYPE
<!-- Pick relevant types and delete the rest -->
- Improvement/feature implementation
- Breaking changes


#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [X] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [X] All changes follow the code style **[REQUIRED]**
- [X] All new and existing tests pass **[REQUIRED]**
- [ ] Changes require config files to be updated
    - [ ] Config files have been updated
- [X] Changes require documentation to be updated
    - [X] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated


#### MOTIVATION AND CONTEXT
<!-- Why are these changes required? -->
<!-- What problems do these changes solve? -->
<!-- Link to relevant issues -->

`distutils` don't support many of the pretty crucial features such as,
well, uninstalling.  For years I've been opposed to letting them go,
because I didn't like how `setuptools` throws an error when installing
out of `PYTHONPATH` but currently I think my use case wasn't justified
enough.  Let's do this.


#### TESTING
<!-- What tests have been run? -->
<!-- How does the changes affect other areas of the codebase? -->

I've installed the `ranger-fm` package from `setup.py` into a fresh
virtualenv.