### PR TITLE
Apply refactored function name to bind command on example script

### DIFF
--- a/examples/shell_automatic_cd.sh
+++ b/examples/shell_automatic_cd.sh
@@ -19,5 +19,9 @@ ranger_cd() {
     rm -f -- "$temp_file"
 }
 
-# This binds Ctrl-O to ranger_cd:
-bind '"\C-o":"ranger_cd\C-m"'
+# This binds Ctrl-O to ranger_cd on bash or zsh:
+if [ -n "${ZSH_VERSION:+x}" ]; then
+    bindkey -s "\C-o" "ranger_cd\C-m"
+else
+    bind '"\C-o":"ranger_cd\C-m"'
+fi

--- a/examples/shell_automatic_cd.sh
+++ b/examples/shell_automatic_cd.sh
@@ -19,5 +19,5 @@ ranger_cd() {
     rm -f -- "$temp_file"
 }
 
-# This binds Ctrl-O to ranger-cd:
-bind '"\C-o":"ranger-cd\C-m"'
+# This binds Ctrl-O to ranger_cd:
+bind '"\C-o":"ranger_cd\C-m"'


### PR DESCRIPTION
<!-- Provide a descriptive summary of the changes in the title above -->

#### ISSUE TYPE
<!-- Pick relevant types and delete the rest -->
- Breaking changes

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [x] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [x] All changes follow the code style **[REQUIRED]**
- [x] All new and existing tests pass **[REQUIRED]**

#### DESCRIPTION
<!-- Describe the changes in detail -->
Function name was refactored from `ranger-cd` to `ranger_cd` in #1743, but it hadn't applied to the bind command at the bottom.

#### OTHER ISSUE
Maybe I should create an Issue for it? Anyway, in the comments,
```
# directory to the last visited one after ranger quits. Either put it into your
# .zshrc/.bashrc/etc or source this file from your shell configuration.
```
This implies sourcing it would also work in zsh and other shells with key binding feature out of the box, but it's not:
The function's compatible with zsh but I found out `bind` is bash's built-in command,  
`bindkey -s "\C-o" "ranger_cd\C-m"` works on zsh.