### PR TITLE
Update HIGHLIGHT_STYLE documentation

### DIFF
--- a/doc/ranger.1
+++ b/doc/ranger.1
@@ -1901,7 +1901,8 @@ running:
 .IP HIGHLIGHT_STYLE 8
 .IX Item "HIGHLIGHT_STYLE"
 Specifies the theme to be used for syntax highlighting when \fIhighlight\fR is
-installed. Find out possible values by running \f(CW\*(C`highlight \-\-list\-themes\*(C'\fR.
+installed. Find out possible values by running
+\&\f(CW\*(C`highlight \-\-list\-scripts=themes\*(C'\fR.
 .IP HIGHLIGHT_TABWIDTH 8
 .IX Item "HIGHLIGHT_TABWIDTH"
 Specifies the number of spaces to use to replace tabs in \fIhighlight\fRed files.

--- a/doc/ranger.pod
+++ b/doc/ranger.pod
@@ -2182,7 +2182,8 @@ running:
 =item HIGHLIGHT_STYLE
 
 Specifies the theme to be used for syntax highlighting when I<highlight> is
-installed. Find out possible values by running C<highlight --list-themes>.
+installed. Find out possible values by running
+C<highlight --list-scripts=themes>.
 
 =item HIGHLIGHT_TABWIDTH
 


### PR DESCRIPTION
It seems `highlight` dropped the `--list-themes` option, now you need to
specify `--list-scripts=themes`.