### PR TITLE
Handling NoneType when work with history-size variables.

### DIFF
--- a/ranger/container/history.py
+++ b/ranger/container/history.py
@@ -13,7 +13,7 @@ class HistoryEmptyException(Exception):
 class History(object):
 
     def __init__(self, maxlen=None, unique=True):
-        assert maxlen is not None, "maxlen cannot be None"
+        maxlen = float('inf') if maxlen is None else maxlen
         if isinstance(maxlen, History):
             self.history = list(maxlen.history)
             self.index = maxlen.index


### PR DESCRIPTION
# ISSUE TYPE
<!-- Pick relevant types and delete the rest -->
- Bug fix

#### RUNTIME ENVIRONMENT
<!-- Details of your runtime environment -->
<!-- Retrieve Python/ranger version and locale with `ranger -\-version` -->
- Operating system and version: Linux
- Terminal emulator and version: st
- Python version: 3.8.6
- Ranger version/commit: ranger-master v1.9.3-144-g94be2268
- Locale: en_US.UTF-8

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [X] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [X] All changes follow the code style **[REQUIRED]**
- [X] All new and existing tests pass **[REQUIRED]**
- [ ] Changes require config files to be updated
    - [ ] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
<!-- Describe the changes in detail -->
Handling NoneType when work with history-size variables.
Old code:
`assert maxlen is not None, "maxlen cannot be None"`
Using infinity variable for "none" value.
#### MOTIVATION AND CONTEXT
<!-- Why are these changes required? -->
<!-- What problems do these changes solve? -->
<!-- Link to relevant issues -->
#1895 

#### TESTING
<!-- What tests have been run? -->
<!-- How does the changes affect other areas of the codebase? -->
I have not "AssertionError: maxlen cannot be None" or other errors.

#### IMAGES / VIDEOS<!-- Only if relevant -->
<!-- Link or embed images and videos of screenshots, sketches etc. -->

