### PR TITLE
Fix: can't automatically refresh statusbar

### DIFF
--- a/ranger/__init__.py
+++ b/ranger/__init__.py
@@ -36,7 +36,7 @@ def version_helper():
 # Information
 __license__ = 'GPL3'
 __version__ = '1.9.3'
-__release__ = True
+__release__ = False
 __author__ = __maintainer__ = 'Roman Zimbelmann'
 __email__ = 'hut@hut.pm'
 

--- a/ranger/ext/vcs/vcs.py
+++ b/ranger/ext/vcs/vcs.py
@@ -246,7 +246,8 @@ class VcsRoot(Vcs):  # pylint: disable=abstract-method
         try:
             self.head = self.data_info(self.HEAD)
             self.branch = self.data_branch()
-            self.status_subpaths = self.data_status_subpaths()
+            if not self.obj.flat:
+                self.status_subpaths = self.data_status_subpaths()
             self.obj.vcsremotestatus = self.data_status_remote()
             self.obj.vcsstatus = self._status_root()
         except VcsError as ex:

--- a/ranger/ext/vcs/vcs.py
+++ b/ranger/ext/vcs/vcs.py
@@ -325,26 +325,6 @@ class VcsRoot(Vcs):  # pylint: disable=abstract-method
         if purge:
             self.__init__(self.obj)
 
-    def check_outdated(self):
-        """Check if root is outdated"""
-        if self.updatetime is None:
-            return True
-
-        for wroot, wdirs, _ in os.walk(self.path):
-            wrootobj = self.obj.fm.get_directory(wroot)
-            wrootobj.load_if_outdated()
-            if wroot != self.path and wrootobj.vcs.is_root_pointer:
-                wdirs[:] = []
-                continue
-
-            if wrootobj.stat and self.updatetime < wrootobj.stat.st_mtime:
-                return True
-            if wrootobj.files_all:
-                for wfile in wrootobj.files_all:
-                    if wfile.stat and self.updatetime < wfile.stat.st_mtime:
-                        return True
-        return False
-
     def status_subpath(self, path, is_directory=False):
         """
         Returns the status of path
@@ -439,7 +419,7 @@ class VcsThread(threading.Thread):  # pylint: disable=too-many-instance-attribut
             dirobj.vcs.reinit()
             if dirobj.vcs.track:
                 rootvcs = dirobj.vcs.rootvcs
-                if rootvcs.path not in self._roots and rootvcs.check_outdated():
+                if rootvcs.path not in self._roots:
                     self._roots.add(rootvcs.path)
                     if rootvcs.update_root():
                         rootvcs.update_tree()

--- a/ranger/gui/ansi.py
+++ b/ranger/gui/ansi.py
@@ -59,6 +59,8 @@ def text_with_fg_bg_attr(ansi_text):  # pylint: disable=too-many-branches,too-ma
 
                 elif n == 1:                      # enable attribute
                     attr |= color.bold
+                elif n == 3:
+                    attr |= color.italic
                 elif n == 4:
                     attr |= color.underline
                 elif n == 5:

--- a/ranger/gui/color.py
+++ b/ranger/gui/color.py
@@ -15,6 +15,7 @@ bool(attr & reverse) # => False
 
 from __future__ import (absolute_import, division, print_function)
 
+import sys
 import curses
 
 DEFAULT_FOREGROUND = curses.COLOR_WHITE
@@ -62,6 +63,7 @@ default    = -1
 
 normal     = curses.A_NORMAL
 bold       = curses.A_BOLD
+italic     = curses.A_ITALIC if sys.version_info >= (3, 7) else normal
 blink      = curses.A_BLINK
 reverse    = curses.A_REVERSE
 underline  = curses.A_UNDERLINE

--- a/ranger/gui/ui.py
+++ b/ranger/gui/ui.py
@@ -409,6 +409,7 @@ class UI(  # pylint: disable=too-many-instance-attributes,too-many-public-method
                 self.browser.columns[-1].draw_image()
 
     def close_pager(self):
+        self.browser.columns[-1].scroll_extra = self.pager.scroll_begin
         if self.console.visible:
             self.console.focused = True
         self.pager.close()
@@ -424,6 +425,7 @@ class UI(  # pylint: disable=too-many-instance-attributes,too-many-public-method
         self.pager.visible = True
         self.pager.focused = True
         self.browser.visible = False
+        self.pager.scroll_begin = self.browser.columns[-1].scroll_extra
         return self.pager
 
     def open_embedded_pager(self):

--- a/ranger/gui/widgets/statusbar.py
+++ b/ranger/gui/widgets/statusbar.py
@@ -42,6 +42,8 @@ class StatusBar(Widget):  # pylint: disable=too-many-instance-attributes
         self.column = column
         self.settings.signal_bind('setopt.display_size_in_status_bar',
                                   self.request_redraw, weak=True)
+        for opt in ('hidden_filter', 'show_hidden'):
+            self.settings.signal_bind('setopt.' + opt, self.request_redraw, weak=True)
 
     def request_redraw(self):
         self.need_redraw = True


### PR DESCRIPTION
<!-- Provide a descriptive summary of the changes in the title above -->

#### ISSUE TYPE
<!-- Pick relevant types and delete the rest -->
- Bug fix


#### RUNTIME ENVIRONMENT
<!-- Details of your runtime environment -->
<!-- Retrieve Python/ranger version and locale with `ranger -\-version` -->
- Operating system and version: ArchLinux
- Terminal emulator and version: Alacritty
- Python version: 3.83
- Ranger version/commit: master
- Locale: 

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [x] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [x] All changes follow the code style **[REQUIRED]**
- [x] All new and existing tests pass **[REQUIRED]**
- [ ] Changes require config files to be updated
    - [ ] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
<!-- Describe the changes in detail -->
After set hidden_filter or show_hidden, statusbar can't refresh the latest statistics of the directory data.


#### MOTIVATION AND CONTEXT
<!-- Why are these changes required? -->
<!-- What problems do these changes solve? -->
<!-- Link to relevant issues -->
use signal bind to solve this issue.

#### TESTING
<!-- What tests have been run? -->
<!-- How does the changes affect other areas of the codebase? -->


#### IMAGES / VIDEOS<!-- Only if relevant -->
<!-- Link or embed images and videos of screenshots, sketches etc. -->
