### PR TITLE
Fix crash if man is not installed when hit '?' and 'm'.

### DIFF
--- a/ranger/core/actions.py
+++ b/ranger/core/actions.py
@@ -975,7 +975,7 @@ class Actions(  # pylint: disable=too-many-instance-attributes,too-many-public-m
                 return
         process = self.run(['man', 'ranger'])
         if process is None:
-            self.notify("Show manpage failed, check if man is installed", bad=True)
+            self.notify("Failed to show man page, check if man is installed", bad=True)
             return
         if process.poll() == 16:
             self.notify("Could not find manpage.", bad=True)

--- a/ranger/core/actions.py
+++ b/ranger/core/actions.py
@@ -974,6 +974,9 @@ class Actions(  # pylint: disable=too-many-instance-attributes,too-many-public-m
             if process.poll() != 16:
                 return
         process = self.run(['man', 'ranger'])
+        if process is None:
+            self.notify("Show manpage failed, check if man is installed", bad=True)
+            return
         if process.poll() == 16:
             self.notify("Could not find manpage.", bad=True)
 

--- a/ranger/core/actions.py
+++ b/ranger/core/actions.py
@@ -28,6 +28,7 @@ from ranger.core.loader import CommandLoader, CopyLoader
 from ranger.core.shared import FileManagerAware, SettingsAware
 from ranger.core.tab import Tab
 from ranger.ext.direction import Direction
+from ranger.ext.get_executables import get_executables
 from ranger.ext.keybinding_parser import key_to_string, construct_keybinding
 from ranger.ext.macrodict import MacroDict, MACRO_FAIL, macro_val
 from ranger.ext.next_available_filename import next_available_filename
@@ -968,17 +969,18 @@ class Actions(  # pylint: disable=too-many-instance-attributes,too-many-public-m
         pager.set_source(lines)
 
     def display_help(self):
-        manualpath = self.relpath('../doc/ranger.1')
-        if os.path.exists(manualpath):
-            process = self.run(['man', manualpath])
-            if process.poll() != 16:
-                return
-        process = self.run(['man', 'ranger'])
-        if process is None:
-            self.notify("Failed to show man page, check if man is installed", bad=True)
-            return
-        if process.poll() == 16:
-            self.notify("Could not find manpage.", bad=True)
+        if 'man' in get_executables():
+            manualpath = self.relpath('../doc/ranger.1')
+            if os.path.exists(manualpath):
+                process = self.run(['man', manualpath])
+                if process.poll() != 16:
+                    return
+            process = self.run(['man', 'ranger'])
+            if process.poll() == 16:
+                self.notify("Could not find manpage.", bad=True)
+        else:
+            self.notify("Failed to show man page, check if man is installed",
+                        bad=True)
 
     def display_log(self):
         logs = list(self.get_log())


### PR DESCRIPTION
On some systems (e.g. archlinuxarm) man is not installed by default, hit
'?' and 'm' will cause ranger crashed, showing:
AttributeError: 'NoneType' object has no attribute 'poll'.

<!-- Provide a descriptive summary of the changes in the title above -->

#### ISSUE TYPE
<!-- Pick relevant types and delete the rest -->
- Bug fix

#### RUNTIME ENVIRONMENT
<!-- Details of your runtime environment -->
<!-- Retrieve Python/ranger version and locale with `ranger -\-version` -->
- Operating system and version: archlinuxarm, with kernel 5.8.0
- Terminal emulator and version: zsh 5.8
- Python version: 3.9.1
- Ranger version/commit: 1.9.3
- Locale: zh_CN.UTF-8

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [x] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [X] All changes follow the code style **[REQUIRED]**
- [X] All new and existing tests pass **[REQUIRED]**
- [ ] Changes require config files to be updated
    - [ ] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
<!-- Describe the changes in detail -->
Hit ? and m on archlinuxarm will cause ranger to crash.

#### TESTING
<!-- What tests have been run? -->
<!-- How does the changes affect other areas of the codebase? -->
I have tested it on archlinuxarm.
