### PR TITLE
Fix empty console when using :console without position option

### DIFF
--- a/ranger/config/commands.py
+++ b/ranger/config/commands.py
@@ -853,6 +853,8 @@ class console(Command):
                 command = command.replace(separate, '', 1)
             else:
                 position = None
+        else:
+            command = self.rest(1)
         self.fm.open_console(command, position=position)
 
 

--- a/ranger/config/commands.py
+++ b/ranger/config/commands.py
@@ -847,12 +847,11 @@ class console(Command):
                 pass
         elif self.arg(1)[0:2] == '-s':
             command = self.rest(3)
-            separate = self.arg(2)
-            position = command.find(separate)
-            if position != -1:
-                command = command.replace(separate, '', 1)
-            else:
-                position = None
+            sentinel = self.arg(2)
+            pos = command.find(sentinel)
+            if pos != -1:
+                command = command.replace(sentinel, '', 1)
+                position = pos
         self.fm.open_console(command, position=position)
 
 

--- a/ranger/config/commands.py
+++ b/ranger/config/commands.py
@@ -838,7 +838,7 @@ class console(Command):
 
     def execute(self):
         position = None
-        command = ""
+        command = self.rest(1)
         if self.arg(1)[0:2] == '-p':
             command = self.rest(2)
             try:
@@ -853,8 +853,6 @@ class console(Command):
                 command = command.replace(separate, '', 1)
             else:
                 position = None
-        else:
-            command = self.rest(1)
         self.fm.open_console(command, position=position)
 
 


### PR DESCRIPTION
<!-- Provide a descriptive summary of the changes in the title above -->

#### ISSUE TYPE
- Bug fix

#### RUNTIME ENVIRONMENT
- Operating system and version: Arch Linux
- Terminal emulator and version: rxvt-unicode 9.22-10
- Python version: Python 3.9.1
- Ranger version/commit: commit 6e78bbe3 (current master)
- Locale: en_US

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [x] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [x] All changes follow the code style **[REQUIRED]**
- [x] All new and existing tests pass **[REQUIRED]**
- [ ] Changes require config files to be updated
    - [ ] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
<!-- Describe the changes in detail -->
Merge 6e78bbe39 introduced an option for :console to specify cursor position with
a sentinel character. Since then it doesn't actually insert the command if none
of the cursor position options are used, which is fixed here.

Steps to reproduce:
- Run the command `:console test`

Result on current master: the console input is empty, doesn't show the command "test".
Result with this change: the console shows the command "test". Cursor is positioned at the end.

#### MOTIVATION AND CONTEXT
<!-- Why are these changes required? -->
<!-- What problems do these changes solve? -->
<!-- Link to relevant issues -->
Breaking change was introduced in merge commit 6e78bbe39 https://github.com/ranger/ranger/commit/6e78bbe39a5a5edecf6021788a63799333fa7e43