### PR TITLE
Fix encoding of cached filenames

### DIFF
--- a/ranger/core/actions.py
+++ b/ranger/core/actions.py
@@ -1025,7 +1025,7 @@ class Actions(  # pylint: disable=too-many-instance-attributes,too-many-public-m
             inode = stat(path).st_ino
         inode_path = "{0}{1}".format(str(inode), path)
         if PY3:
-            inode_path = inode_path.encode('utf-8', 'backslashescape')
+            inode_path = inode_path.encode('utf-8', 'backslashreplace')
         return '{0}.jpg'.format(sha512(inode_path).hexdigest())
 
     def get_preview(self, fobj, width, height):


### PR DESCRIPTION
A typo crept into the encoding of paths used for the hashes of cached
images. The error handler "backslashescape" doesn't exist, it should've
been "backslashreplace."

Fixes #2119