### PR TITLE
Added showing number of all files, if we have filter.

### DIFF
--- a/ranger/gui/widgets/statusbar.py
+++ b/ranger/gui/widgets/statusbar.py
@@ -304,7 +304,10 @@ class StatusBar(Widget):  # pylint: disable=too-many-instance-attributes
             # away and don't see them anymore.
             right.add('Mrk', base, 'marked')
         elif target.files:
-            right.add(str(target.pointer + 1) + '/' + str(len(target.files)) + '  ', base)
+            if target.filter == None:
+                right.add("{ptr}/{num}  ".format(ptr=str(target.pointer + 1), num=str(len(target.files))), base)
+            else:
+                right.add("{ptr}/{num}({all})  ".format(ptr=str(target.pointer + 1), num=str(len(target.files)), all=str(len(target.files_all))), base)
             if max_pos <= 0:
                 right.add('All', base, 'all')
             elif pos == 0:


### PR DESCRIPTION
<!-- Provide a descriptive summary of the changes in the title above -->

#### ISSUE TYPE
<!-- Pick relevant types and delete the rest -->
- Improvement/feature implementation


#### RUNTIME ENVIRONMENT
<!-- Details of your runtime environment -->
<!-- Retrieve Python/ranger version and locale with `ranger -\-version` -->
- Python version: 3.9.1
- Ranger version/commit: ranger-master v1.9.3-216-gaabaa4fd / 07bad74
- Locale: en_US.UTF-8

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [X] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [X] All changes follow the code style **[REQUIRED]**
- [X] All new and existing tests pass **[REQUIRED]**
- [ ] Changes require config files to be updated
    - [ ] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
<!-- Describe the changes in detail -->
If we have active filter(not default), then adding the numbers of all files in dir(with hidden by default).

#### MOTIVATION AND CONTEXT
<!-- Why are these changes required? -->
<!-- What problems do these changes solve? -->
<!-- Link to relevant issues -->
#2067
Actually needed feature. I also catch myself in situation "where these files wtf".