### PR TITLE
Fix file URI prefix

### DIFF
--- a/ranger/core/main.py
+++ b/ranger/core/main.py
@@ -244,7 +244,7 @@ https://github.com/ranger/ranger/issues
 
 def get_paths(args):
     if args.paths:
-        prefix = 'file:///'
+        prefix = 'file://'
         prefix_length = len(prefix)
         paths = [path[prefix_length:] if path.startswith(prefix) else path for path in args.paths]
     else:


### PR DESCRIPTION
Currently, ranger incorrectly handles file URI path arguments (does not open, reports *Inaccessible paths*). This is due to the URI prefix string in the code containing an extra slash (`file:///` instead of `file://`). This PR fixes that.

#### ISSUE TYPE

- Bug fix

#### RUNTIME ENVIRONMENT

- Operating system and version: Fedora 33
- Terminal emulator and version: rxvt-unicode v9.22
- Python version: 3.9.1
- Ranger version: 1.9.3
- Locale: en_US.UTF-8

#### CHECKLIST

- [X] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [X] All changes follow the code style **[REQUIRED]**
- [X] All new and existing tests pass **[REQUIRED]**
- [ ] Changes require config files to be updated
    - [ ] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION

Please see #2265.

#### MOTIVATION AND CONTEXT

This PR fixes #2265.


#### TESTING

Tested using `make test_py` as well as manually.