### PR TITLE
feat: use quicklook on Mac to preview pdf

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ For enhanced file previews (with `scope.sh`):
   archives as their first image
 * `lynx`, `w3m` or `elinks` to preview html pages
 * `pdftotext` or `mutool` (and `fmt`) for textual `pdf` previews, `pdftoppm` to
-  preview as image
+  preview as image, and built-in `qlmanage` to preview as image on Mac.
 * `djvutxt` for textual DjVu previews, `ddjvu` to preview as image
 * `calibre` or `epub-thumbnailer` for image previews of ebooks
 * `transmission-show` for viewing BitTorrent information

--- a/ranger/config/rifle.conf
+++ b/ranger/config/rifle.conf
@@ -154,6 +154,7 @@ ext pdf, has okular,   X, flag f = okular -- "$@"
 ext pdf, has epdfview, X, flag f = epdfview -- "$@"
 ext pdf, has qpdfview, X, flag f = qpdfview "$@"
 ext pdf, has open,     X, flag f = open "$@"
+ext pdf, has qlmanage, X, flag f = qlmanage -p "$@"
 
 ext sc,    has sc,                    = sc -- "$@"
 ext docx?, has catdoc,       terminal = catdoc -- "$@" | $PAGER

--- a/ranger/data/scope.sh
+++ b/ranger/data/scope.sh
@@ -160,7 +160,18 @@ handle_image() {
         #     exit 1;;
 
         ## PDF
-        # application/pdf)
+        application/pdf)
+            if [[ "$(uname)" = "Darwin" ]]; then
+                ## Use mac built-in quicklook to preview pdf
+                ## rename extension from .png to .jpg provided by IMAGE_CACHE_PATH
+                ## image viewer can determine the actual format
+                qlmanage -t -s "${DEFAULT_SIZE%x*}" \
+                         -o "${IMAGE_CACHE_PATH%/*}" \
+                         ${FILE_PATH} \
+                         && mv "${IMAGE_CACHE_PATH%/*}/${FILE_PATH##*/}.png" "${IMAGE_CACHE_PATH}" \
+                         && exit 6 || exit 1
+            fi
+            exit 1;;
         #     pdftoppm -f 1 -l 1 \
         #              -scale-to-x "${DEFAULT_SIZE%x*}" \
         #              -scale-to-y -1 \

--- a/ranger/data/scope.sh
+++ b/ranger/data/scope.sh
@@ -172,6 +172,14 @@ handle_image() {
                          && exit 6 || exit 1
             fi
             exit 1;;
+            #if [[ "$(uname)" = "Darwin" ]]; then
+            #    echo 'Previewing in Mac Quicklook'
+            #    cat /tmp/rangerql.pid | xargs kill -9 > /dev/null 2>&1
+            #    nohup qlmanage -p ${FILE_PATH} > /dev/null 2>&1  &
+            #    rm /tmp/rangerql.pid
+            #    echo $! > "/tmp/rangerql.pid" && exit 5
+            #fi
+            #exit 1;;
         #     pdftoppm -f 1 -l 1 \
         #              -scale-to-x "${DEFAULT_SIZE%x*}" \
         #              -scale-to-y -1 \


### PR DESCRIPTION
<!-- Provide a descriptive summary of the changes in the title above -->

#### ISSUE TYPE
<!-- Pick relevant types and delete the rest -->
- Improvement/feature implementation

#### RUNTIME ENVIRONMENT
<!-- Details of your runtime environment -->
<!-- Retrieve Python/ranger version and locale with `ranger -\-version` -->
- Operating system and version: macos 11.2.2
- Terminal emulator and version: iTerm2 3.4.4
- Python version: Python 2.7 built in with macos
- Ranger version/commit: 1.9.3
- Locale: en_US

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [x] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [x] All changes follow the code style **[REQUIRED]**
- [x] All new and existing tests pass **[REQUIRED]**
- [ ] Changes require config files to be updated
    - [x] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
<!-- Describe the changes in detail -->
quicklook is Mac's built-in tool for previewing. Use it to preview pdf.

#### MOTIVATION AND CONTEXT
<!-- Why are these changes required? -->
<!-- What problems do these changes solve? -->
<!-- Link to relevant issues -->
Actually quicklook can preview many other formats. It's worthwhile to enable it by default, because every mac comes with it.


#### TESTING
<!-- What tests have been run? -->
<!-- How does the changes affect other areas of the codebase? -->
works on my mac. qlmanage is available on every mac. not sure since when, maybe 10 years ago, to the latest macos. And from my feeling, the API never changes.

#### IMAGES / VIDEOS<!-- Only if relevant -->
<!-- Link or embed images and videos of screenshots, sketches etc. -->
