### PR TITLE
Change chmod maps

### DIFF
--- a/ranger/config/rc.conf
+++ b/ranger/config/rc.conf
@@ -627,13 +627,13 @@ eval for arg in "rwxXst": cmd("map +u{0} shell -f chmod u+{0} %s".format(arg))
 eval for arg in "rwxXst": cmd("map +g{0} shell -f chmod g+{0} %s".format(arg))
 eval for arg in "rwxXst": cmd("map +o{0} shell -f chmod o+{0} %s".format(arg))
 eval for arg in "rwxXst": cmd("map +a{0} shell -f chmod a+{0} %s".format(arg))
-eval for arg in "rwxXst": cmd("map +{0}  shell -f chmod u+{0} %s".format(arg))
+eval for arg in "rwxXst": cmd("map +{0}  shell -f chmod +{0} %s".format(arg))
 
 eval for arg in "rwxXst": cmd("map -u{0} shell -f chmod u-{0} %s".format(arg))
 eval for arg in "rwxXst": cmd("map -g{0} shell -f chmod g-{0} %s".format(arg))
 eval for arg in "rwxXst": cmd("map -o{0} shell -f chmod o-{0} %s".format(arg))
 eval for arg in "rwxXst": cmd("map -a{0} shell -f chmod a-{0} %s".format(arg))
-eval for arg in "rwxXst": cmd("map -{0}  shell -f chmod u-{0} %s".format(arg))
+eval for arg in "rwxXst": cmd("map -{0}  shell -f chmod -{0} %s".format(arg))
 
 # ===================================================================
 # == Define keys for the console


### PR DESCRIPTION
The maps without explicit target only changed user permissions. The
chmod utility changes all permissions when the target's omitted. This
brings both more in line.

Fixes #2161