### PR TITLE
:touch create missing directories

### DIFF
--- a/ranger/config/commands.py
+++ b/ranger/config/commands.py
@@ -928,10 +928,14 @@ class touch(Command):
     """
 
     def execute(self):
-        from os.path import join, expanduser, lexists
+        from os.path import join, expanduser, lexists, dirname
+        from os import makedirs
 
         fname = join(self.fm.thisdir.path, expanduser(self.rest(1)))
+        dirname = dirname(fname)
         if not lexists(fname):
+            if not lexists(dirname):
+                makedirs(dirname)
             open(fname, 'a').close()
         else:
             self.fm.notify("file/directory exists!", bad=True)


### PR DESCRIPTION
`:mkdir` creates directories recursively like `mkdir -p`.
`:touch` failed when parent directories didn't exist, for convenience
and consistency it now creates missing directories recursively.

Fixes #1998