### PR TITLE
Centering tab text with/without directory name

### DIFF
--- a/ranger/gui/widgets/titlebar.py
+++ b/ranger/gui/widgets/titlebar.py
@@ -132,10 +132,11 @@ class TitleBar(Widget):
             for tabname in self.fm.get_tab_list():
                 tabtext = self._get_tab_text(tabname)
                 clr = 'good' if tabname == self.fm.current_tab else 'bad'
+                bar.addright(' ', 'space', fixed=True)
                 bar.addright(tabtext, 'tab', clr, fixed=True)
 
     def _get_tab_text(self, tabname):
-        result = ' ' + str(tabname)
+        result = str(tabname)
         if self.settings.dirname_in_tabs:
             dirname = basename(self.fm.tabs[tabname].path)
             if not dirname:
@@ -144,7 +145,7 @@ class TitleBar(Widget):
                 result += ":" + dirname[:14] + self.ellipsis[self.settings.unicode_ellipsis]
             else:
                 result += ":" + dirname
-        return result + ' '
+        return result
 
     def _print_result(self, result):
         self.win.move(0, 0)

--- a/ranger/gui/widgets/titlebar.py
+++ b/ranger/gui/widgets/titlebar.py
@@ -121,6 +121,11 @@ class TitleBar(Widget):
                 self.settings.show_selection_in_titlebar:
             bar.add(self.fm.thisfile.relative_path, 'file')
 
+    def _add_tab(self, bar, tabname):
+        tabtext = self._get_tab_text(tabname)
+        clr = 'good' if tabname == self.fm.current_tab else 'bad'
+        bar.addright(tabtext, 'tab', clr, fixed=True)
+
     def _get_right_part(self, bar):
         # TODO: fix that pressed keys are cut off when chaining CTRL keys
         kbuf = str(self.fm.ui.keybuffer)
@@ -129,11 +134,11 @@ class TitleBar(Widget):
         bar.addright(kbuf, 'keybuffer', fixed=True)
         bar.addright(' ', 'space', fixed=True)
         if len(self.fm.tabs) > 1:
-            for tabname in self.fm.get_tab_list():
-                tabtext = self._get_tab_text(tabname)
-                clr = 'good' if tabname == self.fm.current_tab else 'bad'
+            tablist = self.fm.get_tab_list()
+            self._add_tab(bar, tablist[0])
+            for tabname in tablist[1:]:
                 bar.addright(' ', 'space', fixed=True)
-                bar.addright(tabtext, 'tab', clr, fixed=True)
+                self._add_tab(bar, tabname)
 
     def _get_tab_text(self, tabname):
         result = str(tabname)

--- a/ranger/gui/widgets/titlebar.py
+++ b/ranger/gui/widgets/titlebar.py
@@ -144,7 +144,7 @@ class TitleBar(Widget):
                 result += ":" + dirname[:14] + self.ellipsis[self.settings.unicode_ellipsis]
             else:
                 result += ":" + dirname
-        return result
+        return result + ' '
 
     def _print_result(self, result):
         self.win.move(0, 0)


### PR DESCRIPTION
<!-- Provide a descriptive summary of the changes in the title above -->

#### ISSUE TYPE
- Improvement/feature implementation

#### RUNTIME ENVIRONMENT

<!-- Details of your runtime environment -->
<!-- Retrieve Python/ranger version and locale with `ranger -\-version` -->
- Operating system and version: WSL
- Terminal emulator and version: mintty
- Python version: 3.9.1
- Ranger version/commit: 1.9.3
- Locale: en_US.UTF-8

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [x] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [x] All changes follow the code style **[REQUIRED]**
- [x] All new and existing tests pass **[REQUIRED]**
- [ ] Changes require config files to be updated
    - [ ] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
Tab text is not centered due to not having a space on the right of text. Adding a space to make tabs text centered.


#### MOTIVATION AND CONTEXT
<!-- Why are these changes required? -->
Cosmetic and looks better.
<!-- What problems do these changes solve? -->
Irritation
<!-- Link to relevant issues -->


#### TESTING
<!-- What tests have been run? -->
Ran ranger with and without directory in tab names.

<!-- How does the changes affect other areas of the codebase? -->
Not much.

#### IMAGES / VIDEOS<!-- Only if relevant -->
<!-- Link or embed images and videos of screenshots, sketches etc. -->
