### PR TITLE
Hashlib requires objects implementing the buffer API

### DIFF
--- a/ranger/core/actions.py
+++ b/ranger/core/actions.py
@@ -1048,10 +1048,10 @@ class Actions(  # pylint: disable=too-many-instance-attributes,too-many-public-m
 
     @staticmethod
     def sha512_encode(path, inode=None):
-        if not inode:
+        if inode is None:
             inode = stat(path).st_ino
         sha = sha512(
-            os.path.join(path, str(inode)).encode('utf-8','backslashescape')
+            "{0}{1}".format(path, str(inode)).encode('utf-8', 'backslashescape')
         )
         return '{0}.jpg'.format(sha.hexdigest())
 

--- a/ranger/core/actions.py
+++ b/ranger/core/actions.py
@@ -13,7 +13,6 @@ import re
 import shlex
 import shutil
 import string
-import struct
 import tempfile
 from inspect import cleandoc
 from stat import S_IEXEC
@@ -1050,9 +1049,11 @@ class Actions(  # pylint: disable=too-many-instance-attributes,too-many-public-m
     @staticmethod
     def sha512_encode(path):
         stat_ = stat(path)
-        sha = sha512('{dev},{inode},{mtime}'.format(
-            dev=stat_.st_dev, inode=stat_.st_ino, mtime=stat_.st_mtime).encode(
-                'utf-8', 'backslashreplace'))
+        sha = sha512(
+            '{dev},{inode},{mtime}'.format(
+                dev=stat_.st_dev, inode=stat_.st_ino, mtime=stat_.st_mtime
+            ).encode('utf-8', 'backslashreplace')
+        )
         return '{0}.jpg'.format(sha.hexdigest())
 
     def get_preview(self, fobj, width, height):  # pylint: disable=too-many-return-statements

--- a/ranger/core/actions.py
+++ b/ranger/core/actions.py
@@ -1052,10 +1052,9 @@ class Actions(  # pylint: disable=too-many-instance-attributes,too-many-public-m
         stat_ = stat(path)
         # How I arrived at the pack format string:
         #   < -> little-endian
-        #   l -> st_dev: signed int (32/64 bits depending on platform)
         #   L -> st_ino: unsigned int (ditto)
         #   d -> st_mtime: double in python
-        sha = sha512(pack('<lLd', stat_.st_dev, stat_.st_ino, stat_.st_mtime))
+        sha = sha512(pack('<Ld', stat_.st_ino, stat_.st_mtime))
         return '{0}.jpg'.format(sha.hexdigest())
 
     def get_preview(self, fobj, width, height):  # pylint: disable=too-many-return-statements

--- a/ranger/core/actions.py
+++ b/ranger/core/actions.py
@@ -13,6 +13,7 @@ import re
 import shlex
 import shutil
 import string
+import struct
 import tempfile
 from inspect import cleandoc
 from stat import S_IEXEC
@@ -1049,9 +1050,9 @@ class Actions(  # pylint: disable=too-many-instance-attributes,too-many-public-m
     @staticmethod
     def sha512_encode(path):
         stat_ = stat(path)
-        sha = sha512(stat_.st_dev)
-        sha.update(stat_.st_ino)
-        sha.update(stat_.st_mtime)
+        sha = sha512('{dev},{inode},{mtime}'.format(
+            dev=stat_.st_dev, inode=stat_.st_ino, mtime=stat_.st_mtime).encode(
+                'utf-8', 'backslashreplace'))
         return '{0}.jpg'.format(sha.hexdigest())
 
     def get_preview(self, fobj, width, height):  # pylint: disable=too-many-return-statements


### PR DESCRIPTION
The hashes from python's hashlib only support objects that implement the
buffer API. Bytes objects (python 2 string, python 3 string.encode())
are such objects.

Passing fields from a stat object to a hash directly caused crashes
whenever ranger checked for an image preview.

Fixes #2032