### PR TITLE
Add comments about key binding to automatic cd example

### DIFF
--- a/examples/shell_automatic_cd.sh
+++ b/examples/shell_automatic_cd.sh
@@ -20,4 +20,9 @@ ranger_cd() {
 }
 
 # This binds Ctrl-O to ranger_cd:
-bind '"\C-o":"ranger_cd\C-m"'
+# For bash:
+# bind '"\C-o":"ranger_cd\C-m"'
+# For zsh:
+# bindkey -s '^o' 'ranger_cd^M'
+
+# Check the wiki for more control and for fish.

--- a/examples/shell_automatic_cd.sh
+++ b/examples/shell_automatic_cd.sh
@@ -24,5 +24,6 @@ ranger_cd() {
 # bind '"\C-o":"ranger_cd\C-m"'
 # For zsh:
 # bindkey -s '^o' 'ranger_cd^M'
+# For sh you'd need to customize `.inputrc`.
 
 # Check the wiki for more control and for fish.


### PR DESCRIPTION
The bind invocation in the example is bash specific. I've commented it out and added information for how to bind the function in zsh and plain sh. And a pointer to the wiki for fish.

This should be clearer, not everyone may want the keybinding anyway.