### PR TITLE
Fix mimetypes initialization #1744

### DIFF
--- a/ranger/core/filter_stack.py
+++ b/ranger/core/filter_stack.py
@@ -6,7 +6,6 @@
 from __future__ import (absolute_import, division, print_function)
 
 import re
-import mimetypes
 # pylint: disable=invalid-name
 try:
     from itertools import izip_longest as zip_longest
@@ -59,13 +58,13 @@ class NameFilter(BaseFilter):
 
 
 @stack_filter("mime")
-class MimeFilter(BaseFilter):
+class MimeFilter(BaseFilter, FileManagerAware):
     def __init__(self, pattern):
         self.pattern = pattern
         self.regex = re.compile(pattern)
 
     def __call__(self, fobj):
-        mimetype, _ = mimetypes.guess_type(fobj.relative_path)
+        mimetype, _ = self.fm.mimetypes.guess_type(fobj.relative_path)
         if mimetype is None:
             return False
         return self.regex.search(mimetype)

--- a/ranger/core/fm.py
+++ b/ranger/core/fm.py
@@ -73,9 +73,11 @@ class FM(Actions,  # pylint: disable=too-many-instance-attributes
         self.hostname = socket.gethostname()
         self.home_path = os.path.expanduser('~')
 
-        mimetypes.knownfiles.append(os.path.expanduser('~/.mime.types'))
-        mimetypes.knownfiles.append(self.relpath('data/mime.types'))
         self.mimetypes = mimetypes.MimeTypes()
+        extra_files = [self.relpath('data/mime.types'), os.path.expanduser("~/.mime.types")]
+        for path in mimetypes.knownfiles + extra_files:
+            if os.path.isfile(path):
+                self.mimetypes.read(path)
 
     def initialize(self):  # pylint: disable=too-many-statements
         """If ui/bookmarks are None, they will be initialized here."""

--- a/ranger/core/fm.py
+++ b/ranger/core/fm.py
@@ -73,11 +73,10 @@ class FM(Actions,  # pylint: disable=too-many-instance-attributes
         self.hostname = socket.gethostname()
         self.home_path = os.path.expanduser('~')
 
-        self.mimetypes = mimetypes.MimeTypes()
-        extra_files = [self.relpath('data/mime.types'), os.path.expanduser("~/.mime.types")]
-        for path in mimetypes.knownfiles + extra_files:
-            if os.path.isfile(path):
-                self.mimetypes.read(path)
+        if not mimetypes.inited:
+            extra_files = [self.relpath('data/mime.types'), os.path.expanduser("~/.mime.types")]
+            mimetypes.init(mimetypes.knownfiles + extra_files)
+        self.mimetypes = mimetypes
 
     def initialize(self):  # pylint: disable=too-many-statements
         """If ui/bookmarks are None, they will be initialized here."""

--- a/ranger/ext/rifle.py
+++ b/ranger/ext/rifle.py
@@ -144,7 +144,6 @@ class Rifle(object):  # pylint: disable=too-many-instance-attributes
         self.config_file = config_file
         self._app_flags = ''
         self._app_label = None
-        self._initialized_mimetypes = False
         self._mimetype = None
         self._skip = None
         self.rules = None
@@ -252,9 +251,8 @@ class Rifle(object):  # pylint: disable=too-many-instance-attributes
             return self._mimetype
 
         import mimetypes
-        for path in self._mimetype_known_files:
-            if path not in mimetypes.knownfiles:
-                mimetypes.knownfiles.append(path)
+        if not mimetypes.inited:
+            mimetypes.init(mimetypes.knownfiles + self._mimetype_known_files)
         self._mimetype, _ = mimetypes.guess_type(fname)
 
         if not self._mimetype:


### PR DESCRIPTION
<!-- Provide a descriptive summary of the changes in the title above -->

#### ISSUE TYPE
<!-- Pick relevant types and delete the rest -->
- Bug fix

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [X] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [X] All changes follow the code style **[REQUIRED]**
- [X] All new and existing tests pass **[REQUIRED]**
- [ ] Changes require config files to be updated
    - [ ] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
<!-- Describe the changes in detail -->
Changes how `MimeTypes` objects are used and initialized in ranger and rifle. In both use cases, the same set of
mimetype files are read and added on top of the hardcoded defaults in the mimetypes python library:

1. Mimetype files set in system (python/mimetypes library installation)
2. The `data/mime.types` from ranger (standalone rifle remains exception here)
3. The `~/.mime.types` if it exists

#### MOTIVATION AND CONTEXT
<!-- Why are these changes required? -->
<!-- What problems do these changes solve? -->
<!-- Link to relevant issues -->

This fixes issue #1744 (on my system at least).

The discussion in #1744 seems to suggest that mimetypes behavior varies across some variables (python version and/or
library versions and/or other system specs). So I guess in some configurations these changes can lead to loading the
same mimetype file multiple times, which is fine.

#### TESTING
<!-- What tests have been run? -->
<!-- How does the changes affect other areas of the codebase? -->
