### PR TITLE
Actions: Add on pull_request again

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -5,6 +5,10 @@ on:
     paths:
       - '.github/workflows/pylint.yml'
       - '**.py'
+  pull_request:
+    paths:
+      - '.github/workflows/pylint.yml'
+      - '**.py'
 
 jobs:
   test_pylint:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -5,6 +5,10 @@ on:
     paths:
       - '.github/workflows/python.yml'
       - '**.py'
+  pull_request:
+    paths:
+      - '.github/workflows/python.yml'
+      - '**.py'
 
 jobs:
   test_py:

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -5,6 +5,10 @@ on:
     paths:
       - '.github/workflows/shellcheck.yml'
       - 'ranger/data/scope.sh'
+  pull_request:
+    paths:
+      - '.github/workflows/shellcheck.yml'
+      - 'ranger/data/scope.sh'
 
 jobs:
   test_shellcheck:


### PR DESCRIPTION
My testing was flawed. The status checks seemed to work fine because the
builds were triggered on push in the same repo. But this doesn't work
across repos. So GH Actions having run to completion on someone's fork
doesn't give us the status checks we need. Therefore we want to run our
Actions on PRs too, that way they're run from the ranger repo as well
and the status checks should actually be informative.

One possible improvement is that we could duplicate the workflows we
want to run on PRs, that way we can drop all the things that don't
really matter for status checks from the version matrices. Otoh that
means we have pretty much duplicated workflows we need to keep in sync.
Thank you for your lack of abstractions, GH Actions 🙄