### PR TITLE
Width correction for relative line numbers

### DIFF
--- a/ranger/gui/widgets/browsercolumn.py
+++ b/ranger/gui/widgets/browsercolumn.py
@@ -278,7 +278,9 @@ class BrowserColumn(Pager):  # pylint: disable=too-many-instance-attributes
 
         # Set the size of the linum text field to the number of digits in the
         # visible files in directory.
-        linum_text_len = len(str(self.scroll_begin + self.hei))
+        linum_text_len = len(str(len(self.target.files)
+                                 if self.settings.line_numbers == 'relative'
+                                 else self.scroll_begin + self.hei))
         linum_format = "{0:>" + str(linum_text_len) + "}"
 
         selected_i = self._get_index_of_selected_file()


### PR DESCRIPTION
Believe it or not, ranger has *never* done this correctly.  I may have bitched about it in the past.  Today, I fixed it for everyone.

Long live relatives.

```
 ----------------------------------------     ---------------------------------------
|12 .gtk-bookmarks                 482 B |   |12 .gtk-bookmarks                482 B |
|11 .gtkrc-2.0                  -> 715 B |   |11 .gtkrc-2.0                 -> 715 B |
|10 .gtkrc-2.0-viewing-distance  -> 30 B |   |10 .gtkrc-2.0-viewing-distance -> 30 B |
| 9 .inputrc                   -> 1.52 K |   | 9 .inputrc                  -> 1.52 K |
| 8 .lesshst                       451 B |   | 8 .lesshst                      451 B |
| 7 .lftprc                    -> 194 B  |   | 7 .lftprc                    -> 194 B |
| 6 .mailcap                   -> 771 B  |   | 6 .mailcap                   -> 771 B |
| 5 .mille                        568 B  |   | 5 .mille                        568 B |
| 4 .msmtprc                     3.83 K  |   | 4 .msmtprc                     3.83 K |
| 3 .netrc                        543 B  |   | 3 .netrc                        543 B |
| 2 .python_history              8.11 K  |   | 2 .python_history              8.11 K |
| 1 .units                     -> 630 B  |   | 1 .units                     -> 630 B |
|83 .units_history                1.54 K |   |83 .units_history               1.54 K |
| 1 .urlview                   -> 425 B  |   | 1 .urlview                   -> 425 B |
| 2 .viminfo                      151 K  |   | 2 .viminfo                      152 K |
| 3 .vimrc                    -> 15.7 K  |   | 3 .vimrc                    -> 15.7 K |
| 4 .vnstatrc                 -> 1.32 K  |   | 4 .vnstatrc                 -> 1.32 K |
| 5 .wcalc_history                480 B  |   | 5 .wcalc_history                480 B |
| 6 .wcalcrc                   -> 352 B  |   | 6 .wcalcrc                   -> 352 B |
| 7 .wget-hsts                    625 B  |   | 7 .wget-hsts                    625 B |
| 8 .wgetrc                    -> 335 B  |   | 8 .wgetrc                    -> 335 B |
| 9 .Xauthority                   202 B  |   | 9 .Xauthority                   202 B |
|10 .xinitrc                  -> 1.04 K  |   |10 .xinitrc                  -> 1.04 K |
|11 .xmodmaprc                -> 11.9 K  |   |11 .xmodmaprc                -> 11.9 K |
 ----------------------------------------     ---------------------------------------
 Previous                                     Current
```

Questionnaire answers are identical to #2345.