### PR TITLE
Clickable preview

### DIFF
--- a/doc/ranger.1
+++ b/doc/ranger.1
@@ -133,7 +133,7 @@
 .\" ========================================================================
 .\"
 .IX Title "RANGER 1"
-.TH RANGER 1 "ranger-1.9.3" "2021-01-22" "ranger manual"
+.TH RANGER 1 "ranger-1.9.3" "2021-05-17" "ranger manual"
 .\" For nroff, turn off justification.  Always turn off hyphenation; it makes
 .\" way too many mistakes in technical documents.
 .if n .ad l
@@ -850,11 +850,11 @@ Backspace.
 .IX Header "MOUSE BUTTONS"
 .IP "Left Mouse Button" 4
 .IX Item "Left Mouse Button"
-Click on something and you'll move there.  To run a file, \*(L"enter\*(R" it, like a
-directory, by clicking on the preview.
+Click on something and you'll move there.
 .IP "Right Mouse Button" 4
 .IX Item "Right Mouse Button"
-Enter a directory or run a file.
+Enter a directory or run a file. To run a file you can either right click the
+file in the main column or right click on the preview.
 .IP "Scroll Wheel" 4
 .IX Item "Scroll Wheel"
 Scrolls up or down.  You can point at the column of the parent directory while
@@ -1086,8 +1086,8 @@ will be temporarily disabled automatically.
 .IP "padding_right [bool]" 4
 .IX Item "padding_right [bool]"
 When collapse_preview is on and there is no preview, should there remain a
-little padding on the right?  This allows you to click into that space to run
-the file.
+little padding on the right?  This allows you to right click into that space to
+run the file.
 .IP "preview_directories [bool] <zP>" 4
 .IX Item "preview_directories [bool] <zP>"
 Preview directories in the preview column?
@@ -1345,7 +1345,7 @@ See also: man 1 chmod
 .IX Item "console [-pN | -s sentinel] command"
 Opens the console with the command already typed in. The cursor is placed at
 \&\fIN\fR or at the first occurrence of \fIsentinel\fR. Note that sentinel strings can
-potentially occur inside macro expansions. If you cannot provide a sentinel,
+potentially occur inside macro expansions. If you cannot provide a sentinel
 which is guaranteed to be unique, you should use \f(CW\*(C`\-p\*(C'\fR.
 .IP "copymap  \fIkey\fR \fInewkey\fR [\fInewkey2\fR ...]" 2
 .IX Item "copymap key newkey [newkey2 ...]"

--- a/doc/ranger.pod
+++ b/doc/ranger.pod
@@ -884,12 +884,12 @@ Backspace.
 
 =item Left Mouse Button
 
-Click on something and you'll move there.  To run a file, "enter" it, like a
-directory, by clicking on the preview.
+Click on something and you'll move there.
 
 =item Right Mouse Button
 
-Enter a directory or run a file.
+Enter a directory or run a file. To run a file you can either right click the
+file in the main column or right click on the preview.
 
 =item Scroll Wheel
 
@@ -1148,8 +1148,8 @@ will be temporarily disabled automatically.
 =item padding_right [bool]
 
 When collapse_preview is on and there is no preview, should there remain a
-little padding on the right?  This allows you to click into that space to run
-the file.
+little padding on the right?  This allows you to right click into that space to
+run the file.
 
 =item preview_directories [bool] <zP>
 

--- a/ranger/gui/widgets/browsercolumn.py
+++ b/ranger/gui/widgets/browsercolumn.py
@@ -99,7 +99,10 @@ class BrowserColumn(Pager):  # pylint: disable=too-many-instance-attributes
                             self.fm.thisdir.move_to_obj(clicked_file)
                             self.fm.execute_file(clicked_file)
         elif self.target.is_file:
-            self.scrollbit(direction)
+            if event.pressed(3):
+                self.fm.execute_file(self.target)
+            else:
+                self.scrollbit(direction)
         else:
             if self.level > 0 and not direction:
                 self.fm.move(right=0)


### PR DESCRIPTION
A regression when implementing preview scrolling meant that clicking the preview no longer opens files.

I have fixed this regression but changed the original behavior to require a right click because the left click caused plenty of frustration by accidentally opening files when focusing the terminal window.