### PR TITLE
Add capability to preview GZ files

### DIFF
--- a/ranger/data/scope.sh
+++ b/ranger/data/scope.sh
@@ -54,6 +54,7 @@ handle_extension() {
         rpm|rz|t7z|tar|tbz|tbz2|tgz|tlz|txz|tZ|tzo|war|xpi|xz|Z|zip)
             atool --list -- "${FILE_PATH}" && exit 5
             bsdtar --list --file "${FILE_PATH}" && exit 5
+	    zcat -- "${FILE_PATH}" && exit 5
             exit 1;;
         rar)
             ## Avoid password prompt by providing empty password


### PR DESCRIPTION
#### ISSUE TYPE
- Improvement/feature implementation

#### RUNTIME ENVIRONMENT
Ubuntu 20.04 LTS
zsh
ranger version: ranger 1.9.3
Python version: 3.8.5 (default, Jul 28 2020, 12:59:40) [GCC 9.3.0]
Locale: en_US.UTF-8

#### CHECKLIST
- [X ] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [X ] All changes follow the code style **[REQUIRED]**
- [X ] All new and existing tests pass **[REQUIRED]**
- [ ] Changes require config files to be updated
    - [ ] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
Allows for previewing GZ files.

#### MOTIVATION AND CONTEXT
[2259](https://github.com/ranger/ranger/issues/2259)


#### TESTING
Tested manually
