### PR TITLE
filter command works with pattern, not with string

### DIFF
--- a/doc/ranger.1
+++ b/doc/ranger.1
@@ -1400,8 +1400,8 @@ Examples:
  :eval len(fm.tabs)
  :eval p(\*(L"Hello World!\*(R")
 .IP "filter [\fIstring\fR]" 2
-.IX Item "filter [string]"
-Displays only the files which contain the \fIstring\fR in their basename.  Running
+.IX Item "filter [pattern]"
+Displays only the files matching the regular expression pattern.  Running
 this command without any parameter will reset the filter.
 .Sp
 This command is based on the \fIscout\fR command and supports all of its options.


### PR DESCRIPTION
filter command works with pattern, not with string

Little correction of manual