### PR TITLE
fix reload_cwd with "empty" directory

### DIFF
--- a/ranger/container/directory.py
+++ b/ranger/container/directory.py
@@ -470,6 +470,8 @@ class Directory(  # pylint: disable=too-many-instance-attributes,too-many-public
     def unload(self):
         self.loading = False
         self.load_generator = None
+        self.size__reset()
+        self.runnable__reset()
 
     def load_content(self, schedule=None):
         """Loads the contents of the directory.
@@ -574,7 +576,7 @@ class Directory(  # pylint: disable=too-many-instance-attributes,too-many-public
         except OSError:
             self.infostring = BAD_INFO
             self.accessible = False
-            self.runnable = False
+            self._runnable = False
             return 0
         else:
             if size is None:
@@ -582,7 +584,7 @@ class Directory(  # pylint: disable=too-many-instance-attributes,too-many-public
             else:
                 self.infostring = ' %d' % size
             self.accessible = True
-            self.runnable = True
+            self._runnable = True
             return size
 
     @lazy_property
@@ -595,7 +597,7 @@ class Directory(  # pylint: disable=too-many-instance-attributes,too-many-public
     @lazy_property
     def runnable(self):  # pylint: disable=method-hidden
         self.size  # trigger the lazy property initializer pylint: disable=pointless-statement
-        return self.runnable
+        return self._runnable
 
     def sort_if_outdated(self):
         """Sort the containing files if they are outdated"""


### PR DESCRIPTION
#### ISSUE TYPE
- Bug fix

#### RUNTIME ENVIRONMENT
- Operating system and version: macOS Catalina
- Terminal emulator and version: alacritty
- Python version: 3.9.0
- Ranger version/commit: ranger version: ranger-master v1.9.3-144-gd2aa568d
- Locale: en

#### CHECKLIST
- [x] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [x] All changes follow the code style **[REQUIRED]**
- [x] All new and existing tests pass **[REQUIRED]**

#### DESCRIPTION

When macOS attaches an encrypted disk it will briefly show up in `/Volumes` first (still encrypted I guess). Ranger tries to read it but as it is not ready ranger encounters an error and only shows `empty`. 

When the filesystem is ready ranger still shows `empty` and `reload_cwd` has no effect.

#### MOTIVATION AND CONTEXT

This PR resets `runnable` (and `size`) so the that the directory can be reloaded by `load_bit_by_bit()`.
