### PR TITLE
Default to python3 at install, fall back to python

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,9 +8,9 @@ VERSION_RIFLE = $(VERSION)
 SNAPSHOT_NAME ?= $(NAME)-$(VERSION)-$(shell git rev-parse HEAD | cut -b 1-8).tar.gz
 # Find suitable python version (need python >= 2.6 or 3.1):
 PYTHON ?= $(shell \
-	     (python -c 'import sys; sys.exit(sys.version < "2.6")' && \
+	     (which python3) \
+	     || (python -c 'import sys; sys.exit(sys.version < "2.6")' && \
 	      which python) \
-	     || (which python3) \
 	     || (python2 -c 'import sys; sys.exit(sys.version < "2.6")' && \
 	         which python2) \
 	   )


### PR DESCRIPTION
Since `python` is supposed to always point to a python 2.x executable
and python 2.x is no longer supported by the PSF, we should try to
install with `python3` by default and fall back to `python` and then
`python2`.

Fixes #2006