### PR TITLE
Fix #2187

### DIFF
--- a/ranger.py
+++ b/ranger.py
@@ -10,11 +10,8 @@
 # The other arguments are passed to ranger.
 """":
 temp_file="$(mktemp -t "ranger_cd.XXXXXXXXXX")"
-ranger="${1:-ranger}"
-if [ -n "$1" ]; then
-    shift
-fi
-"$ranger" --choosedir="$temp_file" -- "${@:-$PWD}"
+# command is used to prevent running into a recursive loop if the user aliased `ranger` to `source ranger`
+command ranger --choosedir="$temp_file" "$@"
 return_value="$?"
 if chosen_dir="$(cat -- "$temp_file")" && [ -n "$chosen_dir" ] && [ "$chosen_dir" != "$PWD" ]; then
     cd -- "$chosen_dir"


### PR DESCRIPTION
Fixes issue #2187
Removed apparently incorrect usage of the `$1` positional argument.
Removed the `--` on line 14 which blocked passing options to ranger.

<!-- Provide a descriptive summary of the changes in the title above -->

#### ISSUE TYPE
- Bug fix

#### RUNTIME ENVIRONMENT
- Operating system and version: Linux 5.4.80-2-MANJARO
- Terminal emulator and version: xfce4-terminal 0.8.9.2
- Python version: 3.8.6 (default, Sep 30 2020, 04:00:38) [GCC 10.2.0]
- Ranger version/commit: ranger-master 
- Locale: en_US.UTF-8
- Shell: GNU bash, version 5.0.18(1)-release

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [x] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [x] All changes follow the code style **[REQUIRED]**
- [x] All new and existing tests pass **[REQUIRED]** (I assume, there are no tests on what I changed)
- [ ] Changes require config files to be updated
    - [ ] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
- Removed apparently incorrect usage of the `$1` positional argument, as explained in issue #2187.
- Removed the `--` on line 14 which blocked passing options (`--help` and such) to ranger.
- Remove unnecessary substitution in line 14 (`${@:-$PWD}`). Ranger defaults to current directory on its own if no path is provided.

#### MOTIVATION AND CONTEXT
Fix issue #2187


#### TESTING
I tried running ranger with the following commands and all worked as expected (as opposed to before):
```sh
source ranger
source ranger path/to/begin/at
source ranger --help
source ranger --cmd="echo test"
source ranger --cmd="echo test" path/to/begin/at

alias ranger='source ranger'
ranger
ranger path/to/begin/at
ranger --help
ranger --cmd="echo test"
ranger --cmd="echo test" path/to/begin/at
```
