### PR TITLE
Catch Ueberzug error

### DIFF
--- a/ranger/ext/img_display.py
+++ b/ranger/ext/img_display.py
@@ -745,12 +745,16 @@ class UeberzugImageDisplayer(ImageDisplayer, FileManagerAware):
         self.initialize()
         self.ueberzug_stderr.seek(0, os.SEEK_END)
         err_pos = self.ueberzug_stderr.tell()
+        self.fm.notify("offset: {0}".format(err_pos))
         self.process.stdin.write(json.dumps(kwargs) + '\n')
         self.process.stdin.flush()
+        self.fm.notify("offset after write: {0}".format(self.ueberzug_stderr.tell()))
         self.ueberzug_stderr.seek(0, os.SEEK_END)
+        self.fm.notify("offset after seek: {0}".format(self.ueberzug_stderr.tell()))
         if err_pos != self.ueberzug_stderr.tell():
             self.ueberzug_stderr.seek(self.err_pos)
             err = self.ueberzug_stderr.read()
+            self.fm.notify("err: <{0}>".format(err))
             if err != "":
                 self.fm.notify(err, bad=True)
 

--- a/ranger/ext/img_display.py
+++ b/ranger/ext/img_display.py
@@ -28,7 +28,7 @@ from collections import defaultdict
 import termios
 from contextlib import contextmanager
 import codecs
-from tempfile import NamedTemporaryFile
+from tempfile import NamedTemporaryFile, TemporaryFile
 
 from ranger.core.shared import FileManagerAware
 
@@ -735,7 +735,8 @@ class UeberzugImageDisplayer(ImageDisplayer, FileManagerAware):
             return
 
         self.process = Popen(['ueberzug', 'layer', '--silent'],
-                             cwd=self.working_dir, stdin=PIPE, stderr=PIPE,
+                             cwd=self.working_dir, stdin=PIPE,
+                             stderr=TemporaryFile(),
                              universal_newlines=True)
         self.is_initialized = True
 

--- a/ranger/ext/img_display.py
+++ b/ranger/ext/img_display.py
@@ -737,17 +737,16 @@ class UeberzugImageDisplayer(ImageDisplayer, FileManagerAware):
         self.process = Popen(['ueberzug', 'layer', '--silent'],
                              cwd=self.working_dir, stdin=PIPE, stderr=PIPE,
                              universal_newlines=True)
-        flags = fcntl.fcntl(self.process.stderr, fcntl.F_GETFL)
-        fcntl.fcntl(self.process.stderr, fcntl.F_SETFL, flags | os.O_NONBLOCK)
         self.is_initialized = True
 
     def _execute(self, **kwargs):
         self.initialize()
         self.process.stdin.write(json.dumps(kwargs) + '\n')
         self.process.stdin.flush()
-        err = self.process.stderr.read()
-        if err != "":
-            self.fm.notify(err, bad=True)
+        if self.process.poll():
+            err = self.process.stderr.read()
+            if err != "":
+                self.fm.notify(err, bad=True)
 
     def draw(self, path, start_x, start_y, width, height):
         self._execute(

--- a/ranger/ext/img_display.py
+++ b/ranger/ext/img_display.py
@@ -717,7 +717,7 @@ class KittyImageDisplayer(ImageDisplayer, FileManagerAware):
 
 
 @register_image_displayer("ueberzug")
-class UeberzugImageDisplayer(ImageDisplayer):
+class UeberzugImageDisplayer(ImageDisplayer, FileManagerAware):
     """Implementation of ImageDisplayer using ueberzug.
     Ueberzug can display images in a Xorg session.
     Does not work over ssh.
@@ -734,14 +734,20 @@ class UeberzugImageDisplayer(ImageDisplayer):
                 and not self.process.stdin.closed):
             return
 
-        self.process = Popen(['ueberzug', 'layer', '--silent'], cwd=self.working_dir,
-                             stdin=PIPE, universal_newlines=True)
+        self.process = Popen(['ueberzug', 'layer', '--silent'],
+                             cwd=self.working_dir, stdin=PIPE, stderr=PIPE,
+                             universal_newlines=True)
+        flags = fcntl.fcntl(self.process.stderr, fcntl.F_GETFL)
+        fcntl.fcntl(self.process.stderr, fcntl.F_SETFL, flags | os.O_NONBLOCK)
         self.is_initialized = True
 
     def _execute(self, **kwargs):
         self.initialize()
         self.process.stdin.write(json.dumps(kwargs) + '\n')
         self.process.stdin.flush()
+        err = self.process.stderr.read()
+        if err != "":
+            self.fm.notify(err, bad=True)
 
     def draw(self, path, start_x, start_y, width, height):
         self._execute(

--- a/ranger/ext/img_display.py
+++ b/ranger/ext/img_display.py
@@ -741,9 +741,13 @@ class UeberzugImageDisplayer(ImageDisplayer, FileManagerAware):
 
     def _execute(self, **kwargs):
         self.initialize()
+        self.process.stderr.seek(0, os.SEEK_END)
+        err_pos = self.process.stderr.tell()
         self.process.stdin.write(json.dumps(kwargs) + '\n')
         self.process.stdin.flush()
-        if self.process.poll():
+        self.process.stderr.seek(0, os.SEEK_END)
+        if err_pos != self.process.stderr.tell():
+            self.process.stderr.seek(self.err_pos)
             err = self.process.stderr.read()
             if err != "":
                 self.fm.notify(err, bad=True)

--- a/ranger/ext/img_display.py
+++ b/ranger/ext/img_display.py
@@ -734,22 +734,23 @@ class UeberzugImageDisplayer(ImageDisplayer, FileManagerAware):
                 and not self.process.stdin.closed):
             return
 
+        self.ueberzug_stderr = TemporaryFile()
         self.process = Popen(['ueberzug', 'layer', '--silent'],
                              cwd=self.working_dir, stdin=PIPE,
-                             stderr=TemporaryFile(),
+                             stderr=self.ueberzug_stderr,
                              universal_newlines=True)
         self.is_initialized = True
 
     def _execute(self, **kwargs):
         self.initialize()
-        self.process.stderr.seek(0, os.SEEK_END)
-        err_pos = self.process.stderr.tell()
+        self.ueberzug_stderr.seek(0, os.SEEK_END)
+        err_pos = self.ueberzug_stderr.tell()
         self.process.stdin.write(json.dumps(kwargs) + '\n')
         self.process.stdin.flush()
-        self.process.stderr.seek(0, os.SEEK_END)
-        if err_pos != self.process.stderr.tell():
-            self.process.stderr.seek(self.err_pos)
-            err = self.process.stderr.read()
+        self.ueberzug_stderr.seek(0, os.SEEK_END)
+        if err_pos != self.ueberzug_stderr.tell():
+            self.ueberzug_stderr.seek(self.err_pos)
+            err = self.ueberzug_stderr.read()
             if err != "":
                 self.fm.notify(err, bad=True)
 


### PR DESCRIPTION
Display any Ueberzug errors using the ranger notification machinery so
they don't mess up the interface and appear in the log.

Fixes #2023