### PR TITLE
scope.sh: add mime handling for message/rfc822. This improves #2202.

### DIFF
--- a/ranger/data/scope.sh
+++ b/ranger/data/scope.sh
@@ -282,6 +282,12 @@ handle_mime() {
             pandoc -s -t markdown -- "${FILE_PATH}" && exit 5
             exit 1;;
 
+	## Mails
+	message/rfc822)
+	    ## Parse email with mu: https://github.com/djcb/mu
+	    mu view -- "${FILE_PATH}" && exit 5
+	    exit 1;;
+
         ## XLS
         *ms-excel)
             ## Preview as csv conversion

--- a/ranger/data/scope.sh
+++ b/ranger/data/scope.sh
@@ -284,7 +284,7 @@ handle_mime() {
 
 	## E-mails
 	message/rfc822)
-	    ## Preview email with mu: https://github.com/djcb/mu
+	    ## Parsing performed by mu: https://github.com/djcb/mu
 	    mu view -- "${FILE_PATH}" && exit 5
 	    exit 1;;
 

--- a/ranger/data/scope.sh
+++ b/ranger/data/scope.sh
@@ -282,9 +282,9 @@ handle_mime() {
             pandoc -s -t markdown -- "${FILE_PATH}" && exit 5
             exit 1;;
 
-	## Mails
+	## E-mails
 	message/rfc822)
-	    ## Parse email with mu: https://github.com/djcb/mu
+	    ## Preview email with mu: https://github.com/djcb/mu
 	    mu view -- "${FILE_PATH}" && exit 5
 	    exit 1;;
 


### PR DESCRIPTION
<!-- Provide a descriptive summary of the changes in the title above -->

#### ISSUE TYPE
<!-- Pick relevant types and delete the rest -->
- Improvement/feature implementation

#### RUNTIME ENVIRONMENT
<!-- Details of your runtime environment -->
<!-- Retrieve Python/ranger version and locale with `ranger -\-version` -->
- Operating system and version: Arch Linux 5.12.11-arch1-1
- Terminal emulator and version: st 0.8.4
- Python version: 3.9.5-3
- Ranger version/commit: bff3c6b
- Locale: 
LANG=en_CA.UTF-8
LC_CTYPE="en_CA.UTF-8"
LC_NUMERIC="en_CA.UTF-8"
LC_TIME=en_DK.UTF-8
LC_COLLATE=C
LC_MONETARY="en_CA.UTF-8"
LC_MESSAGES="en_CA.UTF-8"
LC_PAPER="en_CA.UTF-8"
LC_NAME="en_CA.UTF-8"
LC_ADDRESS="en_CA.UTF-8"
LC_TELEPHONE="en_CA.UTF-8"
LC_MEASUREMENT="en_CA.UTF-8"
LC_IDENTIFICATION="en_CA.UTF-8"
LC_ALL=

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [x] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [x] All changes follow the code style **[REQUIRED]**
- [ ] All new and existing tests pass **[REQUIRED]**
- [ ] Changes require config files to be updated
    - [ ] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
<!-- Describe the changes in detail -->
Addresses wishes expressed in #2202:
If [mu](https://github.com/djcb/mu) is installed, displays the content of message/rfc822 in preview, cleared of all formatting tags.

#### MOTIVATION AND CONTEXT
<!-- Why are these changes required? -->
<!-- What problems do these changes solve? -->
<!-- Link to relevant issues -->
Prior to the change, scope.sh had no way to deal with message/rfc822 and no preview was displayed.
In #2202, @philiprhoades came up with a solution to see the subject and sender of emails, but @toonn expressed the wish that we could see the entire email content, parsing the formatting out. This is what this does.

#### TESTING
<!-- What tests have been run? -->
<!-- How does the changes affect other areas of the codebase? -->
This change does not affect anything else.

#### IMAGES / VIDEOS<!-- Only if relevant -->
<!-- Link or embed images and videos of screenshots, sketches etc. -->
