### PR TITLE
fixed ranger crash when right clicking on unfocused folder in a small terminal window

### DIFF
--- a/ranger/core/tab.py
+++ b/ranger/core/tab.py
@@ -69,7 +69,9 @@ class Tab(FileManagerAware, SettingsAware):  # pylint: disable=too-many-instance
 
     def _set_pointer(self, value):
         self._pointer = value
-        self._pointed_obj = self.thisdir.files[self._pointer]
+
+        if self.thisdir.files is not None:
+            self._pointed_obj = self.thisdir.files[self._pointer]
 
     pointer = property(_get_pointer, _set_pointer)
 


### PR DESCRIPTION
<!-- Provide a descriptive summary of the changes in the title above -->

#### ISSUE TYPE
- Bug fix

#### RUNTIME ENVIRONMENT
<!-- Details of your runtime environment -->
<!-- Retrieve Python/ranger version and locale with `ranger -\-version` -->
- Operating system and version: Manjaro Linux 5.4
- Terminal emulator and version: Konsole 20.12.0
- Python version: 3.9.1
- Ranger version/commit: master 
- Locale: en_CA.UTF-8

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [x] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [X] All changes follow the code style **[REQUIRED]**
- [X] All new and existing tests pass **[REQUIRED]**
- [ ] Changes require config files to be updated
    - [ ] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
I added an if statement in tab.py that only changes the pointed object if self.thisdir.files is not none.

#### MOTIVATION AND CONTEXT
Please refer to this issue: [https://github.com/ranger/ranger/issues/2205]

#### TESTING
After applying the fix I was able to right click unfocused folders without ranger crashing. Since this is a small patch, this pull request shouldn't affect other areas of the codebase.
