### PR TITLE
Allow non writable confdir

### DIFF
--- a/ranger/core/main.py
+++ b/ranger/core/main.py
@@ -321,7 +321,7 @@ def parse_arguments():
     args, positional = parser.parse_args()
     args.paths = positional
 
-    def path_init(option):
+    def path_init(option, non_writable_ok=False):
         argval = args.__dict__[option]
         try:
             path = os.path.abspath(argval)
@@ -329,7 +329,7 @@ def parse_arguments():
             sys.stderr.write(
                 '--{0} is not accessible: {1}\n{2}\n'.format(option, argval, str(ex)))
             sys.exit(1)
-        if os.path.exists(path) and not os.access(path, os.W_OK):
+        if not non_writable_ok and os.path.exists(path) and not os.access(path, os.W_OK):
             sys.stderr.write('--{0} is not writable: {1}\n'.format(option, path))
             sys.exit(1)
         return path
@@ -352,7 +352,7 @@ def parse_arguments():
 
     else:
         args.cachedir = path_init('cachedir')
-        args.confdir = path_init('confdir')
+        args.confdir = path_init('confdir', non_writable_ok=True)
         args.datadir = path_init('datadir')
     if args.choosefile:
         args.choosefile = path_init('choosefile')


### PR DESCRIPTION
#### ISSUE TYPE
- Improvement/feature implementation

#### RUNTIME ENVIRONMENT
<!-- Details of your runtime environment -->
<!-- Retrieve Python/ranger version and locale with `ranger -\-version` -->
- Operating system and version: 
`nixos/unstable`
- Terminal emulator and version: 
`alacritty 0.7.2`
- Python version: 
`Python version: 3.8.8 (default, Feb 19 2021, 11:04:50) [GCC 10.2.0]`
- Ranger version/commit: 
`ranger version: ranger-master`
- Locale: 
`Locale: en_US.UTF-8`

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [x] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [x] All changes follow the code style **[REQUIRED]**
- [x] All new and existing tests pass **[REQUIRED]**
- [ ] Changes require config files to be updated
    - [ ] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
<!-- Describe the changes in detail -->
I'd like to place config in a non writable dir.

#### MOTIVATION AND CONTEXT
<!-- Why are these changes required? -->
<!-- What problems do these changes solve? -->
I'm trying to run ranger in vim with [rnvimr](https://github.com/kevinhwang91/rnvimr) on nixos. Ranger config is placed in read only dir and raises an error.
<!-- Link to relevant issues -->


#### TESTING
<!-- What tests have been run? -->
I run `make test` and manually tested changes on my machine.
<!-- How does the changes affect other areas of the codebase? -->


#### IMAGES / VIDEOS<!-- Only if relevant -->
<!-- Link or embed images and videos of screenshots, sketches etc. -->
