### PR TITLE
Tags errors

### DIFF
--- a/ranger/container/tags.py
+++ b/ranger/container/tags.py
@@ -13,15 +13,16 @@ from ranger import PY3
 ALLOWED_KEYS = string.ascii_letters + string.digits + string.punctuation
 
 
-class Tags(object):
+class Tags(FileManagerAware):
     default_tag = '*'
 
     def __init__(self, filename):
 
+        # COMPAT: The intent is to get abspath/normpath's behavior of
+        # collapsing `symlink/..`, abspath is retained for historical reasons
+        # because the documentation states its behavior isn't necessarily in
+        # line with normpath's.
         self._filename = realpath(abspath(expanduser(filename)))
-
-        if isdir(dirname(self._filename)) and not exists(self._filename):
-            open(self._filename, 'w')
 
         self.sync()
 
@@ -71,8 +72,11 @@ class Tags(object):
                 fobj = open(self._filename, 'r', errors='replace')
             else:
                 fobj = open(self._filename, 'r')
-        except OSError:
-            pass
+        except OSError as err:
+            if exists(self._filename):
+                self.fm.notify(err, bad=True)
+            else:
+                self.tags = dict()
         else:
             self.tags = self._parse(fobj)
             fobj.close()
@@ -80,8 +84,8 @@ class Tags(object):
     def dump(self):
         try:
             fobj = open(self._filename, 'w')
-        except OSError:
-            pass
+        except OSError as err:
+            self.fm.notify(err, bad=True)
         else:
             self._compile(fobj)
             fobj.close()

--- a/ranger/container/tags.py
+++ b/ranger/container/tags.py
@@ -30,6 +30,8 @@ class Tags(FileManagerAware):
         return item in self.tags
 
     def add(self, *items, **others):
+        if len(*items) == 0:
+            return
         tag = others.get('tag', self.default_tag)
         self.sync()
         for item in items:
@@ -37,6 +39,8 @@ class Tags(FileManagerAware):
         self.dump()
 
     def remove(self, *items):
+        if len(*items) == 0:
+            return
         self.sync()
         for item in items:
             try:
@@ -46,6 +50,8 @@ class Tags(FileManagerAware):
         self.dump()
 
     def toggle(self, *items, **others):
+        if len(*items) == 0:
+            return
         tag = others.get('tag', self.default_tag)
         tag = str(tag)
         if tag not in ALLOWED_KEYS:

--- a/ranger/container/tags.py
+++ b/ranger/container/tags.py
@@ -5,10 +5,11 @@
 
 from __future__ import (absolute_import, division, print_function)
 
-from os.path import isdir, exists, dirname, abspath, realpath, expanduser, sep
+from os.path import exists, abspath, realpath, expanduser, sep
 import string
 
 from ranger import PY3
+from ranger.core.shared import FileManagerAware
 
 ALLOWED_KEYS = string.ascii_letters + string.digits + string.punctuation
 


### PR DESCRIPTION
Report errors if tag file does not exist

A non-existent tag file leads to an opaque crash without indication to
the user of what went wrong as in #2200. These errors are now reported
through ranger's notify mechanism.

The tag file is no longer created conditionally on `__init__`, only upon
writing saving tags. This changes the behavior somewhat in that an empty
"tagged" file should never be created.

 Only write tags if they might've changed