### PR TITLE
added w3mimgdisplay render location fix for tmux panes

### DIFF
--- a/ranger/ext/img_display.py
+++ b/ranger/ext/img_display.py
@@ -198,9 +198,24 @@ class W3MImageDisplayer(ImageDisplayer, FileManagerAware):
 
         fontw, fonth = self._get_font_dimensions()
 
+        # change the offset for panes if tmux is running
+        tmux_offset_x = 0
+        tmux_offset_y = 0
+        if 'TMUX' in os.environ:
+            tmux_cmd = "tmux display -pt \"${TMUX_PANE:?}\" '#{pane_left} #{pane_top} #{status-position}'"
+            tmux_offset_proc = Popen(tmux_cmd, shell=True, stdout=PIPE)
+            tmux_offset = tmux_offset_proc.stdout.read().decode().split()
+            tmux_offset_x = int(tmux_offset[0])
+            tmux_offset_y = int(tmux_offset[1])
+            if tmux_offset[2] == "top":
+                tmux_offset_y += 1
+
+        start_x = int((start_x - 0.2) * fontw) + (tmux_offset_x * fontw)
+        start_y = (start_y * fonth) + (tmux_offset_y * fonth)
+
         cmd = "6;{x};{y};{w};{h}\n4;\n3;\n".format(
-            x=int((start_x - 0.2) * fontw),
-            y=start_y * fonth,
+            x=start_x,
+            y=start_y,
             # y = int((start_y + 1) * fonth), # (for tmux top status bar)
             w=int((width + 0.4) * fontw),
             h=height * fonth + 1,
@@ -253,8 +268,20 @@ class W3MImageDisplayer(ImageDisplayer, FileManagerAware):
             width = (width * max_height_pixels) // height
             height = max_height_pixels
 
-        start_x = int((start_x - 0.2) * fontw) + self.fm.settings.w3m_offset
-        start_y = (start_y * fonth) + self.fm.settings.w3m_offset
+        # change the offset for panes if tmux is running
+        tmux_offset_x = 0
+        tmux_offset_y = 0
+        if 'TMUX' in os.environ:
+            tmux_cmd = "tmux display -pt \"${TMUX_PANE:?}\" '#{pane_left} #{pane_top} #{status-position}'"
+            tmux_offset_proc = Popen(tmux_cmd, shell=True, stdout=PIPE)
+            tmux_offset = tmux_offset_proc.stdout.read().decode().split()
+            tmux_offset_x = int(tmux_offset[0])
+            tmux_offset_y = int(tmux_offset[1])
+            if tmux_offset[2] == "top":
+                tmux_offset_y += 1
+
+        start_x = int((start_x - 0.2) * fontw) + self.fm.settings.w3m_offset + (tmux_offset_x * fontw)
+        start_y = (start_y * fonth) + self.fm.settings.w3m_offset + (tmux_offset_y * fonth)
 
         return "0;1;{x};{y};{w};{h};;;;;{filename}\n4;\n3;\n".format(
             x=start_x,


### PR DESCRIPTION
<!-- Provide a descriptive summary of the changes in the title above -->
Added some slight awareness to the ImageDisplayer for w3m so that images would be rendered in the appropriate tmux pane.

#### ISSUE TYPE
<!-- Pick relevant types and delete the rest -->
- Bug fix

#### RUNTIME ENVIRONMENT
<!-- Details of your runtime environment -->
<!-- Retrieve Python/ranger version and locale with `ranger -\-version` -->
- Operating system and version: Arch Linux (kernel 5.7.6-arch1-1)
- Terminal emulator and version: rxvt-unicode-pixbuf, 9.22-2, running tmux 3.1_b-1
- Python version: 3.8.3-1
- Ranger version/commit: 1.9.3/4bb83b3
- Locale: en_US.UTF-8

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [X] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [X] All changes follow the code style **[REQUIRED]**
- [X] All new and existing tests pass **[REQUIRED]**
- [ ] Changes require config files to be updated
    - [ ] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
<!-- Describe the changes in detail -->
The _generate_w3m_input() and clear() methods of the W3MImageDisplayer class would choose a point in the terminal to draw the image, which works unless you're using ranger within tmux and tmux has been split into panes, and ranger isn't running in the top-left pane. I've edited those methods to call tmux if the TMUX environment variable is set, to grab where the current pane starts, and add those values to start_x and start_y.

#### MOTIVATION AND CONTEXT
<!-- Why are these changes required? -->
I believe many people use tmux, and many people like the image previews in ranger. Making them work better together increases usability.

<!-- What problems do these changes solve? -->
This solves an image-rendering issue.

<!-- Link to relevant issues -->

#### TESTING
<!-- What tests have been run? -->
"make test" has been run, which returned that two of my lines were too long (which appears to be relatively acceptable? let me know if that needs to change)
<!-- How does the changes affect other areas of the codebase? -->
It doesn't affect other areas of the codebase.


#### IMAGES / VIDEOS<!-- Only if relevant -->
<!-- Link or embed images and videos of screenshots, sketches etc. -->
![Before](https://user-images.githubusercontent.com/25126607/85954539-c0fa6380-b93d-11ea-8d96-a7cc01ab2bc0.png)
![After](https://user-images.githubusercontent.com/25126607/85954572-0b7be000-b93e-11ea-9645-260543f827d5.png)
