### PR TITLE
add 'hide' alias for scout

### DIFF
--- a/ranger/config/rc.conf
+++ b/ranger/config/rc.conf
@@ -25,7 +25,6 @@
 #     multipane: Midnight-commander like multipane view showing all tabs next
 #                to each other
 set viewmode miller
-#set viewmode multipane
 
 # How many columns are there, and what are their relative widths?
 set column_ratios 1,3,4


### PR DESCRIPTION
i've added hide alias for scout command. 
It does the same as `:filter`, but with inverted results of matching. 
`:filter` shows everything, that matches regex and `:hide` hides everything, that matches regex.
