### PR TITLE
Documentation for RANGER_LOAD_DEFAULT_RC

### DIFF
--- a/doc/ranger.1
+++ b/doc/ranger.1
@@ -131,9 +131,10 @@ Create copies of the default configuration files in your local configuration
 directory.  Existing ones will not be overwritten.  Possible values: \fIall\fR,
 \&\fIcommands\fR, \fIcommands_full\fR, \fIrc\fR, \fIrifle\fR, \fIscope\fR.
 .Sp
-Note: You may want to disable loading of the global configuration files by
-exporting \fIRANGER_LOAD_DEFAULT_RC=FALSE\fR in your environment.  See also:
-\&\fBFILES\fR, \fBENVIRONMENT\fR
+Note: You can disable loading of the global \fIrc.conf\fR by exporting
+\&\fIRANGER_LOAD_DEFAULT_RC=FALSE\fR in your environment. Only do so if your
+configuration is complete, as settings that are not specified will be
+undefined. See also: \fB\s-1FILES\s0\fR, \fB\s-1ENVIRONMENT\s0\fR
 .Sp
 \&\-\-copy\-config=\fBcommands\fR will copy only a small sample configuration file with
 a thoroughly commented example.  It is recommended to keep this file tidy to
@@ -1861,10 +1862,10 @@ exists.  External programs can determine whether they were spawned from ranger
 by checking for this variable.
 .IP RANGER_LOAD_DEFAULT_RC 8
 .IX Item "RANGER_LOAD_DEFAULT_RC"
-If this variable is set to FALSE, ranger will not load the default rc.conf.
-This can save time if you copied the whole rc.conf to \fI~/.config/ranger/\fR and
-don't need the default one at all.
-.IP VISUAL 8
+If this variable is set to \s-1FALSE,\s0 ranger will not load the default \fIrc.conf\fR.
+This can save time if you copied the whole \fIrc.conf\fR to \fI~/.config/ranger/\fR
+and don't need the default one at all.
+.IP "\s-1VISUAL\s0" 8
 .IX Item "VISUAL"
 Defines the editor to be used for the "E" key.  Falls back to EDITOR if
 undefined or empty.

--- a/doc/ranger.pod
+++ b/doc/ranger.pod
@@ -103,9 +103,10 @@ Create copies of the default configuration files in your local configuration
 directory.  Existing ones will not be overwritten.  Possible values: I<all>,
 I<commands>, I<commands_full>, I<rc>, I<rifle>, I<scope>.
 
-Note: You may want to disable loading of the global configuration files by
-exporting I<RANGER_LOAD_DEFAULT_RC=FALSE> in your environment.  See also:
-B<FILES>, B<ENVIRONMENT>
+Note: You can disable loading of the global F<rc.conf> by exporting
+I<RANGER_LOAD_DEFAULT_RC=FALSE> in your environment. Only do so if your
+configuration is complete, as settings that are not specified will be
+undefined. See also: B<FILES>, B<ENVIRONMENT>
 
 --copy-config=B<commands> will copy only a small sample configuration file with
 a thoroughly commented example.  It is recommended to keep this file tidy to
@@ -2134,9 +2135,9 @@ by checking for this variable.
 
 =item RANGER_LOAD_DEFAULT_RC
 
-If this variable is set to FALSE, ranger will not load the default rc.conf.
-This can save time if you copied the whole rc.conf to I<~/.config/ranger/> and
-don't need the default one at all.
+If this variable is set to FALSE, ranger will not load the default F<rc.conf>.
+This can save time if you copied the whole F<rc.conf> to I<~/.config/ranger/>
+and don't need the default one at all.
 
 =item VISUAL
 

--- a/ranger/config/rc.conf
+++ b/ranger/config/rc.conf
@@ -6,6 +6,8 @@
 #
 # If you copy this whole file there, you may want to set the environment
 # variable RANGER_LOAD_DEFAULT_RC to FALSE to avoid loading it twice.
+# Note that you are responsible for setting sensible values for *all* settings
+# if you do this.
 #
 # The purpose of this file is mainly to define keybindings and settings.
 # For running more complex python code, please create a plugin in "plugins/" or

--- a/ranger/core/fm.py
+++ b/ranger/core/fm.py
@@ -390,9 +390,11 @@ class FM(Actions,  # pylint: disable=too-many-instance-attributes
             if os.environ.get('RANGER_LOAD_DEFAULT_RC', 'TRUE').upper() != 'FALSE':
                 sys.stderr.write("\n> To stop ranger from loading "
                                  "\033[1mboth\033[0m the default and your custom rc.conf,\n"
-                                 "  please set the environment variable "
+                                 "  you can set the environment variable "
                                  "\033[1mRANGER_LOAD_DEFAULT_RC\033[0m to "
-                                 "\033[1mFALSE\033[0m.\n")
+                                 "\033[1mFALSE\033[0m.\n"
+                                 "  Note that this requires providing sensible "
+                                 "values for all settings.\n")
         else:
             sys.stderr.write("Unknown config file `%s'\n" % which)
 

--- a/ranger/core/fm.py
+++ b/ranger/core/fm.py
@@ -393,8 +393,9 @@ class FM(Actions,  # pylint: disable=too-many-instance-attributes
                                  "  you can set the environment variable "
                                  "\033[1mRANGER_LOAD_DEFAULT_RC\033[0m to "
                                  "\033[1mFALSE\033[0m.\n"
-                                 "  Note that this requires providing sensible "
-                                 "values for all settings.\n")
+                                 "  WARNING: this will give you more maintenance work in the"
+                                 "long run,\n"
+                                 "  like setting values for all new settings in the future.\n")
         else:
             sys.stderr.write("Unknown config file `%s'\n" % which)
 


### PR DESCRIPTION
Far too often users simply set this variable, thinking it's a "Go fast!" switch. This leads to confused users with broken (incomplete) configurations.
    
I've reworded the note to caution readers.