### PR TITLE
dart support addition in rifle.conf

### DIFF
--- a/ranger/config/rifle.conf
+++ b/ranger/config/rifle.conf
@@ -87,8 +87,8 @@ ext x?html?, has w3m,               terminal = w3m "$@"
 # Define the "editor" for text files as first action
 mime ^text,  label editor = ${VISUAL:-$EDITOR} -- "$@"
 mime ^text,  label pager  = $PAGER -- "$@"
-!mime ^text, label editor, ext xml|json|csv|tex|py|pl|rb|rs|js|sh|php = ${VISUAL:-$EDITOR} -- "$@"
-!mime ^text, label pager,  ext xml|json|csv|tex|py|pl|rb|rs|js|sh|php = $PAGER -- "$@"
+!mime ^text, label editor, ext xml|json|csv|tex|py|pl|rb|rs|js|sh|php|dart = ${VISUAL:-$EDITOR} -- "$@"
+!mime ^text, label pager,  ext xml|json|csv|tex|py|pl|rb|rs|js|sh|php|dart = $PAGER -- "$@"
 
 ext 1                         = man "$1"
 ext s[wmf]c, has zsnes, X     = zsnes "$1"
@@ -106,6 +106,7 @@ ext rb  = ruby -- "$1"
 ext js  = node -- "$1"
 ext sh  = sh -- "$1"
 ext php = php -- "$1"
+ext dart = dart "$1"
 
 #--------------------------------------------
 # Audio without X
@@ -273,9 +274,9 @@ label open, has xdg-open = xdg-open "$@"
 label open, has open     = open -- "$@"
 
 # Define the editor for non-text files + pager as last action
-              !mime ^text, !ext xml|json|csv|tex|py|pl|rb|rs|js|sh|php  = ask
-label editor, !mime ^text, !ext xml|json|csv|tex|py|pl|rb|rs|js|sh|php  = ${VISUAL:-$EDITOR} -- "$@"
-label pager,  !mime ^text, !ext xml|json|csv|tex|py|pl|rb|rs|js|sh|php  = $PAGER -- "$@"
+              !mime ^text, !ext xml|json|csv|tex|py|pl|rb|rs|js|sh|php|dart  = ask
+label editor, !mime ^text, !ext xml|json|csv|tex|py|pl|rb|rs|js|sh|php|dart  = ${VISUAL:-$EDITOR} -- "$@"
+label pager,  !mime ^text, !ext xml|json|csv|tex|py|pl|rb|rs|js|sh|php|dart  = $PAGER -- "$@"
 
 
 ######################################################################

--- a/ranger/config/rifle.conf
+++ b/ranger/config/rifle.conf
@@ -106,7 +106,7 @@ ext rb  = ruby -- "$1"
 ext js  = node -- "$1"
 ext sh  = sh -- "$1"
 ext php = php -- "$1"
-ext dart = dart "$1"
+ext dart = dart run -- "$1"
 
 #--------------------------------------------
 # Audio without X


### PR DESCRIPTION
<!-- Provide a descriptive summary of the changes in the title above -->

#### ISSUE TYPE
<!-- Pick relevant types and delete the rest -->
- Improvement/feature implementation

#### RUNTIME ENVIRONMENT
<!-- Details of your runtime environment -->
<!-- Retrieve Python/ranger version and locale with `ranger -\-version` -->
- Operating system and version: Arch Linux 5.11.7-zen
- Terminal emulator and version: kitty
- Python version: 3.9.2
- Ranger version/commit: v1.9.3
- Locale: en_US.UTF-8

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [X] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [X] All changes follow the code style **[REQUIRED]**
- [X] All new and existing tests pass **[REQUIRED]**
- [X] Changes require config files to be updated
    - [X] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
<!-- Describe the changes in detail -->
This Pull request adds dart support in rifle.

#### MOTIVATION AND CONTEXT
<!-- Why are these changes required? -->
<!-- What problems do these changes solve? -->
<!-- Link to relevant issues -->
when creating a new dart file, rifle didn't specially recognised [dart](https://dart.dev/overview) files, so added dart too in rifle.conf