### PR TITLE
Remove xargs execution

### DIFF
--- a/examples/rifle_sxiv.sh
+++ b/examples/rifle_sxiv.sh
@@ -42,7 +42,7 @@ target="$(abspath "$1")"
 count="$(listfiles | grep -m 1 -ZznF "$target" | cut -d: -f1)"
 
 if [ -n "$count" ]; then
-    listfiles | xargs -0 sxiv -n "$count" --
+    listfiles | sed 's/\x0/\n/g' | sxiv -n "$count" -
 else
     sxiv -- "$@" # fallback
 fi


### PR DESCRIPTION
#### ISSUE TYPE
- Bug fix
- Improvement/feature implementation

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [x] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [x] All changes follow the code style **[REQUIRED]**
- [ ] All new and existing tests pass **[REQUIRED]**
- [ ] Changes require config files to be updated
    - [ ] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
The use of `xargs` has a limitation on the *length of `argv`* (number of
arguments). After reaching the maximum number of arguments (~850 for me)
`xargs` will still create the new child process, as with the `-n` switch.
`sxiv` (at least for now, `sxiv-26`) is able to read filenames from STDIN on
its own.

#### MOTIVATION AND CONTEXT
This commit by abandoning `xargs` fixes the aforementioned sideeffect, removes
extra dependency and speeds up the work (at least for me).