### PR TITLE
Fix unicode decode issues in py2

### DIFF
--- a/ranger/core/actions.py
+++ b/ranger/core/actions.py
@@ -20,6 +20,7 @@ from hashlib import sha512
 from logging import getLogger
 
 import ranger
+from ranger import PY3
 from ranger.container.directory import Directory
 from ranger.container.file import File
 from ranger.container.settings import ALLOWED_SETTINGS, ALLOWED_VALUES
@@ -1022,10 +1023,10 @@ class Actions(  # pylint: disable=too-many-instance-attributes,too-many-public-m
     def sha512_encode(path, inode=None):
         if inode is None:
             inode = stat(path).st_ino
-        sha = sha512(
-            "{0}{1}".format(path, str(inode)).encode('utf-8', 'backslashescape')
-        )
-        return '{0}.jpg'.format(sha.hexdigest())
+        inode_path = "{0}{1}".format(str(inode), path)
+        if PY3:
+            inode_path = inode_path.encode('utf-8', 'backslashescape')
+        return '{0}.jpg'.format(sha512(inode_path).hexdigest())
 
     def get_preview(self, fobj, width, height):
         # pylint: disable=too-many-return-statements,too-many-statements


### PR DESCRIPTION
Python 2 implicitly decodes strings as ASCII or the system's default
encoding before encoding a string to bytes. This results in problems if
the string already contains characters outside the ASCII range (> 127).
I reintroduced this bug thinking encoding a string in both python 2 and
3 would be harmless.

Actually swapped the order of the inode and the path which should've
happened in the previous commit.

Fixes #2054