### PR TITLE
POC for an extensible bulk command

### DIFF
--- a/ranger/config/commands.py
+++ b/ranger/config/commands.py
@@ -1225,7 +1225,32 @@ class bulk(Command):
     After you close it, it will be executed.
     """
 
-    bulk = {}
+
+    class id3art(object):
+
+        def get_attribute(self, file):
+            import eyed3
+            return str(eyed3.load(file.relative_path).tag.artist)
+
+
+        def get_change_attribute_cmd(self, file, old, new):
+            from ranger.ext.shell_escape import shell_escape as esc
+            return "eyeD3 -a %s %s" % (esc(new), esc(file))
+
+    class id3tit(object):
+
+        def get_attribute(self, file):
+            import eyed3
+            return str(eyed3.load(file.relative_path).tag.title)
+
+
+        def get_change_attribute_cmd(self, file, old, new):
+            from ranger.ext.shell_escape import shell_escape as esc
+            return "eyeD3 -t %s %s" % (esc(new), esc(file))
+
+    bulk = {'id3art': id3art(),
+            'id3tit': id3tit(),
+            }
 
     def execute(self):  # pylint: disable=too-many-locals,too-many-statements
         import sys


### PR DESCRIPTION
<!-- Provide a descriptive summary of the changes in the title above -->
This is a proof-of-concept for a new `bulk` command that is basically a generic version of `bulkrename` that can be extended by the user, that is, it provides an interface for the user to add custom functions that query and edit any attribute of multiple files at once.

#### ISSUE TYPE
<!-- Pick relevant types and delete the rest -->
- Improvement/feature implementation

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [x] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [x] All changes follow the code style **[REQUIRED]**
- [x] All new and existing tests pass **[REQUIRED]**
- [ ] Changes require config files to be updated
    - [ ] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
<!-- Describe the changes in detail -->
The `bulkrename` command provides a convenient way to edit an attribute of multiple files at once, but it is also very limited since it can only be used for renaming the files.

The new `bulk` command requires that the user adds two functions: one that gets the attribute for the file, and another that generates the shell script command that makes the change of the file attribute to the new one set by the user.

So the user can extend this command by providing the functions that handle the specific attribute they want to change, and the `bulk` command handles the common stuff that was already done by `bulkrename`: open the editor with the attribute for each file in each line, get the changes made by the user on exit, create a shell script with the commands for each attribute changed and finally execute the script for the changes to take effect.

#### MOTIVATION AND CONTEXT
<!-- Why are these changes required? -->
<!-- What problems do these changes solve? -->
<!-- Link to relevant issues -->
This brings more flexibility and use cases for the useful but limited `bulkrename`.

#### TESTING
<!-- What tests have been run? -->
<!-- How does the changes affect other areas of the codebase? -->
As an example of usage, two functions were implemented that use the `bulk` command, `id3art` and `id3tit`. They use the eyeD3 program to edit the artist and title ID3 tags of mp3 files, respectively.

To illustrate the usage, the users can for example: in ranger, select multiple mp3 files that they want to change the artist ID3 tag, type `:bulk id3art`, the editor will open up with the artist of each music file in each line.
After editing and closing, a shell script opens up with the eyeD3 commands that change the artist tag of each one that was modified.
Finally, after reviewing this script and closing, the changes take place.

#### IMAGES / VIDEOS<!-- Only if relevant -->
<!-- Link or embed images and videos of screenshots, sketches etc. -->
