### PR TITLE
Symlinks handling by flat command

### DIFF
--- a/ranger/config/commands.py
+++ b/ranger/config/commands.py
@@ -1730,7 +1730,7 @@ class flat(Command):
     """
     :flat [-FLAGS...] <level>
 
-    Flattens the directory view up to the specified level. By default symlinks are not followed.
+    Flattens the directory view up to the specified level. Symlinks are not followed by default.
 
     Flags:
         -f force symlinks following with loop detection

--- a/ranger/config/commands.py
+++ b/ranger/config/commands.py
@@ -94,7 +94,6 @@ from __future__ import (absolute_import, division, print_function)
 from collections import deque
 import os
 import re
-import warnings
 
 from ranger.api.commands import Command
 
@@ -1740,24 +1739,24 @@ class flat(Command):
          0 remove flattened view
     """
 
-    def __init__(self, *args, **kwargs):
-        super(flat, self).__init__(*args, **kwargs)
-        self.flag, self.level = self.parse_flags()
-
     def execute(self):
         try:
-            if self.flag == 'f1':
-                level = -1
-                follow_symlinks = True
+            if self.arg(2) != '':
+                level = int(self.arg(2))
+                if self.arg(1) == '-f':
+                    follow_symlinks = True
+                else:
+                    raise ValueError
             else:
-                level = int(self.level) if self.level else int(self.flag)
-                follow_symlinks = True if self.flag == 'f' else False
+                level = int(self.arg(1))
+                follow_symlinks = False
         except ValueError:
             self.fm.notify("Syntax: flat [-f] <level>", bad=True)
             return
 
         if level < -1:
             self.fm.notify("Need an integer number (-1, 0, 1, ...)", bad=True)
+            return
 
         self.fm.thisdir.unload()
         self.fm.thisdir.flat = level

--- a/ranger/config/commands.py
+++ b/ranger/config/commands.py
@@ -1728,11 +1728,12 @@ class grep(Command):
 
 class flat(Command):
     """
-    :flat [-f] <level>
+    :flat [-FLAGS...] <level>
 
-    Flattens the directory view up to the specified level.
+    Flattens the directory view up to the specified level. By default symlinks are not followed.
 
-    f - force symlinks following with respect to symlinks loop detection
+    Flags:
+        -f force symlinks following with loop detection
 
     Level:
         -1 fully flattened

--- a/ranger/config/commands.py
+++ b/ranger/config/commands.py
@@ -1761,7 +1761,7 @@ class flat(Command):
 
         self.fm.thisdir.unload()
         self.fm.thisdir.flat = level
-        self.fm.thisdir.flat_follow_symlinks = follow_symlinks
+        self.fm.thisdir.follow_symlinks = follow_symlinks
         self.fm.thisdir.load_content()
 
 

--- a/ranger/container/directory.py
+++ b/ranger/container/directory.py
@@ -84,7 +84,7 @@ def walklevel(some_dir, level, follow_symlinks=False):
         if follow_symlinks:
             if os.path.realpath(root) not in visited_dirs:
                 visited_dirs.append(os.path.realpath(root))
-                
+
             #check if dirs containes already visited directories
             for cur_dir in dirs:
                 if os.path.realpath(os.path.join(root, cur_dir)) in visited_dirs:
@@ -122,8 +122,9 @@ class Directory(  # pylint: disable=too-many-instance-attributes,too-many-public
     cycle_list = None
     loading = False
     progressbar_supported = True
+
     flat = 0
-    flat_follow_symlinks = False
+    follow_symlinks = False
 
     filenames = None
     files = None
@@ -353,7 +354,10 @@ class Directory(  # pylint: disable=too-many-instance-attributes,too-many-public
 
                 if self.flat:
                     filelist = []
-                    for dirpath, dirnames, filenames, link_loop in walklevel(mypath, self.flat, self.flat_follow_symlinks):
+                    for dirpath, dirnames, filenames, link_loop in walklevel(mypath,
+                                                                             self.flat,
+                                                                             self.follow_symlinks):
+
                         if link_loop:
                             self.fm.notify('Symlink loop detected '+link_loop, bad=True)
 

--- a/ranger/container/directory.py
+++ b/ranger/container/directory.py
@@ -10,7 +10,6 @@ import random
 import re
 from collections import deque
 from time import time
-import warnings
 
 from ranger.container.fsobject import BAD_INFO, FileSystemObject
 from ranger.core.loader import Loadable

--- a/ranger/container/directory.py
+++ b/ranger/container/directory.py
@@ -85,7 +85,7 @@ def walklevel(some_dir, level, follow_symlinks=False):
             if os.path.realpath(root) not in visited_dirs:
                 visited_dirs.append(os.path.realpath(root))
 
-            #check if dirs containes already visited directories
+            # check if dirs containes already visited directories
             for cur_dir in dirs:
                 if os.path.realpath(os.path.join(root, cur_dir)) in visited_dirs:
                     link_loop = os.path.join(root, cur_dir)
@@ -359,7 +359,7 @@ class Directory(  # pylint: disable=too-many-instance-attributes,too-many-public
                                                                              self.follow_symlinks):
 
                         if link_loop:
-                            self.fm.notify('Symlink loop detected '+link_loop, bad=True)
+                            self.fm.notify('Symlink loop detected ' + link_loop, bad=True)
 
                         dirlist = [
                             os.path.join("/", dirpath, d)

--- a/tests/ranger/container/test_directory.py
+++ b/tests/ranger/container/test_directory.py
@@ -82,12 +82,18 @@ def create_tree_with_symlinks_no_loop(tmp_path):
     symlink1.symlink_to(file1)
 
 
+def copy_level(level):
+    level_copy = copy.deepcopy(list(level))
+    level_copy[1] = sorted(level_copy[1])  # because os.walk yields dirnames in arbitraty order
+    return tuple(level_copy)
+
+
 def test_walklevel_all_levels_no_symlinks(tmp_path):
     create_tree_no_symlinks(tmp_path)
 
     walklevel_results = []
     for level in walklevel(str(tmp_path), -1):
-        walklevel_results.append(copy.deepcopy(level))
+        walklevel_results.append(copy_level(level))
 
     assert walklevel_results == [(str(tmp_path), ['a', 'b'], [], None),
                                  (str(tmp_path / 'a'), ['c'], ['file1.txt'], None),
@@ -100,7 +106,7 @@ def test_walklevel_first_level_no_symlinks(tmp_path):
 
     walklevel_results = []
     for level in walklevel(str(tmp_path), 1):
-        walklevel_results.append(copy.deepcopy(level))
+        walklevel_results.append(copy_level(level))
 
     assert walklevel_results == [(str(tmp_path), ['a', 'b'], [], None),
                                  (str(tmp_path / 'a'), ['c'], ['file1.txt'], None),
@@ -112,7 +118,7 @@ def test_walklevel_all_levels_symlinks_with_loop(tmp_path):
 
     walklevel_results = []
     for level in walklevel(str(tmp_path), -1, follow_symlinks=True):
-        walklevel_results.append(copy.deepcopy(level))
+        walklevel_results.append(copy_level(level))
 
     assert walklevel_results == [(str(tmp_path), ['a', 'b'], [], None),
                                  (str(tmp_path / 'a'), ['c'], ['file1.txt'],
@@ -126,7 +132,7 @@ def test_walklevel_first_level_symlinks_with_loop(tmp_path):
 
     walklevel_results = []
     for level in walklevel(str(tmp_path), 1, follow_symlinks=True):
-        walklevel_results.append(copy.deepcopy(level))
+        walklevel_results.append(copy_level(level))
 
     assert walklevel_results == [(str(tmp_path), ['a', 'b'], [], None),
                                  (str(tmp_path / 'a'), ['c'], ['file1.txt'],
@@ -139,7 +145,7 @@ def test_walklevel_all_levels_symlinks_without_loop(tmp_path):
 
     walklevel_results = []
     for level in walklevel(str(tmp_path), -1, follow_symlinks=True):
-        walklevel_results.append(copy.deepcopy(level))
+        walklevel_results.append(copy_level(level))
 
     assert walklevel_results == [(str(tmp_path), ['a', 'b'], [], None),
                                  (str(tmp_path / 'a'), ['c'], ['file1.txt'], None),
@@ -152,6 +158,6 @@ def test_walklevel_zero_level_no_symlinks(tmp_path):
 
     walklevel_results = []
     for level in walklevel(str(tmp_path), 0):
-        walklevel_results.append(copy.deepcopy(level))
+        walklevel_results.append(copy_level(level))
 
     assert walklevel_results == [(str(tmp_path), ['a', 'b'], [], None)]

--- a/tests/ranger/container/test_directory.py
+++ b/tests/ranger/container/test_directory.py
@@ -85,6 +85,7 @@ def create_tree_with_symlinks_no_loop(tmp_path):
 def copy_level(level):
     level_copy = copy.deepcopy(list(level))
     level_copy[1] = sorted(level_copy[1])  # because os.walk yields dirnames in arbitraty order
+    level_copy[2] = sorted(level_copy[2])
     return tuple(level_copy)
 
 
@@ -161,8 +162,7 @@ def test_walklevel_all_levels_symlinks_without_loop(tmp_path):
 
     expected_levels = [(str(tmp_path), ['a', 'b'], [], None),
                        (str(tmp_path / 'a'), ['c'], ['file1.txt'], None),
-                       (str(tmp_path / 'a' / 'c'), [],
-                        ['file2.txt', 'link1'], None),
+                       (str(tmp_path / 'a' / 'c'), [], ['file2.txt', 'link1'], None),
                        (str(tmp_path / 'b'), [], ['file3.txt'], None)]
 
     for resulting_level in walklevel_results:

--- a/tests/ranger/container/test_directory.py
+++ b/tests/ranger/container/test_directory.py
@@ -1,0 +1,168 @@
+from ranger.container.directory import walklevel
+import copy
+
+def create_tree_no_symlinks(tmp_path):
+    # ├── a
+    # │   ├── c
+    # │   │   └── file2.txt
+    # │   └── file1.txt
+    # └── b
+    #     └── file3.txt
+ 
+    a = tmp_path / 'a'
+    a.mkdir()
+    file1 = a / 'file1.txt'
+    file1.touch()
+    b = tmp_path / 'b'
+    b.mkdir()
+
+    c = a / 'c'
+    c.mkdir()
+    file2 = c / 'file2.txt'
+    file2.touch()
+
+    file3 = b / 'file3.txt'
+    file3.touch()
+
+def create_tree_with_symlinks_with_loop(tmp_path):
+    # ├── a
+    # │   ├── c
+    # │   │   └── file2.txt
+    # │   ├── file1.txt
+    # │   └── link1 -> a
+    # └── b
+    #     └── file3.txt
+
+    a = tmp_path / 'a'
+    a.mkdir()
+    file1 = a / 'file1.txt'
+    file1.touch()
+    symlink1 = a / 'link1'
+    symlink1.symlink_to(a, target_is_directory=True)
+
+    b = tmp_path / 'b'
+    b.mkdir()
+
+    c = a / 'c'
+    c.mkdir()
+    file2 = c / 'file2.txt'
+    file2.touch()
+ 
+    file3 = b / 'file3.txt'
+    file3.touch()
+
+
+def create_tree_with_symlinks_no_loop(tmp_path):
+    # ├── a
+    # │   ├── c
+    # │   │   ├── file2.txt
+    # │   │   └── link1 -> a/file1.txt
+    # │   └── file1.txt
+    # └── b
+    #     └── file3.txt
+
+    a = tmp_path / 'a'
+    a.mkdir()
+    file1 = a / 'file1.txt'
+    file1.touch()
+    b = tmp_path / 'b'
+    b.mkdir()
+
+    c = a / 'c'
+    c.mkdir()
+    file2 = c / 'file2.txt'
+    file2.touch()
+
+    file3 = b / 'file3.txt'
+    file3.touch()
+    symlink1 = c / 'link1'
+    symlink1.symlink_to(file1)
+
+
+def test_walklevel_all_levels_no_symlinks(tmp_path):
+    create_tree_no_symlinks(tmp_path)
+
+    walklevel_results = []
+    for level in walklevel(str(tmp_path), -1):
+        walklevel_results.append(copy.deepcopy(level))
+
+    assert walklevel_results == [(str(tmp_path), ['a', 'b'], [],
+                                  {'existance': False, 'path': ''}),
+                                 (str(tmp_path / 'a'), ['c'], ['file1.txt'],
+                                  {'existance': False, 'path': ''}),
+                                 (str(tmp_path / 'a' / 'c'), [], ['file2.txt'],
+                                  {'existance': False, 'path': ''}),
+                                 (str(tmp_path / 'b'), [], ['file3.txt'],
+                                  {'existance': False, 'path': ''})]
+
+
+def test_walklevel_first_level_no_symlinks(tmp_path):
+    create_tree_no_symlinks(tmp_path)
+
+    walklevel_results = []
+    for level in walklevel(str(tmp_path), 1):
+        walklevel_results.append(copy.deepcopy(level))
+
+    assert walklevel_results == [(str(tmp_path), ['a', 'b'], [],
+                                  {'existance': False, 'path': ''}),
+                                 (str(tmp_path / 'a'), ['c'], ['file1.txt'],
+                                  {'existance': False, 'path': ''}),
+                                 (str(tmp_path / 'b'), [], ['file3.txt'],
+                                  {'existance': False, 'path': ''})]
+
+
+def test_walklevel_all_levels_symlinks_with_loop(tmp_path):
+    create_tree_with_symlinks_with_loop(tmp_path)
+
+    walklevel_results = []
+    for level in walklevel(str(tmp_path), -1, flat_follow_symlinks=True):
+        walklevel_results.append(copy.deepcopy(level))
+
+    assert walklevel_results == [(str(tmp_path), ['a', 'b'], [],
+                                  {'existance': False, 'path': ''}),
+                                 (str(tmp_path / 'a'), ['c'], ['file1.txt'],
+                                  {'existance': True, 'path': str(tmp_path / 'a' / 'link1')}),
+                                 (str(tmp_path / 'a' / 'c'), [], ['file2.txt'],
+                                  {'existance': False, 'path': ''}),
+                                 (str(tmp_path / 'b'), [], ['file3.txt'],
+                                  {'existance': False, 'path': ''})]
+
+def test_walklevel_first_level_symlinks_with_loop(tmp_path):
+    create_tree_with_symlinks_with_loop(tmp_path)
+
+    walklevel_results = []
+    for level in walklevel(str(tmp_path), 1, flat_follow_symlinks=True):
+        walklevel_results.append(copy.deepcopy(level))
+    
+    assert walklevel_results == [(str(tmp_path), ['a', 'b'], [],
+                                  {'existance': False, 'path': ''}),
+                                 (str(tmp_path / 'a'), ['c'], ['file1.txt'],
+                                  {'existance': True, 'path': str(tmp_path / 'a' / 'link1')}),
+                                 (str(tmp_path / 'b'), [], ['file3.txt'],
+                                  {'existance': False, 'path': ''})]
+
+def test_walklevel_all_levels_symlinks_without_loop(tmp_path):
+    create_tree_with_symlinks_no_loop(tmp_path)
+
+    walklevel_results = []
+    for level in walklevel(str(tmp_path), -1, flat_follow_symlinks=True):
+        walklevel_results.append(copy.deepcopy(level))
+    
+    assert walklevel_results == [(str(tmp_path), ['a', 'b'], [],
+                                  {'existance': False, 'path': ''}),
+                                 (str(tmp_path / 'a'), ['c'], ['file1.txt'],
+                                  {'existance': False, 'path': ''}),
+                                 (str(tmp_path / 'a' / 'c'), [], ['file2.txt', 'link1'],
+                                  {'existance': False, 'path': ''}),
+                                 (str(tmp_path / 'b'), [], ['file3.txt'],
+                                  {'existance': False, 'path': ''})]
+
+def test_walklevel_zero_level_no_symlinks(tmp_path):
+    create_tree_no_symlinks(tmp_path)
+
+    walklevel_results = []
+    for level in walklevel(str(tmp_path), 0):
+        walklevel_results.append(copy.deepcopy(level))
+ 
+    assert walklevel_results == [(str(tmp_path), ['a', 'b'], [],
+                                  {'existance': False, 'path': ''})]

--- a/tests/ranger/container/test_directory.py
+++ b/tests/ranger/container/test_directory.py
@@ -1,5 +1,6 @@
-from ranger.container.directory import walklevel
 import copy
+
+from ranger.container.directory import walklevel
 
 def create_tree_no_symlinks(tmp_path):
     # ├── a
@@ -8,20 +9,20 @@ def create_tree_no_symlinks(tmp_path):
     # │   └── file1.txt
     # └── b
     #     └── file3.txt
- 
-    a = tmp_path / 'a'
-    a.mkdir()
-    file1 = a / 'file1.txt'
-    file1.touch()
-    b = tmp_path / 'b'
-    b.mkdir()
 
-    c = a / 'c'
-    c.mkdir()
-    file2 = c / 'file2.txt'
+    a_dir = tmp_path / 'a'
+    a_dir.mkdir()
+    file1 = a_dir / 'file1.txt'
+    file1.touch()
+    b_dir = tmp_path / 'b'
+    b_dir.mkdir()
+
+    c_dir = a_dir / 'c'
+    c_dir.mkdir()
+    file2 = c_dir / 'file2.txt'
     file2.touch()
 
-    file3 = b / 'file3.txt'
+    file3 = b_dir / 'file3.txt'
     file3.touch()
 
 def create_tree_with_symlinks_with_loop(tmp_path):
@@ -33,22 +34,22 @@ def create_tree_with_symlinks_with_loop(tmp_path):
     # └── b
     #     └── file3.txt
 
-    a = tmp_path / 'a'
-    a.mkdir()
-    file1 = a / 'file1.txt'
+    a_dir = tmp_path / 'a'
+    a_dir.mkdir()
+    file1 = a_dir / 'file1.txt'
     file1.touch()
-    symlink1 = a / 'link1'
-    symlink1.symlink_to(a, target_is_directory=True)
+    symlink1 = a_dir / 'link1'
+    symlink1.symlink_to(a_dir, target_is_directory=True)
 
-    b = tmp_path / 'b'
-    b.mkdir()
+    b_dir = tmp_path / 'b'
+    b_dir.mkdir()
 
-    c = a / 'c'
-    c.mkdir()
-    file2 = c / 'file2.txt'
+    c_dir = a_dir / 'c'
+    c_dir.mkdir()
+    file2 = c_dir / 'file2.txt'
     file2.touch()
- 
-    file3 = b / 'file3.txt'
+
+    file3 = b_dir / 'file3.txt'
     file3.touch()
 
 
@@ -61,21 +62,21 @@ def create_tree_with_symlinks_no_loop(tmp_path):
     # └── b
     #     └── file3.txt
 
-    a = tmp_path / 'a'
-    a.mkdir()
-    file1 = a / 'file1.txt'
+    a_dir = tmp_path / 'a'
+    a_dir.mkdir()
+    file1 = a_dir / 'file1.txt'
     file1.touch()
-    b = tmp_path / 'b'
-    b.mkdir()
+    b_dir = tmp_path / 'b'
+    b_dir.mkdir()
 
-    c = a / 'c'
-    c.mkdir()
-    file2 = c / 'file2.txt'
+    c_dir = a_dir / 'c'
+    c_dir.mkdir()
+    file2 = c_dir / 'file2.txt'
     file2.touch()
 
-    file3 = b / 'file3.txt'
+    file3 = b_dir / 'file3.txt'
     file3.touch()
-    symlink1 = c / 'link1'
+    symlink1 = c_dir / 'link1'
     symlink1.symlink_to(file1)
 
 
@@ -112,8 +113,8 @@ def test_walklevel_all_levels_symlinks_with_loop(tmp_path):
         walklevel_results.append(copy.deepcopy(level))
 
     assert walklevel_results == [(str(tmp_path), ['a', 'b'], [], None),
-                                 (str(tmp_path / 'a'), ['c'], ['file1.txt'], 
-                                     str(tmp_path / 'a' / 'link1')),
+                                 (str(tmp_path / 'a'), ['c'], ['file1.txt'],
+                                  str(tmp_path / 'a' / 'link1')),
                                  (str(tmp_path / 'a' / 'c'), [], ['file2.txt'], None),
                                  (str(tmp_path / 'b'), [], ['file3.txt'], None)]
 
@@ -123,10 +124,10 @@ def test_walklevel_first_level_symlinks_with_loop(tmp_path):
     walklevel_results = []
     for level in walklevel(str(tmp_path), 1, follow_symlinks=True):
         walklevel_results.append(copy.deepcopy(level))
-    
+
     assert walklevel_results == [(str(tmp_path), ['a', 'b'], [], None),
-                                 (str(tmp_path / 'a'), ['c'], ['file1.txt'], 
-                                     str(tmp_path / 'a' / 'link1')),
+                                 (str(tmp_path / 'a'), ['c'], ['file1.txt'],
+                                  str(tmp_path / 'a' / 'link1')),
                                  (str(tmp_path / 'b'), [], ['file3.txt'], None)]
 
 def test_walklevel_all_levels_symlinks_without_loop(tmp_path):
@@ -135,7 +136,7 @@ def test_walklevel_all_levels_symlinks_without_loop(tmp_path):
     walklevel_results = []
     for level in walklevel(str(tmp_path), -1, follow_symlinks=True):
         walklevel_results.append(copy.deepcopy(level))
-    
+
     assert walklevel_results == [(str(tmp_path), ['a', 'b'], [], None),
                                  (str(tmp_path / 'a'), ['c'], ['file1.txt'], None),
                                  (str(tmp_path / 'a' / 'c'), [], ['file2.txt', 'link1'], None),
@@ -147,5 +148,5 @@ def test_walklevel_zero_level_no_symlinks(tmp_path):
     walklevel_results = []
     for level in walklevel(str(tmp_path), 0):
         walklevel_results.append(copy.deepcopy(level))
- 
+
     assert walklevel_results == [(str(tmp_path), ['a', 'b'], [], None)]

--- a/tests/ranger/container/test_directory.py
+++ b/tests/ranger/container/test_directory.py
@@ -86,14 +86,10 @@ def test_walklevel_all_levels_no_symlinks(tmp_path):
     for level in walklevel(str(tmp_path), -1):
         walklevel_results.append(copy.deepcopy(level))
 
-    assert walklevel_results == [(str(tmp_path), ['a', 'b'], [],
-                                  {'existance': False, 'path': ''}),
-                                 (str(tmp_path / 'a'), ['c'], ['file1.txt'],
-                                  {'existance': False, 'path': ''}),
-                                 (str(tmp_path / 'a' / 'c'), [], ['file2.txt'],
-                                  {'existance': False, 'path': ''}),
-                                 (str(tmp_path / 'b'), [], ['file3.txt'],
-                                  {'existance': False, 'path': ''})]
+    assert walklevel_results == [(str(tmp_path), ['a', 'b'], [], None),
+                                 (str(tmp_path / 'a'), ['c'], ['file1.txt'], None),
+                                 (str(tmp_path / 'a' / 'c'), [], ['file2.txt'], None),
+                                 (str(tmp_path / 'b'), [], ['file3.txt'], None)]
 
 
 def test_walklevel_first_level_no_symlinks(tmp_path):
@@ -103,59 +99,47 @@ def test_walklevel_first_level_no_symlinks(tmp_path):
     for level in walklevel(str(tmp_path), 1):
         walklevel_results.append(copy.deepcopy(level))
 
-    assert walklevel_results == [(str(tmp_path), ['a', 'b'], [],
-                                  {'existance': False, 'path': ''}),
-                                 (str(tmp_path / 'a'), ['c'], ['file1.txt'],
-                                  {'existance': False, 'path': ''}),
-                                 (str(tmp_path / 'b'), [], ['file3.txt'],
-                                  {'existance': False, 'path': ''})]
+    assert walklevel_results == [(str(tmp_path), ['a', 'b'], [], None),
+                                 (str(tmp_path / 'a'), ['c'], ['file1.txt'], None),
+                                 (str(tmp_path / 'b'), [], ['file3.txt'], None)]
 
 
 def test_walklevel_all_levels_symlinks_with_loop(tmp_path):
     create_tree_with_symlinks_with_loop(tmp_path)
 
     walklevel_results = []
-    for level in walklevel(str(tmp_path), -1, flat_follow_symlinks=True):
+    for level in walklevel(str(tmp_path), -1, follow_symlinks=True):
         walklevel_results.append(copy.deepcopy(level))
 
-    assert walklevel_results == [(str(tmp_path), ['a', 'b'], [],
-                                  {'existance': False, 'path': ''}),
-                                 (str(tmp_path / 'a'), ['c'], ['file1.txt'],
-                                  {'existance': True, 'path': str(tmp_path / 'a' / 'link1')}),
-                                 (str(tmp_path / 'a' / 'c'), [], ['file2.txt'],
-                                  {'existance': False, 'path': ''}),
-                                 (str(tmp_path / 'b'), [], ['file3.txt'],
-                                  {'existance': False, 'path': ''})]
+    assert walklevel_results == [(str(tmp_path), ['a', 'b'], [], None),
+                                 (str(tmp_path / 'a'), ['c'], ['file1.txt'], 
+                                     str(tmp_path / 'a' / 'link1')),
+                                 (str(tmp_path / 'a' / 'c'), [], ['file2.txt'], None),
+                                 (str(tmp_path / 'b'), [], ['file3.txt'], None)]
 
 def test_walklevel_first_level_symlinks_with_loop(tmp_path):
     create_tree_with_symlinks_with_loop(tmp_path)
 
     walklevel_results = []
-    for level in walklevel(str(tmp_path), 1, flat_follow_symlinks=True):
+    for level in walklevel(str(tmp_path), 1, follow_symlinks=True):
         walklevel_results.append(copy.deepcopy(level))
     
-    assert walklevel_results == [(str(tmp_path), ['a', 'b'], [],
-                                  {'existance': False, 'path': ''}),
-                                 (str(tmp_path / 'a'), ['c'], ['file1.txt'],
-                                  {'existance': True, 'path': str(tmp_path / 'a' / 'link1')}),
-                                 (str(tmp_path / 'b'), [], ['file3.txt'],
-                                  {'existance': False, 'path': ''})]
+    assert walklevel_results == [(str(tmp_path), ['a', 'b'], [], None),
+                                 (str(tmp_path / 'a'), ['c'], ['file1.txt'], 
+                                     str(tmp_path / 'a' / 'link1')),
+                                 (str(tmp_path / 'b'), [], ['file3.txt'], None)]
 
 def test_walklevel_all_levels_symlinks_without_loop(tmp_path):
     create_tree_with_symlinks_no_loop(tmp_path)
 
     walklevel_results = []
-    for level in walklevel(str(tmp_path), -1, flat_follow_symlinks=True):
+    for level in walklevel(str(tmp_path), -1, follow_symlinks=True):
         walklevel_results.append(copy.deepcopy(level))
     
-    assert walklevel_results == [(str(tmp_path), ['a', 'b'], [],
-                                  {'existance': False, 'path': ''}),
-                                 (str(tmp_path / 'a'), ['c'], ['file1.txt'],
-                                  {'existance': False, 'path': ''}),
-                                 (str(tmp_path / 'a' / 'c'), [], ['file2.txt', 'link1'],
-                                  {'existance': False, 'path': ''}),
-                                 (str(tmp_path / 'b'), [], ['file3.txt'],
-                                  {'existance': False, 'path': ''})]
+    assert walklevel_results == [(str(tmp_path), ['a', 'b'], [], None),
+                                 (str(tmp_path / 'a'), ['c'], ['file1.txt'], None),
+                                 (str(tmp_path / 'a' / 'c'), [], ['file2.txt', 'link1'], None),
+                                 (str(tmp_path / 'b'), [], ['file3.txt'], None)]
 
 def test_walklevel_zero_level_no_symlinks(tmp_path):
     create_tree_no_symlinks(tmp_path)
@@ -164,5 +148,4 @@ def test_walklevel_zero_level_no_symlinks(tmp_path):
     for level in walklevel(str(tmp_path), 0):
         walklevel_results.append(copy.deepcopy(level))
  
-    assert walklevel_results == [(str(tmp_path), ['a', 'b'], [],
-                                  {'existance': False, 'path': ''})]
+    assert walklevel_results == [(str(tmp_path), ['a', 'b'], [], None)]

--- a/tests/ranger/container/test_directory.py
+++ b/tests/ranger/container/test_directory.py
@@ -2,13 +2,14 @@ import copy
 
 from ranger.container.directory import walklevel
 
+
 def create_tree_no_symlinks(tmp_path):
-    # ├── a
-    # │   ├── c
-    # │   │   └── file2.txt
-    # │   └── file1.txt
-    # └── b
-    #     └── file3.txt
+    # |-- a
+    # |   |-- c
+    # |   |   `-- file2.txt
+    # |   `-- file1.txt
+    # `-- b
+    #     `-- file3.txt
 
     a_dir = tmp_path / 'a'
     a_dir.mkdir()
@@ -25,14 +26,15 @@ def create_tree_no_symlinks(tmp_path):
     file3 = b_dir / 'file3.txt'
     file3.touch()
 
+
 def create_tree_with_symlinks_with_loop(tmp_path):
-    # ├── a
-    # │   ├── c
-    # │   │   └── file2.txt
-    # │   ├── file1.txt
-    # │   └── link1 -> a
-    # └── b
-    #     └── file3.txt
+    # |-- a
+    # |   |-- c
+    # |   |   `-- file2.txt
+    # |   |-- file1.txt
+    # |   `-- link1 -> a
+    # `-- b
+    #     `-- file3.txt
 
     a_dir = tmp_path / 'a'
     a_dir.mkdir()
@@ -54,13 +56,13 @@ def create_tree_with_symlinks_with_loop(tmp_path):
 
 
 def create_tree_with_symlinks_no_loop(tmp_path):
-    # ├── a
-    # │   ├── c
-    # │   │   ├── file2.txt
-    # │   │   └── link1 -> a/file1.txt
-    # │   └── file1.txt
-    # └── b
-    #     └── file3.txt
+    # |-- a
+    # |   |-- c
+    # |   |   |-- file2.txt
+    # |   |   `-- link1 -> a/file1.txt
+    # |   `-- file1.txt
+    # `-- b
+    #     `-- file3.txt
 
     a_dir = tmp_path / 'a'
     a_dir.mkdir()
@@ -118,6 +120,7 @@ def test_walklevel_all_levels_symlinks_with_loop(tmp_path):
                                  (str(tmp_path / 'a' / 'c'), [], ['file2.txt'], None),
                                  (str(tmp_path / 'b'), [], ['file3.txt'], None)]
 
+
 def test_walklevel_first_level_symlinks_with_loop(tmp_path):
     create_tree_with_symlinks_with_loop(tmp_path)
 
@@ -130,6 +133,7 @@ def test_walklevel_first_level_symlinks_with_loop(tmp_path):
                                   str(tmp_path / 'a' / 'link1')),
                                  (str(tmp_path / 'b'), [], ['file3.txt'], None)]
 
+
 def test_walklevel_all_levels_symlinks_without_loop(tmp_path):
     create_tree_with_symlinks_no_loop(tmp_path)
 
@@ -141,6 +145,7 @@ def test_walklevel_all_levels_symlinks_without_loop(tmp_path):
                                  (str(tmp_path / 'a'), ['c'], ['file1.txt'], None),
                                  (str(tmp_path / 'a' / 'c'), [], ['file2.txt', 'link1'], None),
                                  (str(tmp_path / 'b'), [], ['file3.txt'], None)]
+
 
 def test_walklevel_zero_level_no_symlinks(tmp_path):
     create_tree_no_symlinks(tmp_path)

--- a/tests/ranger/container/test_directory.py
+++ b/tests/ranger/container/test_directory.py
@@ -82,17 +82,26 @@ def create_tree_with_symlinks_no_loop(tmp_path):
     symlink1.symlink_to(file1)
 
 
+def copy_level(level):
+    level_copy = copy.deepcopy(list(level))
+    level_copy[1] = sorted(level_copy[1])  # because os.walk yields dirnames in arbitraty order
+    return tuple(level_copy)
+
+
 def test_walklevel_all_levels_no_symlinks(tmp_path):
     create_tree_no_symlinks(tmp_path)
 
     walklevel_results = []
     for level in walklevel(str(tmp_path), -1):
-        walklevel_results.append(copy.deepcopy(level))
+        walklevel_results.append(copy_level(level))
 
-    assert walklevel_results == [(str(tmp_path), ['a', 'b'], [], None),
-                                 (str(tmp_path / 'a'), ['c'], ['file1.txt'], None),
-                                 (str(tmp_path / 'a' / 'c'), [], ['file2.txt'], None),
-                                 (str(tmp_path / 'b'), [], ['file3.txt'], None)]
+    expected_levels = [(str(tmp_path), ['a', 'b'], [], None),
+                       (str(tmp_path / 'a'), ['c'], ['file1.txt'], None),
+                       (str(tmp_path / 'a' / 'c'), [], ['file2.txt'], None),
+                       (str(tmp_path / 'b'), [], ['file3.txt'], None)]
+
+    for resulting_level in walklevel_results:
+        assert resulting_level in expected_levels
 
 
 def test_walklevel_first_level_no_symlinks(tmp_path):
@@ -100,11 +109,14 @@ def test_walklevel_first_level_no_symlinks(tmp_path):
 
     walklevel_results = []
     for level in walklevel(str(tmp_path), 1):
-        walklevel_results.append(copy.deepcopy(level))
+        walklevel_results.append(copy_level(level))
 
-    assert walklevel_results == [(str(tmp_path), ['a', 'b'], [], None),
-                                 (str(tmp_path / 'a'), ['c'], ['file1.txt'], None),
-                                 (str(tmp_path / 'b'), [], ['file3.txt'], None)]
+    expected_levels = [(str(tmp_path), ['a', 'b'], [], None),
+                       (str(tmp_path / 'a'), ['c'], ['file1.txt'], None),
+                       (str(tmp_path / 'b'), [], ['file3.txt'], None)]
+
+    for resulting_level in walklevel_results:
+        assert resulting_level in expected_levels
 
 
 def test_walklevel_all_levels_symlinks_with_loop(tmp_path):
@@ -112,13 +124,16 @@ def test_walklevel_all_levels_symlinks_with_loop(tmp_path):
 
     walklevel_results = []
     for level in walklevel(str(tmp_path), -1, follow_symlinks=True):
-        walklevel_results.append(copy.deepcopy(level))
+        walklevel_results.append(copy_level(level))
 
-    assert walklevel_results == [(str(tmp_path), ['a', 'b'], [], None),
-                                 (str(tmp_path / 'a'), ['c'], ['file1.txt'],
-                                  str(tmp_path / 'a' / 'link1')),
-                                 (str(tmp_path / 'a' / 'c'), [], ['file2.txt'], None),
-                                 (str(tmp_path / 'b'), [], ['file3.txt'], None)]
+    expected_levels = [(str(tmp_path), ['a', 'b'], [], None),
+                       (str(tmp_path / 'a'), ['c'], ['file1.txt'],
+                        str(tmp_path / 'a' / 'link1')),
+                       (str(tmp_path / 'a' / 'c'), [], ['file2.txt'], None),
+                       (str(tmp_path / 'b'), [], ['file3.txt'], None)]
+
+    for resulting_level in walklevel_results:
+        assert resulting_level in expected_levels
 
 
 def test_walklevel_first_level_symlinks_with_loop(tmp_path):
@@ -126,12 +141,15 @@ def test_walklevel_first_level_symlinks_with_loop(tmp_path):
 
     walklevel_results = []
     for level in walklevel(str(tmp_path), 1, follow_symlinks=True):
-        walklevel_results.append(copy.deepcopy(level))
+        walklevel_results.append(copy_level(level))
 
-    assert walklevel_results == [(str(tmp_path), ['a', 'b'], [], None),
-                                 (str(tmp_path / 'a'), ['c'], ['file1.txt'],
-                                  str(tmp_path / 'a' / 'link1')),
-                                 (str(tmp_path / 'b'), [], ['file3.txt'], None)]
+    expected_levels = [(str(tmp_path), ['a', 'b'], [], None),
+                       (str(tmp_path / 'a'), ['c'], ['file1.txt'],
+                        str(tmp_path / 'a' / 'link1')),
+                       (str(tmp_path / 'b'), [], ['file3.txt'], None)]
+
+    for resulting_level in walklevel_results:
+        assert resulting_level in expected_levels
 
 
 def test_walklevel_all_levels_symlinks_without_loop(tmp_path):
@@ -139,12 +157,16 @@ def test_walklevel_all_levels_symlinks_without_loop(tmp_path):
 
     walklevel_results = []
     for level in walklevel(str(tmp_path), -1, follow_symlinks=True):
-        walklevel_results.append(copy.deepcopy(level))
+        walklevel_results.append(copy_level(level))
 
-    assert walklevel_results == [(str(tmp_path), ['a', 'b'], [], None),
-                                 (str(tmp_path / 'a'), ['c'], ['file1.txt'], None),
-                                 (str(tmp_path / 'a' / 'c'), [], ['file2.txt', 'link1'], None),
-                                 (str(tmp_path / 'b'), [], ['file3.txt'], None)]
+    expected_levels = [(str(tmp_path), ['a', 'b'], [], None),
+                       (str(tmp_path / 'a'), ['c'], ['file1.txt'], None),
+                       (str(tmp_path / 'a' / 'c'), [],
+                        ['file2.txt', 'link1'], None),
+                       (str(tmp_path / 'b'), [], ['file3.txt'], None)]
+
+    for resulting_level in walklevel_results:
+        assert resulting_level in expected_levels
 
 
 def test_walklevel_zero_level_no_symlinks(tmp_path):
@@ -152,6 +174,6 @@ def test_walklevel_zero_level_no_symlinks(tmp_path):
 
     walklevel_results = []
     for level in walklevel(str(tmp_path), 0):
-        walklevel_results.append(copy.deepcopy(level))
+        walklevel_results.append(copy_level(level))
 
     assert walklevel_results == [(str(tmp_path), ['a', 'b'], [], None)]


### PR DESCRIPTION
<!-- Provide a descriptive summary of the changes in the title above -->

#### ISSUE TYPE
<!-- Pick relevant types and delete the rest -->
- Bug fix

#### RUNTIME ENVIRONMENT
- Operating system and version: Ubuntu 18.04.2
- Terminal emulator and version: GNOME Terminal 3.28.2
- Python version:
3.8.2 (default, Mar 15 2020, 13:26:29) [GCC 7.4.0]
2.7.17 (default, Apr 15 2020, 17:20:14) [GCC 7.5.0]
- Ranger version/commit: ranger-master v1.9.3-24-g1654128f
- Locale: en_US.UTF-8

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [X] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [X] All changes follow the code style **[REQUIRED]**
- [X] All new and existing tests pass **[REQUIRED]**
- [ ] Changes require config files to be updated
    - [ ] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [X] Changes require tests to be updated
    - [X] Tests have been updated

#### DESCRIPTION

This PR adds symlinks handling during flat command. One can now use flag to force walking through symlinks, both for level > 0 and level = -1. In my implementation symlinks are not followed by default.
(that is different from https://github.com/ranger/ranger/commit/9f7001379a88666ad07c7d04a5164ef802499481)

Symlink loop is detected if some directory visited more than once when following symlink (naive, but working approach). When loop have been detected error message is given, pointing to symlink that caused loop, and further processing proceeds without visiting that symlink. I've provided some walklevel function unit-tests for various cases of walking through levels.

#### MOTIVATION AND CONTEXT
#1910 