### PR TITLE
XCF preview thumbnails using gimp

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ For enhanced file previews (with `scope.sh`):
 * `python` or `jq` for JSON files
 * `fontimage` for font previews
 * `openscad` for 3D model previews (`stl`, `off`, `dxf`, `scad`, `csg`)
+* `gimp` with python scripting support for xcf files
 
 Installing
 ----------

--- a/ranger/data/scope.sh
+++ b/ranger/data/scope.sh
@@ -138,6 +138,22 @@ handle_image() {
         #           - "${IMAGE_CACHE_PATH}" < "${FILE_PATH}" \
         #           && exit 6 || exit 1;;
 
+        ## XCF Image
+        image/x-xcf)
+            gimp-console -i --batch-interpreter python-fu-eval -b "
+try:
+    import gimpfu
+    def convert(filename, target):
+        img = pdb.gimp_file_load(filename, filename)
+        layer = pdb.gimp_image_merge_visible_layers(img, gimpfu.CLIP_TO_IMAGE)
+
+        pdb.gimp_file_save(img, layer, target, target)
+        pdb.gimp_image_delete(img)
+    convert(\"${FILE_PATH}\", \"${IMAGE_CACHE_PATH}\")
+finally:
+    pdb.gimp_quit(1)" && exit 6
+            exit 1;;
+
         ## Image
         image/*)
             local orientation


### PR DESCRIPTION
<!-- Provide a descriptive summary of the changes in the title above -->

#### ISSUE TYPE
<!-- Pick relevant types and delete the rest -->
- Improvement/feature implementation

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [X] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [X] All changes follow the code style **[REQUIRED]**
- [X] All new and existing tests pass **[REQUIRED]**
- [X] Changes require config files to be updated
    - [X] Config files have been updated
- [X] Changes require documentation to be updated
    - [X] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
<!-- Describe the changes in detail -->
Generates a thumbnail for an xcf file, using gimp and a short embedded python-fu script.
This feature requires gimp python scripting support to work (for example, in Arch you need the [python2-gimp2](https://aur.archlinux.org/packages/python2-gimp/) package from the AUR)
This could be rewritten to use script-fu which requires no additional possible dependency (besides gimp itself)

#### MOTIVATION AND CONTEXT
<!-- Why are these changes required? -->
<!-- What problems do these changes solve? -->
<!-- Link to relevant issues -->
Scrubbing through a directory with badly named xcf files is a lot easier with thumbnails.


#### TESTING
<!-- What tests have been run? -->
<!-- How does the changes affect other areas of the codebase? -->
Ran `make test` and `make test_shellcheck` with no errors.
This shows a preview of xcf files (using mpv and the w3m method) despite "xcf" still being in 'PREVIEW_BLACKLIST' in `ranger/container/file.py`. Wasn't sure if this is a bug or intended behavior, so I did not change the blacklist.
