### PR TITLE
feat(console): support fallback for console cancel

### DIFF
--- a/ranger/config/commands.py
+++ b/ranger/config/commands.py
@@ -1518,9 +1518,9 @@ class scout(Command):
         if self.KEEP_OPEN in flags and thisdir != self.fm.thisdir:
             # reopen the console:
             if not pattern:
-                self.fm.open_console(self.line)
+                self.fm.open_console(self.line, keep_open=True)
             else:
-                self.fm.open_console(self.line[0:-len(pattern)])
+                self.fm.open_console(self.line[0:-len(pattern)], keep_open=True)
 
         if self.quickly_executed and thisdir != self.fm.thisdir and pattern != "..":
             self.fm.block_input(0.5)

--- a/ranger/core/actions.py
+++ b/ranger/core/actions.py
@@ -219,13 +219,14 @@ class Actions(  # pylint: disable=too-many-instance-attributes,too-many-public-m
         self.ui.redraw_window()
 
     def open_console(self, string='',  # pylint: disable=redefined-outer-name
-                     prompt=None, position=None):
+                     prompt=None, position=None, keep_open=False):
         """:open_console [string]
 
         Open the console.
         """
         self.change_mode('normal')
-        self.ui.open_console(string, prompt=prompt, position=position)
+        self.ui.open_console(string, prompt=prompt, position=position,
+                             keep_open=keep_open)
 
     def execute_console(self, string='',  # pylint: disable=redefined-outer-name
                         wildcards=None, quantifier=None):

--- a/ranger/gui/ui.py
+++ b/ranger/gui/ui.py
@@ -431,8 +431,9 @@ class UI(  # pylint: disable=too-many-instance-attributes,too-many-public-method
         for column in self.browser.columns:
             column.level_restore()
 
-    def open_console(self, string='', prompt=None, position=None):
-        if self.console.open(string, prompt=prompt, position=position):
+    def open_console(self, string='', prompt=None, position=None, keep_open=False):
+        if self.console.open(string, prompt=prompt, position=position,
+                             keep_open=keep_open):
             self.status.msg = None
 
     def close_console(self):


### PR DESCRIPTION
1. add keep_open parameter for open_console(actions, ui, console)
2. add last_file_path and last_filter fields for console class

solve https://github.com/ranger/ranger/issues/900 by the way. 
<!-- Provide a descriptive summary of the changes in the title above -->

#### ISSUE TYPE
<!-- Pick relevant types and delete the rest -->
- Improvement/feature implementation

#### RUNTIME ENVIRONMENT
<!-- Details of your runtime environment -->
<!-- Retrieve Python/ranger version and locale with `ranger -\-version` -->
- Operating system and version: ArchLinux
- Terminal emulator and version: 
- Python version: 3.8.5
- Ranger version/commit: 1.9.3
- Locale:  en_US.UTF-8

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [x] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [x] All changes follow the code style **[REQUIRED]**
- [x] All new and existing tests pass **[REQUIRED]**
- [ ] Changes require config files to be updated
    - [ ] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
Esc for console cancel, below gif is demo.

#### MOTIVATION AND CONTEXT
<!-- Why are these changes required? -->
<!-- What problems do these changes solve? -->
<!-- Link to relevant issues -->
It's a hassle to use `scout` without fallback for console cancel.

#### TESTING
<!-- What tests have been run? -->
<!-- How does the changes affect other areas of the codebase? -->


#### IMAGES / VIDEOS<!-- Only if relevant -->
<!-- Link or embed images and videos of screenshots, sketches etc. -->
![2020-10-01 02-21-31-lanczos](https://user-images.githubusercontent.com/17562139/94725508-777f4180-038e-11eb-9df0-3c7f45b46391.gif)