### PR TITLE
Added -s flag for set position by char seq '^&'.

### DIFF
--- a/doc/ranger.1
+++ b/doc/ranger.1
@@ -133,7 +133,7 @@
 .\" ========================================================================
 .\"
 .IX Title "RANGER 1"
-.TH RANGER 1 "ranger-1.9.3" "2020-11-18" "ranger manual"
+.TH RANGER 1 "ranger-1.9.3" "2021-01-22" "ranger manual"
 .\" For nroff, turn off justification.  Always turn off hyphenation; it makes
 .\" way too many mistakes in technical documents.
 .if n .ad l
@@ -1247,7 +1247,7 @@ ranger.  For your convenience, this is a list of the \*(L"public\*(R" commands i
 \& chain command1[; command2[; command3...]]
 \& chmod octal_number
 \& cmap key command
-\& console [\-pSTARTPOSITION] command
+\& console [\-pSTARTPOSITION | \-s SENTINEL] command
 \& copycmap key newkey [newkey2...]
 \& copymap key newkey [newkey2...]
 \& copypmap key newkey [newkey2...]
@@ -1341,10 +1341,12 @@ example, \fB+ar\fR allows reading for everyone, \-ow forbids others to write and
 777= allows everything.
 .Sp
 See also: man 1 chmod
-.IP "console [\-p\fIN\fR] \fIcommand\fR" 2
-.IX Item "console [-pN] command"
-Opens the console with the command already typed in.  The cursor is placed at
-\&\fIN\fR.
+.IP "console [\-p\fIN\fR | \-s \fIsentinel\fR] \fIcommand\fR" 2
+.IX Item "console [-pN | -s sentinel] command"
+Opens the console with the command already typed in. The cursor is placed at
+\&\fIN\fR or at the first occurrence of \fIsentinel\fR. Note that sentinel strings can
+potentially occur inside macro expansions. If you cannot provide a sentinel,
+which is guaranteed to be unique, you should use \f(CW\*(C`\-p\*(C'\fR.
 .IP "copymap  \fIkey\fR \fInewkey\fR [\fInewkey2\fR ...]" 2
 .IX Item "copymap key newkey [newkey2 ...]"
 .PD 0

--- a/doc/ranger.pod
+++ b/doc/ranger.pod
@@ -1347,7 +1347,7 @@ ranger.  For your convenience, this is a list of the "public" commands including
  chain command1[; command2[; command3...]]
  chmod octal_number
  cmap key command
- console [-pSTARTPOSITION] command
+ console [-pSTARTPOSITION | -s SENTINEL] command
  copycmap key newkey [newkey2...]
  copymap key newkey [newkey2...]
  copypmap key newkey [newkey2...]
@@ -1448,10 +1448,12 @@ example, B<+ar> allows reading for everyone, -ow forbids others to write and
 
 See also: man 1 chmod
 
-=item console [-pI<N>] I<command>
+=item console [-pI<N> | -s I<sentinel>] I<command>
 
-Opens the console with the command already typed in.  The cursor is placed at
-I<N>.
+Opens the console with the command already typed in. The cursor is placed at
+I<N> or at the first occurrence of I<sentinel>. Note that sentinel strings can
+potentially occur inside macro expansions. If you cannot provide a sentinel
+which is guaranteed to be unique, you should use C<-p>.
 
 =item copymap  I<key> I<newkey> [I<newkey2> ...]
 

--- a/ranger/config/commands.py
+++ b/ranger/config/commands.py
@@ -850,7 +850,7 @@ class console(Command):
             separate = self.arg(2)
             position = command.find(separate)
             if position != -1:
-                command = command.replace(separate, '')
+                command = command.replace(separate, '', 1)
             else:
                 position = None
         self.fm.open_console(command, position=position)

--- a/ranger/config/commands.py
+++ b/ranger/config/commands.py
@@ -828,21 +828,30 @@ class mark_tag(Command):
 
 
 class console(Command):
-    """:console <command>
+    """:console [-p N] [-s] <command>
 
+    Flags:
+     -p N   Set position at N index
+     -s     Set postion at '^&'
     Open the console with the given command.
     """
 
     def execute(self):
         position = None
+        command = self.rest(2)
         if self.arg(1)[0:2] == '-p':
             try:
                 position = int(self.arg(1)[2:])
             except ValueError:
                 pass
+        elif self.arg(1)[0:2] == '-s':
+            position = command.find('^&')
+            if position != -1:
+                command = command.replace('^&', '')
             else:
-                self.shift()
-        self.fm.open_console(self.rest(1), position=position)
+                position = None
+        self.fm.open_console(command, position=position)
+
 
 
 class load_copy_buffer(Command):

--- a/ranger/config/commands.py
+++ b/ranger/config/commands.py
@@ -828,7 +828,7 @@ class mark_tag(Command):
 
 
 class console(Command):
-    """:console [-p N] [-s sep] <command>
+    """:console [-p N | -s sep] <command>
 
     Flags:
      -p N   Set position at N index

--- a/ranger/config/commands.py
+++ b/ranger/config/commands.py
@@ -828,30 +828,32 @@ class mark_tag(Command):
 
 
 class console(Command):
-    """:console [-p N] [-s] <command>
+    """:console [-p N] [-s sep] <command>
 
     Flags:
      -p N   Set position at N index
-     -s     Set postion at '^&'
+     -s sep Set position at separator(any char[s] sequence), example '#'
     Open the console with the given command.
     """
 
     def execute(self):
         position = None
-        command = self.rest(2)
+        command = ""
         if self.arg(1)[0:2] == '-p':
+            command = self.rest(2)
             try:
                 position = int(self.arg(1)[2:])
             except ValueError:
                 pass
         elif self.arg(1)[0:2] == '-s':
-            position = command.find('^&')
+            command = self.rest(3)
+            separate = self.arg(2)
+            position = command.find(separate)
             if position != -1:
-                command = command.replace('^&', '')
+                command = command.replace(separate, '')
             else:
                 position = None
         self.fm.open_console(command, position=position)
-
 
 
 class load_copy_buffer(Command):


### PR DESCRIPTION
<!-- Provide a descriptive summary of the changes in the title above -->

#### ISSUE TYPE
<!-- Pick relevant types and delete the rest -->
- Improvement/feature implementation

#### RUNTIME ENVIRONMENT
<!-- Details of your runtime environment -->
<!-- Retrieve Python/ranger version and locale with `ranger -\-version` -->
- Operating system and version: Archlinux, 5.10.8-arch1-1
- Terminal emulator and version: st
- Python version: 3.9.1
- Ranger version/commit: ranger-master v1.9.3-174-g290c1f5f
- Locale: en_US.UTF-8

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [X] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [X] All changes follow the code style **[REQUIRED]**
- [X] All new and existing tests pass **[REQUIRED]**
- [X] Changes require config files to be updated (config/command.py)

#### DESCRIPTION
<!-- Describe the changes in detail -->
Added '-s' flag for "console" command. It sets cursor position at index of special characters.
'%^' make some errors and '^&' look pretty and little logical.

#### MOTIVATION AND CONTEXT
<!-- Why are these changes required? -->
<!-- What problems do these changes solve? -->
<!-- Link to relevant issues -->
#1914
And it's actully usefull feature.

#### TESTING
<!-- What tests have been run? -->
<!-- How does the changes affect other areas of the codebase? -->


#### IMAGES / VIDEOS<!-- Only if relevant -->
<!-- Link or embed images and videos of screenshots, sketches etc. -->
