### PR TITLE
WIP: make bookmarks and tags work from rc.conf

### DIFF
--- a/ranger/container/bookmarks.py
+++ b/ranger/container/bookmarks.py
@@ -202,6 +202,15 @@ class Bookmarks(FileManagerAware):
 
         self._update_mtime()
 
+    def enable_autosave(self, boolean):
+        """
+        Enable autosave, which will save bookmarks to disk instantly
+        """
+        if boolean:
+            self.autosave = True
+        else:
+            self.autosave = False
+
     def enable_saving_backtick_bookmark(self, boolean):
         """
         Adds or removes the ' from the list of nonpersitent bookmarks

--- a/ranger/core/actions.py
+++ b/ranger/core/actions.py
@@ -935,18 +935,25 @@ class Actions(  # pylint: disable=too-many-instance-attributes,too-many-public-m
         except KeyError:
             pass
 
-    def set_bookmark(self, key, val=None):
+    def set_bookmark(self, key, val=None, persistent=True):
         """Set the bookmark with the name <key> to the current directory"""
         if val is None:
             val = self.thisdir
         else:
             val = Directory(val)
         self.bookmarks.update_if_outdated()
+
+        if not persistent:
+            self.bookmarks.nonpersistent_bookmarks.remove(key)
+        else:
+            self.bookmarks.nonpersistent_bookmarks.add(key)
+
         self.bookmarks[str(key)] = val
 
     def unset_bookmark(self, key):
         """Delete the bookmark with the name <key>"""
         self.bookmarks.update_if_outdated()
+        self.bookmarks.nonpersistent_bookmarks.remove(key)
         del self.bookmarks[str(key)]
 
     def draw_bookmarks(self):

--- a/ranger/core/actions.py
+++ b/ranger/core/actions.py
@@ -8,7 +8,7 @@ from __future__ import (absolute_import, division, print_function)
 import codecs
 import os
 from os import link, symlink, listdir, stat
-from os.path import join, isdir, realpath, exists
+from os.path import join, isdir, realpath, exists, abspath
 import re
 import shlex
 import shutil
@@ -889,7 +889,7 @@ class Actions(  # pylint: disable=too-many-instance-attributes,too-many-public-m
         if paths is None:
             tags = tuple(x.realpath for x in self.thistab.get_selection())
         else:
-            tags = [realpath(path) for path in paths]
+            tags = [abspath(path) for path in paths]
         if value is True:
             self.tags.add(*tags, tag=tag or self.tags.default_tag)
         elif value is False:
@@ -909,6 +909,10 @@ class Actions(  # pylint: disable=too-many-instance-attributes,too-many-public-m
 
         Remove a tag <character>. See :tag_toggle for keyword arguments.
         """
+
+        if isinstance(paths, str):
+            paths = [paths]
+
         self.tag_toggle(tag=tag, paths=paths, value=False, movedown=movedown)
 
     def tag_add(self, tag=None, paths=None, movedown=None):
@@ -916,6 +920,10 @@ class Actions(  # pylint: disable=too-many-instance-attributes,too-many-public-m
 
         Add a tag <character>. See :tag_toggle for keyword arguments.
         """
+
+        if isinstance(paths, str):
+            paths = [paths]
+
         self.tag_toggle(tag=tag, paths=paths, value=True, movedown=movedown)
 
     # --------------------------

--- a/ranger/core/actions.py
+++ b/ranger/core/actions.py
@@ -873,7 +873,7 @@ class Actions(  # pylint: disable=too-many-instance-attributes,too-many-public-m
     # Tags are saved in ~/.config/ranger/tagged and simply mark if a
     # file is important to you in any context.
 
-    def tag_toggle(self, tag=None, paths=None, value=None, movedown=None):
+    def tag_toggle(self, tag=None, paths=None, value=None, movedown=None, persistent=True):
         """:tag_toggle <character>
 
         Toggle a tag <character>.
@@ -889,13 +889,13 @@ class Actions(  # pylint: disable=too-many-instance-attributes,too-many-public-m
         if paths is None:
             tags = tuple(x.realpath for x in self.thistab.get_selection())
         else:
-            tags = [abspath(path) for path in paths]
+            tags = [realpath(path) for path in paths]
         if value is True:
-            self.tags.add(*tags, tag=tag or self.tags.default_tag)
+            self.tags.add(*tags, tag=tag or self.tags.default_tag, persistent=persistent)
         elif value is False:
             self.tags.remove(*tags)
         else:
-            self.tags.toggle(*tags, tag=tag or self.tags.default_tag)
+            self.tags.toggle(*tags, tag=tag or self.tags.default_tag, persistent=persistent)
 
         if movedown is None:
             movedown = len(tags) == 1 and paths is None
@@ -915,7 +915,7 @@ class Actions(  # pylint: disable=too-many-instance-attributes,too-many-public-m
 
         self.tag_toggle(tag=tag, paths=paths, value=False, movedown=movedown)
 
-    def tag_add(self, tag=None, paths=None, movedown=None):
+    def tag_add(self, tag=None, paths=None, movedown=None, persistent=True):
         """:tag_add <character>
 
         Add a tag <character>. See :tag_toggle for keyword arguments.
@@ -924,7 +924,7 @@ class Actions(  # pylint: disable=too-many-instance-attributes,too-many-public-m
         if isinstance(paths, str):
             paths = [paths]
 
-        self.tag_toggle(tag=tag, paths=paths, value=True, movedown=movedown)
+        self.tag_toggle(tag=tag, paths=paths, value=True, movedown=movedown, persistent=persistent)
 
     # --------------------------
     # -- Bookmarks

--- a/ranger/core/fm.py
+++ b/ranger/core/fm.py
@@ -78,7 +78,7 @@ class FM(Actions,  # pylint: disable=too-many-instance-attributes
         mimetypes.knownfiles.append(self.relpath('data/mime.types'))
         self.mimetypes = mimetypes.MimeTypes()
 
-        # initialize bookmarks, so they can be set while loading config
+        # initialize bookmarks and tags, so they can be set while loading config
         if ranger.args.clean:
             bookmarkfile = None
         else:
@@ -88,6 +88,11 @@ class FM(Actions,  # pylint: disable=too-many-instance-attributes
             bookmarktype=Directory,
             autosave=False)
         self.bookmarks.load()
+
+        if ranger.args.clean:
+            self.tags = TagsDummy("")
+        elif self.tags is None:
+            self.tags = Tags(self.datapath('tagged'))
 
     def initialize(self):
         """If ui/bookmarks are None, they will be initialized here."""
@@ -120,11 +125,6 @@ class FM(Actions,  # pylint: disable=too-many-instance-attributes
             'setopt.preview_images',
             lambda signal: signal.fm.previews.clear(),
         )
-
-        if ranger.args.clean:
-            self.tags = TagsDummy("")
-        elif self.tags is None:
-            self.tags = Tags(self.datapath('tagged'))
 
         # respect the setting set for bookmarks
         if self.bookmarks is not None:

--- a/ranger/core/fm.py
+++ b/ranger/core/fm.py
@@ -78,6 +78,17 @@ class FM(Actions,  # pylint: disable=too-many-instance-attributes
         mimetypes.knownfiles.append(self.relpath('data/mime.types'))
         self.mimetypes = mimetypes.MimeTypes()
 
+        # initialize bookmarks, so they can be set while loading config
+        if ranger.args.clean:
+            bookmarkfile = None
+        else:
+            bookmarkfile = self.datapath('bookmarks')
+        self.bookmarks = Bookmarks(
+            bookmarkfile=bookmarkfile,
+            bookmarktype=Directory,
+            autosave=False)
+        self.bookmarks.load()
+
     def initialize(self):
         """If ui/bookmarks are None, they will be initialized here."""
 
@@ -115,16 +126,9 @@ class FM(Actions,  # pylint: disable=too-many-instance-attributes
         elif self.tags is None:
             self.tags = Tags(self.datapath('tagged'))
 
-        if self.bookmarks is None:
-            if ranger.args.clean:
-                bookmarkfile = None
-            else:
-                bookmarkfile = self.datapath('bookmarks')
-            self.bookmarks = Bookmarks(
-                bookmarkfile=bookmarkfile,
-                bookmarktype=Directory,
-                autosave=self.settings.autosave_bookmarks)
-            self.bookmarks.load()
+        # respect the setting set for bookmarks
+        if self.bookmarks is not None:
+            self.bookmarks.enable_autosave(self.settings.autosave_bookmarks)
             self.bookmarks.enable_saving_backtick_bookmark(
                 self.settings.save_backtick_bookmark)
 

--- a/ranger/core/main.py
+++ b/ranger/core/main.py
@@ -115,6 +115,12 @@ def main(
     exit_msg = ''
     exit_code = 0
     try:  # pylint: disable=too-many-nested-blocks
+        # Initialize data directory before initializing objects
+        if not args.clean:
+            # Create data directory
+            if not os.path.exists(args.datadir):
+                os.makedirs(args.datadir)
+
         # Initialize objects
         fm = FM(paths=paths)
         FileManagerAware.fm_set(fm)
@@ -149,10 +155,6 @@ def main(
             curses_interrupt_handler.install_interrupt_handler()
 
         if not args.clean:
-            # Create data directory
-            if not os.path.exists(args.datadir):
-                os.makedirs(args.datadir)
-
             # Restore saved tabs
             tabs_datapath = fm.datapath('tabs')
             if fm.settings.save_tabs_on_exit and os.path.exists(tabs_datapath) and not args.paths:


### PR DESCRIPTION
Ability to specify `set_bookmark` and `tag_add` in rc.conf, and make them non-persistent as not to add them to `bookmarks` and `tagged` as well.

#### ISSUE TYPE
<!-- Pick relevant types and delete the rest -->
- Improvement/feature implementation

#### RUNTIME ENVIRONMENT
<!-- Details of your runtime environment -->
<!-- Retrieve Python/ranger version and locale with `ranger -\-version` -->
#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [ ] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [ ] All changes follow the code style **[REQUIRED]**
- [ ] All new and existing tests pass **[REQUIRED]**
- [ ] Changes require config files to be updated
    - [ ] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
<!-- Describe the changes in detail -->


#### MOTIVATION AND CONTEXT
<!-- Why are these changes required? -->
<!-- What problems do these changes solve? -->
<!-- Link to relevant issues -->


#### TESTING
<!-- What tests have been run? -->
<!-- How does the changes affect other areas of the codebase? -->


#### IMAGES / VIDEOS<!-- Only if relevant -->
<!-- Link or embed images and videos of screenshots, sketches etc. -->
