### PR TITLE
Fix tmux image display for other possible TERMs

### DIFF
--- a/ranger/ext/img_display.py
+++ b/ranger/ext/img_display.py
@@ -298,7 +298,7 @@ class ITerm2ImageDisplayer(ImageDisplayer, FileManagerAware):
         content = self._encode_image_content(path)
         display_protocol = "\033"
         close_protocol = "\a"
-        if "screen" in os.environ['TERM']:
+        if os.environ["TERM"].startswith(("screen", "tmux")):
             display_protocol += "Ptmux;\033\033"
             close_protocol += "\033\\"
 
@@ -430,7 +430,7 @@ class URXVTImageDisplayer(ImageDisplayer, FileManagerAware):
     def __init__(self):
         self.display_protocol = "\033"
         self.close_protocol = "\a"
-        if "screen" in os.environ['TERM']:
+        if os.environ["TERM"].startswith(("screen", "tmux")):
             self.display_protocol += "Ptmux;\033\033"
             self.close_protocol += "\033\\"
         self.display_protocol += "]20;"


### PR DESCRIPTION
<!-- Provide a descriptive summary of the changes in the title above -->
This fixes what TERMs are checked in relation to a tmux session and then apply the correct escape sequences for the URxvt and iterm backends
#### ISSUE TYPE
<!-- Pick relevant types and delete the rest -->
- Bug fix

#### RUNTIME ENVIRONMENT
<!-- Details of your runtime environment -->
<!-- Retrieve Python/ranger version and locale with `ranger -\-version` -->
- Operating system and version: Arch Linux
- Terminal emulator and version: rxvt-unicode 9.26
- Python version: 3.9.5
- Ranger version/commit: 
- Locale: UTF-8

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [X] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [X] All changes follow the code style **[REQUIRED]**
- [X] All new and existing tests pass **[REQUIRED]**
- [ ] Changes require config files to be updated
    - [ ] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
<!-- Describe the changes in detail -->
Previously, only the TERM value of `screen` was checked when performing image previews inside of tmux. This PR expands the possible values checked to include all(?) tmux TERM values.

#### MOTIVATION AND CONTEXT
<!-- Why are these changes required? -->
My image previews weren't working with the urxvt backend inside of tmux :(
<!-- What problems do these changes solve? -->
The image previews work inside of tmux now!
<!-- Link to relevant issues -->


#### TESTING
<!-- What tests have been run? -->
No tests run to be honest. This shouldn't impact anything, it's a pretty minor change.
<!-- How does the changes affect other areas of the codebase? -->


#### IMAGES / VIDEOS<!-- Only if relevant -->
<!-- Link or embed images and videos of screenshots, sketches etc. -->
