### PR TITLE
Fix python versions compatibility in scope.sh

### DIFF
--- a/ranger/data/scope.sh
+++ b/ranger/data/scope.sh
@@ -218,7 +218,8 @@ handle_image() {
         #     { [ "$rar" ] && fn=$(unrar lb -p- -- "${FILE_PATH}"); } || \
         #     { [ "$zip" ] && fn=$(zipinfo -1 -- "${FILE_PATH}"); } || return
         #
-        #     fn=$(echo "$fn" | python -c "import sys; import mimetypes as m; \
+        #     fn=$(echo "$fn" | python -c "from __future__ import print_function; \
+        #             import sys; import mimetypes as m; \
         #             [ print(l, end='') for l in sys.stdin if \
         #               (m.guess_type(l[:-1])[0] or '').startswith('image/') ]" |\
         #         sort -V | head -n 1)


### PR DESCRIPTION
<!-- Provide a descriptive summary of the changes in the title above -->

#### ISSUE TYPE
<!-- Pick relevant types and delete the rest -->
- Bug fix

#### RUNTIME ENVIRONMENT
<!-- Details of your runtime environment -->
<!-- Retrieve Python/ranger version and locale with `ranger -\-version` -->
- Operating system and version: `Ubuntu 20.04 LTS` & `macOS Catalina`
- Terminal emulator and version: `Gnome-Terminal` / `iTerm 2`
- Python version: `Python 3.8` & `Python 2.7.18`
- Ranger version/commit: `master`
- Locale: `en_US.utf8`

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [X] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [X] All changes follow the code style **[REQUIRED]**
- [X] All new and existing tests pass **[REQUIRED]**
- [ ] Changes require config files to be updated
    - [ ] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
<!-- Describe the changes in detail -->
Add `from __future__ import print_function` to `python -c` command.

#### MOTIVATION AND CONTEXT
<!-- Why are these changes required? -->
The preview for Zip file cannot show properly if `/usr/bin/python` is `Python 2`. 
<!-- What problems do these changes solve? -->
<!-- Link to relevant issues -->


#### TESTING
<!-- What tests have been run? -->
<!-- How does the changes affect other areas of the codebase? -->


#### IMAGES / VIDEOS<!-- Only if relevant -->
<!-- Link or embed images and videos of screenshots, sketches etc. -->
