### PR TITLE
Set column_rations to Golden Cut

### DIFF
--- a/ranger/config/rc.conf
+++ b/ranger/config/rc.conf
@@ -27,7 +27,7 @@
 set viewmode miller
 
 # How many columns are there, and what are their relative widths?
-set column_ratios 1,3,4
+set column_ratios 100,161,420
 
 # Which files should be hidden? (regular expression)
 set hidden_filter ^\.|\.(?:pyc|pyo|bak|swp)$|^lost\+found$|^__(py)?cache__$


### PR DESCRIPTION
Check https://github.com/ranger/ranger/issues/2052 for full background and multiple screenshots and comparisons to now.

It's a about a much more welcoming UX using Golden Cut ratios instead the current setup.

#### ISSUE TYPE
- Improvement/feature implementation

#### RUNTIME ENVIRONMENT
- irrelevant

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [x] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [x] All changes follow the code style **[REQUIRED]**
- [x] All new and existing tests pass **[REQUIRED]**
- [x] Changes require config files to be updated
    - [x] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION

It's a small change but creates a big impact making ranger a more polished impression.

#### MOTIVATION AND CONTEXT

It's not a must but it's an easy change and low hanging fruits which give ranger a more mature appearance.

https://github.com/ranger/ranger/issues/2052

#### TESTING
no test are required

#### IMAGES / VIDEOS

##### How it looks now

![image](https://user-images.githubusercontent.com/43666255/88367895-2733a400-cd8d-11ea-88de-db10d92c2711.png)

##### Golden Cut ratio to the column left

`set column_ratios 100,161,259`

![image](https://user-images.githubusercontent.com/43666255/88367561-5bf32b80-cd8c-11ea-82ab-e38dffe018f3.png)

##### Golden Cut ratio to all columns left
kind of a recursive Golden Cut:  `set column_ratios 100,161,420`

![image](https://user-images.githubusercontent.com/43666255/88367727-c1471c80-cd8c-11ea-9cb4-d89d34ac0077.png)
