### PR TITLE
Typo in the command binding

### DIFF
--- a/examples/shell_automatic_cd.sh
+++ b/examples/shell_automatic_cd.sh
@@ -19,5 +19,5 @@ ranger_cd() {
     rm -f -- "$temp_file"
 }
 
-# This binds Ctrl-O to ranger-cd:
-bind '"\C-o":"ranger-cd\C-m"'
+# This binds Ctrl-O to ranger_cd:
+bind '"\C-o":"ranger_cd\C-m"'


### PR DESCRIPTION
The shell function is called `ranger_cd`, but the `bind` command has a typo, `ranger-cd`.