### PR TITLE
Fixes #1511 and #1995 with suggested fix from nQ8hzkZw

### DIFF
--- a/ranger/gui/widgets/browsercolumn.py
+++ b/ranger/gui/widgets/browsercolumn.py
@@ -413,7 +413,7 @@ class BrowserColumn(Pager):  # pylint: disable=too-many-instance-attributes
             self.color_reset()
 
     def _get_index_of_selected_file(self):
-        if self.fm.ui.viewmode == 'multipane' and self.tab:
+        if self.fm.ui.viewmode == 'multipane' and self.tab != self.fm.thistab:
             return self.tab.pointer
         return self.target.pointer
 


### PR DESCRIPTION
#### ISSUE TYPE
- Bug fix

#### RUNTIME ENVIRONMENT
- not relevant

#### CHECKLIST
- [X] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [X] All changes follow the code style **[REQUIRED]**
- [X] All new and existing tests pass **[REQUIRED]**
- [ ] Changes require config files to be updated
    - [ ] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
Added the suggested changes from #1511 to fix #1995 and #1511


#### MOTIVATION AND CONTEXT
When operations trigger a redraw of the directory in multipane mode that changes the order or count of files/directories, the pointer position is correctly set, but the displayed pointer position is wrong.
It can happen on "showing hidden files", ":mkdir" and any sorting.
> Why are these changes required?

Because I keep deleting wrong files after a sort.
#1995
#1511


#### TESTING
make test and manually tested all operations that trigger a redraw
