### PR TITLE
Allow `PAGER` environment variable to contain spaces for options/flags

### DIFF
--- a/doc/rifle.1
+++ b/doc/rifle.1
@@ -133,7 +133,7 @@
 .\" ========================================================================
 .\"
 .IX Title "RIFLE 1"
-.TH RIFLE 1 "rifle-1.9.3" "2020-02-08" "rifle manual"
+.TH RIFLE 1 "rifle-1.9.3" "2020-11-08" "rifle manual"
 .\" For nroff, turn off justification.  Always turn off hyphenation; it makes
 .\" way too many mistakes in technical documents.
 .if n .ad l

--- a/doc/rifle.1
+++ b/doc/rifle.1
@@ -216,8 +216,8 @@ List all the different methods:
 .PP
 .Vb 4
 \& $ rifle \-l helloworld.py
-\& 0:editor::"$EDITOR" \-\- "$@"
-\& 1:pager::"$PAGER" \-\- "$@"
+\& 0:editor::$EDITOR \-\- "$@"
+\& 1:pager::$PAGER \-\- "$@"
 \& 2:::python \-\- "$1"
 .Ve
 .PP

--- a/doc/rifle.pod
+++ b/doc/rifle.pod
@@ -117,8 +117,8 @@ Specifies the directory for configuration files. Defaults to F<$HOME/.config>.
 List all the different methods:
 
  $ rifle -l helloworld.py
- 0:editor::"$EDITOR" -- "$@"
- 1:pager::"$PAGER" -- "$@"
+ 0:editor::$EDITOR -- "$@"
+ 1:pager::$PAGER -- "$@"
  2:::python -- "$1"
 
 Display its content by opening it with "cat":

--- a/examples/rifle_different_file_opener.conf
+++ b/examples/rifle_different_file_opener.conf
@@ -5,5 +5,5 @@
 else = xdg-open "$1"
 
 # You need an "editor" and "pager" in order to use certain functions in ranger:
-label editor = "$EDITOR" -- "$@"
-label pager  = "$PAGER" -- "$@"
+label editor = $EDITOR -- "$@"
+label pager  = $PAGER -- "$@"

--- a/ranger/config/rifle.conf
+++ b/ranger/config/rifle.conf
@@ -86,9 +86,9 @@ ext x?html?, has w3m,               terminal = w3m "$@"
 #-------------------------------------------
 # Define the "editor" for text files as first action
 mime ^text,  label editor = ${VISUAL:-$EDITOR} -- "$@"
-mime ^text,  label pager  = "$PAGER" -- "$@"
+mime ^text,  label pager  = $PAGER -- "$@"
 !mime ^text, label editor, ext xml|json|csv|tex|py|pl|rb|rs|js|sh|php = ${VISUAL:-$EDITOR} -- "$@"
-!mime ^text, label pager,  ext xml|json|csv|tex|py|pl|rb|rs|js|sh|php = "$PAGER" -- "$@"
+!mime ^text, label pager,  ext xml|json|csv|tex|py|pl|rb|rs|js|sh|php = $PAGER -- "$@"
 
 ext 1                         = man "$1"
 ext s[wmf]c, has zsnes, X     = zsnes "$1"
@@ -156,7 +156,7 @@ ext pdf, has qpdfview, X, flag f = qpdfview "$@"
 ext pdf, has open,     X, flag f = open "$@"
 
 ext sc,    has sc,                    = sc -- "$@"
-ext docx?, has catdoc,       terminal = catdoc -- "$@" | "$PAGER"
+ext docx?, has catdoc,       terminal = catdoc -- "$@" | $PAGER
 
 ext                        sxc|xlsx?|xlt|xlw|gnm|gnumeric, has gnumeric,    X, flag f = gnumeric -- "$@"
 ext                        sxc|xlsx?|xlt|xlw|gnm|gnumeric, has kspread,     X, flag f = kspread -- "$@"
@@ -207,15 +207,15 @@ ext xcf,                    X, flag f = gimp -- "$@"
 #-------------------------------------------
 
 # avoid password prompt by providing empty password
-ext 7z, has 7z = 7z -p l "$@" | "$PAGER"
+ext 7z, has 7z = 7z -p l "$@" | $PAGER
 # This requires atool
-ext ace|ar|arc|bz2?|cab|cpio|cpt|deb|dgc|dmg|gz,     has atool = atool --list --each -- "$@" | "$PAGER"
-ext iso|jar|msi|pkg|rar|shar|tar|tgz|xar|xpi|xz|zip, has atool = atool --list --each -- "$@" | "$PAGER"
+ext ace|ar|arc|bz2?|cab|cpio|cpt|deb|dgc|dmg|gz,     has atool = atool --list --each -- "$@" | $PAGER
+ext iso|jar|msi|pkg|rar|shar|tar|tgz|xar|xpi|xz|zip, has atool = atool --list --each -- "$@" | $PAGER
 ext 7z|ace|ar|arc|bz2?|cab|cpio|cpt|deb|dgc|dmg|gz,  has atool = atool --extract --each -- "$@"
 ext iso|jar|msi|pkg|rar|shar|tar|tgz|xar|xpi|xz|zip, has atool = atool --extract --each -- "$@"
 
 # Listing and extracting archives without atool:
-ext tar|gz|bz2|xz, has tar = tar vvtf "$1" | "$PAGER"
+ext tar|gz|bz2|xz, has tar = tar vvtf "$1" | $PAGER
 ext tar|gz|bz2|xz, has tar = for file in "$@"; do tar vvxf "$file"; done
 ext bz2, has bzip2 = for file in "$@"; do bzip2 -dk "$file"; done
 ext zip, has unzip = unzip -l "$1" | less
@@ -275,7 +275,7 @@ label open, has open     = open -- "$@"
 # Define the editor for non-text files + pager as last action
               !mime ^text, !ext xml|json|csv|tex|py|pl|rb|rs|js|sh|php  = ask
 label editor, !mime ^text, !ext xml|json|csv|tex|py|pl|rb|rs|js|sh|php  = ${VISUAL:-$EDITOR} -- "$@"
-label pager,  !mime ^text, !ext xml|json|csv|tex|py|pl|rb|rs|js|sh|php  = "$PAGER" -- "$@"
+label pager,  !mime ^text, !ext xml|json|csv|tex|py|pl|rb|rs|js|sh|php  = $PAGER -- "$@"
 
 
 ######################################################################


### PR DESCRIPTION
Allow `PAGER` environment variable to contain spaces for options/flags. This PR is the same as: https://github.com/ranger/ranger/pull/128

#### ISSUE TYPE
- Bug fix

#### RUNTIME ENVIRONMENT
- Operating system and version:
Nixos 20.03.3191.504f993df9a (Markhor)
- Terminal emulator and version: 
alacritty 0.4.3
- Python version:
Python 3.7.6 
- Ranger version/commit: 1.9.3 
- Locale: en_US.UTF-8

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [X] The `CONTRIBUTING` document has been read
- [X] All changes follow the code style
- [X] All new and existing tests pass
- [X] Changes require config files to be updated
    - [X] Config files have been updated
- [X] Changes require documentation to be updated
    - [X] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION

 See the commit message: https://github.com/ranger/ranger/commit/a8105b082f94729669d0509f07c98aa566c0278f .


#### MOTIVATION AND CONTEXT

Some Linux distros like Nixos define the default PAGER as a `"<binary> <flags...>"`. The default ranger configuration doesn't work with distros having that configuration.

Additionally, this change is consistent with the lack of quoting for `EDITOR` in the default `rifle.conf` (https://github.com/ranger/ranger/blob/master/ranger/config/rifle.conf#L88).

#### TESTING

All existing tests pass. Only config is affected.

#### IMAGES / VIDEOS<!-- Only if relevant -->

Not relevant.