### PR TITLE
Initial commit. Add "auto_tabs_remap" option and remap_tabs func. Some

### DIFF
--- a/ranger/config/rc.conf
+++ b/ranger/config/rc.conf
@@ -168,6 +168,9 @@ set draw_borders none
 # Display the directory name in tabs?
 set dirname_in_tabs false
 
+# Sort tab names when a tab is closed
+set auto_tabs_remap true
+
 # Enable the mouse support?
 set mouse_enabled true
 

--- a/ranger/container/settings.py
+++ b/ranger/container/settings.py
@@ -37,6 +37,7 @@ ALLOWED_SETTINGS = {
     'column_ratios': (tuple, list),
     'confirm_on_delete': str,
     'dirname_in_tabs': bool,
+    'auto_tabs_remap': bool,
     'display_size_in_main_column': bool,
     'display_size_in_status_bar': bool,
     "display_free_space_in_status_bar": bool,

--- a/ranger/core/actions.py
+++ b/ranger/core/actions.py
@@ -1237,19 +1237,28 @@ class Actions(  # pylint: disable=too-many-instance-attributes,too-many-public-m
             self.signal_emit('tab.change', old=previous_tab, new=self.thistab)
             self.signal_emit('tab.layoutchange')
 
+    def remap_tabs(self):
+        tab_names = list(self.tabs.values())
+        tabs_len = len(tab_names)
+        self.tabs = {l+1: tab_names[l] for l in range(tabs_len)}
+
     def tab_close(self, name=None):
         if name is None:
             name = self.current_tab
         tab = self.tabs[name]
         if name == self.current_tab:
-            direction = -1 if name == self.get_tab_list()[-1] else 1
+            direction = -1 if name == self.get_tab_list()[-1] else 0 if self.settings.auto_tabs_remap else 1
             previous = self.current_tab
             self.tab_move(direction)
-            if previous == self.current_tab:
+            if previous == self.current_tab and not self.settings.auto_tabs_remap:
                 return  # can't close last tab
         if name in self.tabs:
             del self.tabs[name]
+            # Remap all dict
+            if self.settings.auto_tabs_remap:
+                self.remap_tabs()
         self.restorable_tabs.append(tab)
+        self.ui.titlebar.request_redraw()
         self.signal_emit('tab.layoutchange')
 
     def tab_restore(self):


### PR DESCRIPTION
Rename tab names when tab closed.
#### ISSUE TYPE
<!-- Pick relevant types and delete the rest -->
- Improvement/feature implementation

#### RUNTIME ENVIRONMENT
<!-- Details of your runtime environment -->
<!-- Retrieve Python/ranger version and locale with `ranger -\-version` -->
- Operating system and version: linux 5.9.8-arch1-1
- Terminal emulator and version: st 0.8.4
- Python version: 3.8.6
- Ranger version/commit: ranger-master v1.9.3-122-g4b6bf5bd
- Locale: en_US.UTF-8

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [X] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [X] All changes follow the code style **[REQUIRED]**
- [X] All new and existing tests pass **[REQUIRED]**
- [X] Changes require config files to be updated
    - [X] Config files have been updated
- [X] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
When some tab is closed, we iterate over the dictionary of tab names and assign new values from 1.
The logic of assigning the current tab after closing is similar to the old logic, but confusing because of the offset.
<1><**2**><3><4>
*Close tab.*
<1><**2**><3>
Now 3 is tab under '2'-name.


#### MOTIVATION AND CONTEXT
<!-- Why are these changes required? -->
<!-- What problems do these changes solve? -->
<!-- Link to relevant issues -->
#2041 issue.

#### TESTING
<!-- What tests have been run? -->
<!-- How does the changes affect other areas of the codebase? -->


#### IMAGES / VIDEOS<!-- Only if relevant -->
<!-- Link or embed images and videos of screenshots, sketches etc. -->

