### PR TITLE
After touch and mkdir, automatically select generated file or dir

### DIFF
--- a/ranger/config/commands.py
+++ b/ranger/config/commands.py
@@ -914,8 +914,10 @@ class mkdir(Command):
         dirname = join(self.fm.thisdir.path, expanduser(self.rest(1)))
         if not lexists(dirname):
             makedirs(dirname)
+            self.fm.get_directory(os.path.dirname(dirname)).load_content(schedule=False)
         else:
-            self.fm.notify("file/directory exists!", bad=True)
+            self.fm.notify("file/directory exists!")
+        self.fm.select_file(dirname)
 
     def tab(self, tabnum):
         return self._tab_directory_content()
@@ -933,8 +935,11 @@ class touch(Command):
         fname = join(self.fm.thisdir.path, expanduser(self.rest(1)))
         if not lexists(fname):
             open(fname, 'a').close()
+            self.fm.get_directory(os.path.dirname(fname)).load_content(schedule=False)
         else:
-            self.fm.notify("file/directory exists!", bad=True)
+            self.fm.notify("file/directory exists!")
+            os.utime(fname)
+        self.fm.select_file(fname)
 
     def tab(self, tabnum):
         return self._tab_directory_content()


### PR DESCRIPTION


<!-- Provide a descriptive summary of the changes in the title above -->

#### ISSUE TYPE
<!-- Pick relevant types and delete the rest -->
- Improvement/feature implementation

#### RUNTIME ENVIRONMENT
<!-- Details of your runtime environment -->
<!-- Retrieve Python/ranger version and locale with `ranger -\-version` -->
- Operating system and version: ArchLinux
- Terminal emulator and version: Alacritty
- Python version:  3.8
- Ranger version/commit: v1.9.3
- Locale: 

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [x] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [x] All changes follow the code style **[REQUIRED]**
- [x] All new and existing tests pass **[REQUIRED]**
- [ ] Changes require config files to be updated
    - [ ] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
<!-- Describe the changes in detail -->
Use directory.load_content(schedule=False) force update content.

#### MOTIVATION AND CONTEXT
<!-- Why are these changes required? -->
<!-- What problems do these changes solve? -->
<!-- Link to relevant issues -->
Improve https://github.com/ranger/ranger/issues/2026 and https://github.com/ranger/ranger/issues/1028
directory.files_all will not update when creating new file or dir because
directory.load_content without parameter schedule=False is asynchronous

#### TESTING
<!-- What tests have been run? -->
<!-- How does the changes affect other areas of the codebase? -->


#### IMAGES / VIDEOS<!-- Only if relevant -->
<!-- Link or embed images and videos of screenshots, sketches etc. -->
