### PR TITLE
Switching between first/last tab

### DIFF
--- a/ranger/config/rc.conf
+++ b/ranger/config/rc.conf
@@ -25,7 +25,6 @@
 #     multipane: Midnight-commander like multipane view showing all tabs next
 #                to each other
 set viewmode miller
-#set viewmode multipane
 
 # How many columns are there, and what are their relative widths?
 set column_ratios 1,3,4

--- a/ranger/config/rc.conf
+++ b/ranger/config/rc.conf
@@ -539,8 +539,8 @@ map <A-Right> tab_move 1
 map <A-Left>  tab_move -1
 map gt        tab_move 1
 map gT        tab_move -1
-map ga        tab_move 0 useOffsetAsTabIndex=yes
-map gz        tab_move -1 useOffsetAsTabIndex=yes
+map ga        tab_move 0 use_offset_as_index=yes
+map gz        tab_move -1 use_offset_as_index=yes
 map gn        tab_new
 map gc        tab_close
 map uq        tab_restore

--- a/ranger/config/rc.conf
+++ b/ranger/config/rc.conf
@@ -539,8 +539,8 @@ map <A-Right> tab_move 1
 map <A-Left>  tab_move -1
 map gt        tab_move 1
 map gT        tab_move -1
-map ga        tab_move 0 use_offset_as_index=yes
-map gz        tab_move -1 use_offset_as_index=yes
+map ga        tab_move 0 is_index=true
+map gz        tab_move -1 is_index=true
 map gn        tab_new
 map gc        tab_close
 map uq        tab_restore

--- a/ranger/config/rc.conf
+++ b/ranger/config/rc.conf
@@ -539,6 +539,8 @@ map <A-Right> tab_move 1
 map <A-Left>  tab_move -1
 map gt        tab_move 1
 map gT        tab_move -1
+map ga        tab_move 0 useOffsetAsTabIndex=yes
+map gz        tab_move -1 useOffsetAsTabIndex=yes
 map gn        tab_new
 map gc        tab_close
 map uq        tab_restore

--- a/ranger/core/actions.py
+++ b/ranger/core/actions.py
@@ -1290,13 +1290,13 @@ class Actions(  # pylint: disable=too-many-instance-attributes,too-many-public-m
                     self.signal_emit('tab.change', old=previous_tab, new=self.thistab)
                     break
 
-    def tab_move(self, offset, useOffsetAsTabIndex=None, narg=None):
+    def tab_move(self, offset, use_offset_as_index=None, narg=None):
         if narg:
             return self.tab_open(narg)
         assert isinstance(offset, int)
         tablist = self.get_tab_list()
         current_index = tablist.index(self.current_tab)
-        if useOffsetAsTabIndex:
+        if use_offset_as_index:
             newtab = tablist[offset]
         else:
             newtab = tablist[(current_index + offset) % len(tablist)]

--- a/ranger/core/actions.py
+++ b/ranger/core/actions.py
@@ -1290,14 +1290,15 @@ class Actions(  # pylint: disable=too-many-instance-attributes,too-many-public-m
                     self.signal_emit('tab.change', old=previous_tab, new=self.thistab)
                     break
 
-    def tab_move(self, offset, use_offset_as_index=None, narg=None):
+    def tab_move(self, offset, is_index=None, narg=None):
         if narg:
             return self.tab_open(narg)
         assert isinstance(offset, int)
         tablist = self.get_tab_list()
         current_index = tablist.index(self.current_tab)
-        if use_offset_as_index:
-            newtab = tablist[offset]
+        if is_index == 'true':
+            tab_index = offset
+            newtab = tablist[tab_index]
         else:
             newtab = tablist[(current_index + offset) % len(tablist)]
         if newtab != self.current_tab:


### PR DESCRIPTION
Switching between first/last tab 

I tried to do a quest from here #1939 ! I don't know, whether I've done this correct or not. But at first glance it works.

I added keyword argument to tab_move function to make that function use offset as tab index(we don't need offset for going to the first/last tab, but we need index -- zero or -1).

So, we can now write at rc.conf something like:

`map gz tab_move -1 use_offset_as_index=yes`
and it will use -1 not as offset, but as index of tab. So, it switch to the last tab.

`ga` is used for switching to the first tab and `gz` for last. It's easy to remember, because `a` is the first letter of alphabet, and `z` is the last. And it's easy to type :) 