### PR TITLE
Test for and follow tab changes in multipane mode

### DIFF
--- a/ranger/gui/widgets/statusbar.py
+++ b/ranger/gui/widgets/statusbar.py
@@ -43,6 +43,7 @@ class StatusBar(Widget):  # pylint: disable=too-many-instance-attributes
         self.settings.signal_bind('setopt.display_size_in_status_bar',
                                   self.request_redraw, weak=True)
         self.fm.signal_bind('tab.change', self.request_redraw, weak=True)
+        self.fm.signal_bind('setop.viewmode', self.request_redraw, weak=True)
 
     def request_redraw(self):
         self.need_redraw = True
@@ -56,10 +57,9 @@ class StatusBar(Widget):  # pylint: disable=too-many-instance-attributes
     def draw(self):  # pylint: disable=too-many-branches
         """Draw the statusbar"""
 
-        if self.fm.ui.viewmode == self.fm.ui.ALLOWED_VIEWMODES[1]:
-            if self.column != self.fm.ui.browser.main_column:
-                self.column = self.fm.ui.browser.main_column
-                self.need_redraw = True
+        if self.column != self.fm.ui.browser.main_column:
+            self.column = self.fm.ui.browser.main_column
+            self.need_redraw = True
 
         if self.hint and isinstance(self.hint, str):
             if self.old_hint != self.hint:

--- a/ranger/gui/widgets/statusbar.py
+++ b/ranger/gui/widgets/statusbar.py
@@ -42,7 +42,6 @@ class StatusBar(Widget):  # pylint: disable=too-many-instance-attributes
         self.column = column
         self.settings.signal_bind('setopt.display_size_in_status_bar',
                                   self.request_redraw, weak=True)
-        self.fm.signal_bind('tab.change', self.request_redraw, weak=True)
         self.fm.signal_bind('tab.layoutchange', self.request_redraw, weak=True)
         self.fm.signal_bind('setop.viewmode', self.request_redraw, weak=True)
 

--- a/ranger/gui/widgets/statusbar.py
+++ b/ranger/gui/widgets/statusbar.py
@@ -43,6 +43,7 @@ class StatusBar(Widget):  # pylint: disable=too-many-instance-attributes
         self.settings.signal_bind('setopt.display_size_in_status_bar',
                                   self.request_redraw, weak=True)
         self.fm.signal_bind('tab.change', self.request_redraw, weak=True)
+        self.fm.signal_bind('tab.layoutchange', self.request_redraw, weak=True)
         self.fm.signal_bind('setop.viewmode', self.request_redraw, weak=True)
 
     def request_redraw(self):

--- a/ranger/gui/widgets/statusbar.py
+++ b/ranger/gui/widgets/statusbar.py
@@ -42,6 +42,7 @@ class StatusBar(Widget):  # pylint: disable=too-many-instance-attributes
         self.column = column
         self.settings.signal_bind('setopt.display_size_in_status_bar',
                                   self.request_redraw, weak=True)
+        self.fm.signal_bind('tab.change', self.request_redraw, weak=True)
 
     def request_redraw(self):
         self.need_redraw = True
@@ -52,8 +53,13 @@ class StatusBar(Widget):  # pylint: disable=too-many-instance-attributes
     def clear_message(self):
         self.msg = None
 
-    def draw(self):
+    def draw(self):  # pylint: disable=too-many-branches
         """Draw the statusbar"""
+
+        if self.fm.ui.viewmode == self.fm.ui.ALLOWED_VIEWMODES[1]:
+            if self.column != self.fm.ui.browser.main_column:
+                self.column = self.fm.ui.browser.main_column
+                self.need_redraw = True
 
         if self.hint and isinstance(self.hint, str):
             if self.old_hint != self.hint:


### PR DESCRIPTION
#### ISSUE TYPE
- Bug fix for #1880 

#### RUNTIME ENVIRONMENT
- Operating system and version: Manjaro Linux 
- Terminal emulator and version: xfce4-terminal 0.8.9.2
- Python version: 3.8.3 (default, May 17 2020, 18:15:42) [GCC 10.1.0]
- Ranger version/commit: ranger-master 
- Locale: en_AU.UTF-8

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [X] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [X] All changes follow the code style **[REQUIRED]**
- [X] All new and existing tests pass **[REQUIRED]**

#### DESCRIPTION
Bound `tab.change` and `setopt.viewmode` signals to StatusBar widget `request_redraw`
Added a new test to `def draw()` that enforces current column to match browser `main_column`


#### MOTIVATION AND CONTEXT
Solves the bug of the Status bar getting locked to an old directory when switching tabs in multipane mode and on returning to miller mode.

#### TESTING
Ran all existing tests successfully. 
This only affects the statusbar when multipane mode is used.
