### PR TITLE
Fix crashing when empty '--cmd' command line option passed

### DIFF
--- a/ranger/core/actions.py
+++ b/ranger/core/actions.py
@@ -231,7 +231,8 @@ class Actions(  # pylint: disable=too-many-instance-attributes,too-many-public-m
 
         Execute a command for the console
         """
-        command_name = string.lstrip().split()[0]
+        string_striped = string.lstrip()
+        command_name = string_striped.split()[0] if string_striped else ''
         cmd_class = self.commands.get_command(command_name)
         if cmd_class is None:
             self.notify("Command not found: `%s'" % command_name, bad=True)


### PR DESCRIPTION
If run ranger from a shell as 'ranger --cmd=' it crashes since a check for an empty input string is missing.

<!-- Provide a descriptive summary of the changes in the title above -->

#### ISSUE TYPE
<!-- Pick relevant types and delete the rest -->
- Bug fix

#### RUNTIME ENVIRONMENT
<!-- Details of your runtime environment -->
<!-- Retrieve Python/ranger version and locale with `ranger -\-version` -->
- Operating system and version: Arch Linux 5.7.10-arch1-1
- Terminal emulator and version: alacritty 0.4.3
- Python version: 3.8.3 (default, May 17 2020, 18:15:42) [GCC 10.1.0]
- Ranger version/commit: ranger-master v1.9.3-96-gb92366f5
- Locale: en_US.UTF-8

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [X] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [X] All changes follow the code style **[REQUIRED]**
- [X] All new and existing tests pass **[REQUIRED]**
- [ ] Changes require config files to be updated
    - [ ] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
<!-- Describe the changes in detail -->

If run ranger as 'ranger --cmd=' it crashes with the following message:

```plain
ranger version: ranger-master v1.9.3-96-gb92366f5
Python version: 3.8.3 (default, May 17 2020, 18:15:42) [GCC 10.1.0]
Locale: en_US.UTF-8

Traceback (most recent call last):
  File "/home/acesk/Projects/ranger-old/ranger/core/main.py", line 183, in main
    fm.execute_console(command)
  File "/home/acesk/Projects/ranger-old/ranger/core/actions.py", line 234, in execute_console
    command_name = string.lstrip().split()[0]
IndexError: list index out of range

ranger crashed. Please report this traceback at:
https://github.com/ranger/ranger/issues

```

This bug happens due to missing check if an input command name is empty (parameter 'string' in `execute_console()` in `core/actions.py`). I've added a check whether `string.lstrip()` contains any value. If it's empty, 'command_name' variable will be set to `''`.

#### MOTIVATION AND CONTEXT
<!-- Why are these changes required? -->
<!-- What problems do these changes solve? -->
<!-- Link to relevant issues -->

I didn't create a corresponding issue because I found this bug and its fix small enough. 

#### TESTING
<!-- What tests have been run? -->
<!-- How does the changes affect other areas of the codebase? -->

#### IMAGES / VIDEOS<!-- Only if relevant -->
<!-- Link or embed images and videos of screenshots, sketches etc. -->
