### PR TITLE
fix move parent brake on non access folder

### DIFF
--- a/ranger/core/actions.py
+++ b/ranger/core/actions.py
@@ -577,18 +577,18 @@ class Actions(  # pylint: disable=too-many-instance-attributes,too-many-public-m
             if self.ui.pager.visible:
                 self.display_file()
 
-    def move_parent(self, n, narg=None):
+    def move_parent(self, n, narg=1):
         self.change_mode('normal')
-        if narg is not None:
-            n *= narg
         parent = self.thistab.at_level(-1)
-        if parent is not None:
-            if parent.pointer + n < 0:
-                n = 0 - parent.pointer
+        if parent is None: return
+        step = n
+        n = n*narg + parent.pointer
+        while n >= 0:
             try:
-                self.thistab.enter_dir(parent.files[parent.pointer + n])
+                if not self.thistab.enter_dir(parent.files[n]): return
             except IndexError:
-                pass
+                return
+            n += step
 
     def select_file(self, path):
         path = path.strip()

--- a/ranger/core/actions.py
+++ b/ranger/core/actions.py
@@ -577,12 +577,22 @@ class Actions(  # pylint: disable=too-many-instance-attributes,too-many-public-m
             if self.ui.pager.visible:
                 self.display_file()
 
-    def move_parent(self, n, narg=1):
+    def move_parent(self, n, narg=1, is_bound=False):
         self.change_mode('normal')
         parent = self.thistab.at_level(-1)
-        if parent is None: return
+        if parent is None or n == 0: return
         step = n
-        n = n*narg + parent.pointer
+        if is_bound == True:
+            if step < 0:
+                n = 0
+            else:
+                for f in reversed(parent.files):
+                    if f.is_directory:
+                        n = parent.files.index(f)
+                        break
+            step = -step
+        else:
+            n = n*narg + parent.pointer
         while n >= 0:
             try:
                 if not self.thistab.enter_dir(parent.files[n]): return

--- a/ranger/core/tab.py
+++ b/ranger/core/tab.py
@@ -168,7 +168,7 @@ class Tab(FileManagerAware, SettingsAware):  # pylint: disable=too-many-instance
 
         self.fm.signal_emit('cd', previous=previous, new=self.thisdir)
 
-        return True
+        return False
 
     def __repr__(self):
         return "<Tab '%s'>" % self.thisdir


### PR DESCRIPTION
<!-- Provide a descriptive summary of the changes in the title above -->
Fix breaking parent_move on non access folder. This folders would are skipped.

#### ISSUE TYPE
<!-- Pick relevant types and delete the rest -->
- Improvement/feature implementation

#### RUNTIME ENVIRONMENT
<!-- Details of your runtime environment -->
XFCE 4.12
<!-- Retrieve Python/ranger version and locale with `ranger -\-version` -->
- Operating system and version: 4.19.0-5-amd64 #1 SMP Debian 4.19.37-5+deb10u2 (2019-08-08) x86_64 GNU/Linux
- Terminal emulator and version: lxterminal 0.3.2
- Python version: 3.6
- Ranger version/commit: ranger 1.9.2
- Locale: ru_UA.UTF-8

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [x] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [x] All changes follow the code style **[REQUIRED]**
- [x] All new and existing tests pass **[REQUIRED]**
- [ ] Changes require config files to be updated
    - [ ] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
<!-- Describe the changes in detail -->
On navigation parent_move(1/-1) watch a navigation stop on folders with out an access. For example, root folder
Fix breaking parent_move on non access folder for tab. Such folders would are skipped with this code.

#### MOTIVATION AND CONTEXT
<!-- Why are these changes required? --> improvement navigation parent_move
<!-- What problems do these changes solve? --> correct handling a parent_move
<!-- Link to relevant issues -->


#### TESTING
<!-- What tests have been run? -->
<!-- How does the changes affect other areas of the codebase? -->


#### IMAGES / VIDEOS<!-- Only if relevant -->
<!-- Link or embed images and videos of screenshots, sketches etc. -->
