### PR TITLE
fix macros quoting in console command

### DIFF
--- a/ranger/config/commands.py
+++ b/ranger/config/commands.py
@@ -830,7 +830,14 @@ class console(Command):
     """:console <command>
 
     Open the console with the given command.
+    Add shell-like macros escaping if given command need it.
     """
+    def __init__(self, *args, **kwargs):
+        super(console, self).__init__(*args, **kwargs)
+
+        command_class = self.fm.commands.get_command(self.arg(1))
+        if command_class:
+            self.escape_macros_for_shell = command_class.escape_macros_for_shell
 
     def execute(self):
         position = None


### PR DESCRIPTION
<!-- Provide a descriptive summary of the changes in the title above -->

#### ISSUE TYPE
<!-- Pick relevant types and delete the rest -->
- Bug fix

#### RUNTIME ENVIRONMENT
<!-- Details of your runtime environment -->
<!-- Retrieve Python/ranger version and locale with `ranger -\-version` -->
Operating system and version: Ubuntu 18.04.2
Terminal emulator and version: GNOME Terminal 3.28.2
Python version:
3.8.2 (default, Mar 15 2020, 13:26:29) [GCC 7.4.0]
2.7.17 (default, Apr 15 2020, 17:20:14) [GCC 7.5.0]
Ranger version/commit: ranger-master v1.9.3-24-g1654128f
Locale: en_US.UTF-8

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [X] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [X] All changes follow the code style **[REQUIRED]**
- [X] All new and existing tests pass **[REQUIRED]**
- [ ] Changes require config files to be updated
    - [ ] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
When invoking command through 'console' command, macroses are not escaped with quotes. Thus, substitution of file names containing spaces or other should-be-escaped chars becomes wrong. This happens because invoked command class instance, which handles escaping control var state (escape_macros_for_shell) is not created by the time of substitution. To fix this behavior i've added escape_macros_for_shell variable to 'console' initialization. 'console' __init__ adds shell-like macros escaping if given command need it (e.g. there are three commands that set macros escaping: shell, delete, trash).

#### MOTIVATION AND CONTEXT
#1734 