### PR TITLE
Add experimental sixel support for image preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ For enhanced file previews (with `scope.sh`):
 
 * `img2txt` (from `caca-utils`) for ASCII-art image previews
 * `w3mimgdisplay`, `ueberzug`, `mpv`, `iTerm2`, `kitty`, `terminology` or `urxvt` for image previews
-* `convert` (from `imagemagick`) to auto-rotate images and for SVG previews
+* `convert` (from `imagemagick`) to auto-rotate images, for SVG previews and for `sixel` image preview method
 * `ffmpegthumbnailer` for video thumbnails
 * `highlight`, `bat` or `pygmentize` for syntax highlighting of code
 * `atool`, `bsdtar`, `unrar` and/or `7z` to preview archives

--- a/doc/ranger.1
+++ b/doc/ranger.1
@@ -308,7 +308,7 @@ are automatically used when available but completely optional.
 \&\f(CW\*(C`w3mimgdisplay\*(C'\fR, \f(CW\*(C`ueberzug\*(C'\fR, \f(CW\*(C`mpv\*(C'\fR, \f(CW\*(C`iTerm2\*(C'\fR, \f(CW\*(C`kitty\*(C'\fR, \f(CW\*(C`terminology\*(C'\fR or
 \&\f(CW\*(C`urxvt\*(C'\fR for image previews
 .IP "\-" 2
-\&\f(CW\*(C`convert\*(C'\fR (from \f(CW\*(C`imagemagick\*(C'\fR) to auto-rotate images and for \s-1SVG\s0 previews
+\&\f(CW\*(C`convert\*(C'\fR (from \f(CW\*(C`imagemagick\*(C'\fR) to auto-rotate images, for \s-1SVG\s0 previews and for \f(CW\*(C`sixel\*(C'\fR image preview method
 .IP "\-" 2
 \&\f(CW\*(C`ffmpegthumbnailer\*(C'\fR for video thumbnails
 .IP "\-" 2
@@ -412,6 +412,16 @@ To enable this feature, install the program \*(L"w3m\*(R" and set the option
 .PP
 When using a terminal with a nonzero border which is not automatically detected, the w3m preview will be misaligned.
 Use the \f(CW\*(C`w3m_offset\*(C'\fR option to manually adjust the image offset. This should be the same value as the terminal's border value.
+.PP
+\fIsixel\fR
+.IX Subsection "sixel"
+.PP
+This method allows to preview images over ssh, requires certain terminals which
+support Sixel graphics format (tested on \*(L"xterm\*(R", \*(L"iTerm2\*(R"
+\&\*(L"mintty\*(R", \*(L"foot\*(R" and \*(L"mlterm\*(R").
+.PP
+To enable this feature, install the program \*(L"ImageMagick\*(R" and set the option
+\&\f(CW\*(C`preview_images_method\*(C'\fR to sixel.
 .SS "\s-1SELECTION\s0"
 .IX Subsection "SELECTION"
 The \fIselection\fR is defined as \*(L"All marked files \s-1IF THERE ARE ANY,\s0 otherwise

--- a/doc/ranger.pod
+++ b/doc/ranger.pod
@@ -359,6 +359,15 @@ C<preview_images_method> to w3m.
 When using a terminal with a nonzero border which is not automatically detected, the w3m preview will be misaligned.
 Use the C<w3m_offset> option to manually adjust the image offset. This should be the same value as the terminal's border value.
 
+=head3 sixel
+
+This method allows to preview images over ssh, requires certain terminals which
+support Sixel graphics format (tested on "xterm", "iTerm2" "mintty", "foot" and
+"mlterm").
+
+To enable this feature, install the program "ImageMagick" and set the option
+C<preview_images_method> to sixel.
+
 =head2 SELECTION
 
 The I<selection> is defined as "All marked files IF THERE ARE ANY, otherwise

--- a/ranger/config/rc.conf
+++ b/ranger/config/rc.conf
@@ -113,6 +113,11 @@ set preview_images false
 #   Preview images in full color with the external command "ueberzug".
 #   Images are shown by using a child window.
 #   Only for users who run X11 in GNU/Linux.
+#
+# * sixel:
+#   Preview images in full color using old Sixel graphics format. This
+#   requires ImageMagick and a terminal which supports Sixel (e.g. xterm,
+#   iTerm2, mintty, foot).
 set preview_images_method w3m
 
 # Delay in seconds before displaying an image with the w3m method.

--- a/ranger/container/settings.py
+++ b/ranger/container/settings.py
@@ -113,7 +113,7 @@ ALLOWED_VALUES = {
     'one_indexed': [False, True],
     'preview_images_method': ['w3m', 'iterm2', 'terminology',
                               'urxvt', 'urxvt-full', 'kitty',
-                              'ueberzug'],
+                              'ueberzug', 'sixel'],
     'vcs_backend_bzr': ['disabled', 'local', 'enabled'],
     'vcs_backend_git': ['enabled', 'disabled', 'local'],
     'vcs_backend_hg': ['disabled', 'local', 'enabled'],

--- a/ranger/ext/img_display.py
+++ b/ranger/ext/img_display.py
@@ -360,7 +360,7 @@ class ITerm2ImageDisplayer(ImageDisplayer, FileManagerAware):
                 file_handle.seek(0)
                 size = 2
                 ftype = 0
-                while not 0xc0 <= ftype <= 0xcf:
+                while not 0xc0 <= ftype <= 0xcf or ftype in (0xc4, 0xc8, 0xcc):
                     file_handle.seek(size, 1)
                     byte = file_handle.read(1)
                     while ord(byte) == 0xff:


### PR DESCRIPTION
#### ISSUE TYPE
- Improvement/feature implementation

#### RUNTIME ENVIRONMENT
- Operating system and version: Arch Linux
- Terminal emulator and version: foot (1.6.2 +ime)
- Python version: 3.9.1 (default, Dec 13 2020, 11:55:53) [GCC 10.2.0]
- Ranger version/commit: ranger-master (73bcd80c1c3e721391c75015cb4ec03532357ad9)
- Locale: en_US.UTF-8

#### CHECKLIST

- [X] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [X] All changes follow the code style **[REQUIRED]**
- [X] All new and existing tests pass **[REQUIRED]**
- [X] Changes require config files to be updated
    - [X] Config files have been updated
- [X] Changes require documentation to be updated
    - [X] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
This patch adds ability to use ImageMagick and Sixel graphics format for image preview

#### MOTIVATION AND CONTEXT
#723 

#### TESTING

#### IMAGES / VIDEOS
![image](https://user-images.githubusercontent.com/5285328/105533205-75057680-5cf4-11eb-8c1f-a0651639f2ce.png)
![image](https://user-images.githubusercontent.com/5285328/105533763-3cb26800-5cf5-11eb-888f-02c1044d7f39.png)
