### PR TITLE
Fix files index

### DIFF
--- a/ranger/core/tab.py
+++ b/ranger/core/tab.py
@@ -73,6 +73,8 @@ class Tab(FileManagerAware, SettingsAware):  # pylint: disable=too-many-instance
             self._pointed_obj = self.thisdir.files[self._pointer]
         except TypeError:
             pass
+        except IndexError:
+            pass
 
     pointer = property(_get_pointer, _set_pointer)
 


### PR DESCRIPTION
When we try type ```scout -aestf``` (flag 'f' is important), we get "IndexError: list index out of range".

#### ISSUE TYPE
<!-- Pick relevant types and delete the rest -->
- Bug fix

#### RUNTIME ENVIRONMENT
<!-- Details of your runtime environment -->
<!-- Retrieve Python/ranger version and locale with `ranger -\-version` -->
- Operating system and version: Linux
- Terminal emulator and version: st
- Python version: 3.8.6 (default, Sep 30 2020, 04:00:38) [GCC 10.2.0]
- Ranger version/commit: ranger-master v1.9.3-146-g6fd49695
- Locale: en_US.UTF-8

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [X] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [X] All changes follow the code style **[REQUIRED]**
- [X] All new and existing tests pass **[REQUIRED]**
- [ ] Changes require config files to be updated
    - [ ] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
<!-- Describe the changes in detail -->
I just add new handler for IndexError, as toonn did it in #2071.

#### MOTIVATION AND CONTEXT
<!-- Why are these changes required? -->
<!-- What problems do these changes solve? -->
<!-- Link to relevant issues -->
I many often get this error and I hate this.
I also think it may be relate with: #2086, #2136, #2173, #2125

#### TESTING
<!-- What tests have been run? -->
<!-- How does the changes affect other areas of the codebase? -->


#### IMAGES / VIDEOS<!-- Only if relevant -->
<!-- Link or embed images and videos of screenshots, sketches etc. -->
