### PR TITLE
commands: Change precedence of clipboard managers

### DIFF
--- a/ranger/config/commands.py
+++ b/ranger/config/commands.py
@@ -1968,7 +1968,7 @@ class yank(Command):
                     ['pbcopy'],
                 ],
             }
-            ordered_managers = ['pbcopy', 'wl-copy', 'xclip', 'xsel']
+            ordered_managers = ['pbcopy', 'xclip', 'xsel', 'wl-copy']
             executables = get_executables()
             for manager in ordered_managers:
                 if manager in executables:

--- a/ranger/config/commands.py
+++ b/ranger/config/commands.py
@@ -1933,7 +1933,7 @@ class linemode(default_linemode):
 
 
 class yank(Command):
-    """:yank [name|dir|path]
+    """:yank [name|dir|path|name_without_extension]
 
     Copies the file's name (default), directory or path into both the primary X
     selection and the clipboard.


### PR DESCRIPTION
`wl-copy` used to take precedence over `xclip` and `xsel` but this can
cause problems. So let's try the other way around, maybe Wayland users
are less likely to have `xclip` and `xsel` installed than the other way
around.

Fixes #1861