### PR TITLE
Calculate width of zero-width characters as zero

### DIFF
--- a/ranger/ext/widestring.py
+++ b/ranger/ext/widestring.py
@@ -6,10 +6,13 @@ from __future__ import (absolute_import, division, print_function)
 
 import sys
 from unicodedata import east_asian_width
+from unicodedata import category
 
 from ranger import PY3
 
 ASCIIONLY = set(chr(c) for c in range(1, 128))
+NONSPACING = 0
+NONSPACING_SYMBOLS = ('Mn', 'Cf')
 NARROW = 1
 WIDE = 2
 WIDE_SYMBOLS = set('WF')
@@ -24,7 +27,9 @@ def uwid(string):
 
 def utf_char_width(string):
     """Return the width of a single character"""
-    if east_asian_width(string) in WIDE_SYMBOLS:
+    if category(string) in NONSPACING_SYMBOLS:
+        return NONSPACING
+    elif east_asian_width(string) in WIDE_SYMBOLS:
         return WIDE
     return NARROW
 

--- a/ranger/gui/widgets/browsercolumn.py
+++ b/ranger/gui/widgets/browsercolumn.py
@@ -17,6 +17,7 @@ except ImportError:
     HAVE_BIDI = False
 
 from ranger.ext.widestring import WideString
+from ranger.ext.widestring import uwid
 from ranger.core import linemode
 
 from . import Widget
@@ -419,7 +420,7 @@ class BrowserColumn(Pager):  # pylint: disable=too-many-instance-attributes
 
     @staticmethod
     def _total_len(predisplay):
-        return sum([len(WideString(s)) for s, _ in predisplay])
+        return sum([uwid(s) for s, _ in predisplay])
 
     def _bidi_transpose(self, text):
         if self.settings.bidi_support and HAVE_BIDI:


### PR DESCRIPTION
Unicode is fun and exciting.  Previously, ranger calculated columnar width of the following string as sixteen:

楽しかった♥︎.txt

It now correctly calculates it as fifteen.  Hint:  Open this document in a hex editor or use vim's g8 command to see what hides behind the heart...

Hidden, non-spacing characters seem to be especially popular with girls from Japan.

<!-- Provide a descriptive summary of the changes in the title above -->

#### ISSUE TYPE
<!-- Pick relevant types and delete the rest -->
- Bug fix

#### RUNTIME ENVIRONMENT
<!-- Details of your runtime environment -->
<!-- Retrieve Python/ranger version and locale with `ranger -\-version` -->
- Operating system and version: Linux 5.4.51-v7l+ #1333 SMP Mon Aug 10 16:51:40 BST 2020 armv7l GNU/Linux
- Terminal emulator and version: XTerm(344)
- Python version: Python 3.7.3
- Ranger version/commit: 521d9f89f5bc3572f54033d04f8ebac26ffa10c6
- Locale: ja_JP.utf8

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [X] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [X] All changes follow the code style **[REQUIRED]**
- [ ] All new and existing tests pass **[REQUIRED]**
Running `make test` fails even with a clean HEAD.  I may open an issue.
- [ ] Changes require config files to be updated
    - [ ] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
<!-- Describe the changes in detail -->


#### MOTIVATION AND CONTEXT
<!-- Why are these changes required? -->
<!-- What problems do these changes solve? -->
What problems do these questions solve?  Stop treating this like a trip to the doctor's office, and let people hack ;)
<!-- Link to relevant issues -->


#### TESTING
<!-- What tests have been run? -->
<!-- How does the changes affect other areas of the codebase? -->


#### IMAGES / VIDEOS<!-- Only if relevant -->
<!-- Link or embed images and videos of screenshots, sketches etc. -->
