### PR TITLE
Update rifle.conf: command "ask" without double quotes can cause numbers of open with incorrect

### DIFF
--- a/ranger/config/rifle.conf
+++ b/ranger/config/rifle.conf
@@ -266,7 +266,7 @@ label open, has xdg-open = xdg-open "$@"
 label open, has open     = open -- "$@"
 
 # Define the editor for non-text files + pager as last action
-              !mime ^text, !ext xml|json|csv|tex|py|pl|rb|rs|js|sh|php  = ask
+              !mime ^text, !ext xml|json|csv|tex|py|pl|rb|rs|js|sh|php  = "ask"
 label editor, !mime ^text, !ext xml|json|csv|tex|py|pl|rb|rs|js|sh|php  = ${VISUAL:-$EDITOR} -- "$@"
 label pager,  !mime ^text, !ext xml|json|csv|tex|py|pl|rb|rs|js|sh|php  = "$PAGER" -- "$@"
 


### PR DESCRIPTION
<!-- Provide a descriptive summary of the changes in the title above -->

#### ISSUE TYPE
<!-- Pick relevant types and delete the rest -->
- Bug fix

#### RUNTIME ENVIRONMENT
<!-- Details of your runtime environment -->
<!-- Retrieve Python/ranger version and locale with `ranger -\-version` -->
- Operating system and version: Archlinux 5.8.9
- Terminal emulator and version: konsole 20.08.1
- Python version: 3.8.5 (default, Sep  5 2020, 10:50:12) [GCC 10.2.0]
- Ranger version/commit: 1.9.3
- Locale: zh_CN.UTF-8

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [x] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [x] All changes follow the code style **[REQUIRED]**
- [x] All new and existing tests pass **[REQUIRED]**
- [x] Changes require config files to be updated
    - [x] Config files have been updated

#### DESCRIPTION
<!-- Describe the changes in detail -->

Command "ask" without double quotes can cause numbers of open with incorrect.

In my case:
```
ext md, has typora, X, flag f = typora1 "$@"
ext md, has typora, X, flag f = typora2 "$@"

mime application/x-executable = ask

ext md, has typora, X, flag f = typora3 "$@"
ext md, has typora, X, flag f = typora4 "$@"
```
```
0 | typora1 "$@"
1 | typora2 "$@"
3 | typora3 "$@"
4 | typora4 "$@"
:open_with
```

#### MOTIVATION AND CONTEXT
<!-- Why are these changes required? -->
<!-- What problems do these changes solve? -->
<!-- Link to relevant issues -->


#### TESTING
<!-- What tests have been run? -->
<!-- How does the changes affect other areas of the codebase? -->


#### IMAGES / VIDEOS<!-- Only if relevant -->
<!-- Link or embed images and videos of screenshots, sketches etc. -->
