### PR TITLE
Fix preview toggle map in freeze_files documentation

### DIFF
--- a/doc/ranger.1
+++ b/doc/ranger.1
@@ -133,7 +133,7 @@
 .\" ========================================================================
 .\"
 .IX Title "RANGER 1"
-.TH RANGER 1 "ranger-1.9.3" "2020-02-22" "ranger manual"
+.TH RANGER 1 "ranger-1.9.3" "2020-08-22" "ranger manual"
 .\" For nroff, turn off justification.  Always turn off hyphenation; it makes
 .\" way too many mistakes in technical documents.
 .if n .ad l
@@ -631,7 +631,7 @@ Reload everything
 Toggle \fIfreeze_files\fR setting.  When active (indicated by a cyan \fI\s-1FROZEN\s0\fR
 message in the status bar), directories and files will not be loaded, improving
 performance when all the files you need are already loaded.  This does not
-affect file previews, which can be toggled with \fIzI\fR.  Also try disabling the
+affect file previews, which can be toggled with \fIzp\fR.  Also try disabling the
 preview of directories with \fIzP\fR.
 .IP "^L" 14
 .IX Item "^L"

--- a/doc/ranger.pod
+++ b/doc/ranger.pod
@@ -578,7 +578,7 @@ Reload everything
 Toggle I<freeze_files> setting.  When active (indicated by a cyan I<FROZEN>
 message in the status bar), directories and files will not be loaded, improving
 performance when all the files you need are already loaded.  This does not
-affect file previews, which can be toggled with I<zI>.  Also try disabling the
+affect file previews, which can be toggled with I<zp>.  Also try disabling the
 preview of directories with I<zP>.
 
 =item ^L


### PR DESCRIPTION
Simple documentation error someone reported in the IRC channel.