### PR TITLE
Fix line length computation when there are ANSI escape codes

### DIFF
--- a/ranger/gui/widgets/pager.py
+++ b/ranger/gui/widgets/pager.py
@@ -246,9 +246,10 @@ class Pager(Widget):  # pylint: disable=too-many-instance-attributes
         while True:
             try:
                 line = self._get_line(i).expandtabs(4)
+                line_len = ansi.char_len(line) if self.markup == 'ansi' else len(line)
                 for part in ((0,) if not
                              self.fm.settings.wrap_plaintext_previews else
-                             range(max(1, ((len(line) - 1) // self.wid) + 1))):
+                             range(max(1, ((line_len - 1) // self.wid) + 1))):
                     shift = part * self.wid
                     if self.markup == 'ansi':
                         line_bit = (ansi.char_slice(line, startx + shift,

--- a/ranger/gui/widgets/pager.py
+++ b/ranger/gui/widgets/pager.py
@@ -246,7 +246,7 @@ class Pager(Widget):  # pylint: disable=too-many-instance-attributes
         while True:
             try:
                 line = self._get_line(i).expandtabs(4)
-                line_len = ansi.char_len(line) if self.markup == 'ansi' else len(line)
+                line_len = ansi.char_len(line)
                 for part in ((0,) if not
                              self.fm.settings.wrap_plaintext_previews else
                              range(max(1, ((line_len - 1) // self.wid) + 1))):


### PR DESCRIPTION
<!-- Provide a descriptive summary of the changes in the title above -->

#### ISSUE TYPE
- Bug fix

#### RUNTIME ENVIRONMENT
<!-- Details of your runtime environment -->
<!-- Retrieve Python/ranger version and locale with `ranger -\-version` -->

- Operating system and version: `Manjaro Linux 20.0.1`
- Terminal emulator and version: `xfce4-terminal 0.8.9.2 (Xfce 4.14)`
- Ranger version: `ranger-master v1.9.3-24-g1654128f`
- Python version: `3.8.2 (default, Apr  8 2020, 14:31:25) [GCC 9.3.0]`
- Locale: `en_US.UTF-8`

#### CHECKLIST
- [X] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [X] All changes follow the code style **[REQUIRED]**
- [X] All new and existing tests pass **[REQUIRED]**
- [ ] Changes require config files to be updated
    - [ ] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
<!-- Describe the changes in detail -->
This PR fixes the computation of the "displayable" line length in the preview, properly ignoring the ANSI escape codes, instead of using `len(line)`.

#### MOTIVATION AND CONTEXT
<!-- Why are these changes required? -->
<!-- What problems do these changes solve? -->
<!-- Link to relevant issues -->

Without this fix, when `wrap_plaintext_previews` is set to `true` and syntax highlighting in the preview is enabled (e.g. after installing `highlight` of `pygmentize`), then the line wrapping is done before the full width of the pager, resulting in shorter previews than possible and in spurious empty lines, not present in the previewed file.

The root cause is that the algorithm to wrap lines splits them based on the pager width, but the line length is computed "naively" using `len(line)`. Invisible ANSI escape codes used for highlighting are counted, making the line seem longer than it really is. So the line is wrapped earlier that needed. For short enough lines this can introduce extra empty lines.

The fix is thus simply to calculate and use the display length of the line in the wrapping algorithm.

#### TESTING
<!-- What tests have been run? -->
<!-- How does the changes affect other areas of the codebase? -->

I ran `make tests_py`, but there is no automated test relevant to this part of the code.

I did manual testing both with and without highlighter installed, and both with and without line wrapping. The bug disappeared... and I didn't notice new ones :).
