### PR TITLE
Adding OCS-52 support

### DIFF
--- a/ranger/config/commands.py
+++ b/ranger/config/commands.py
@@ -1988,14 +1988,14 @@ class yank(Command):
             tty_num = subprocess.check_output(["tty"]).strip()
             with open(tty_num, 'wb') as stdout:
                 base64Content = b'\033]52;c;' + \
-                        base64.b64encode(new_clipboard_contents.encode('utf-8')) + \
-                        b'\a'
+                    base64.b64encode(new_clipboard_contents.encode('utf-8')) + \
+                    b'\a'
                 stdout.write(base64Content)
         else:
             for command in clipboard_commands:
                 with subprocess.Popen(
-                        command, universal_newlines=True, stdin=subprocess.PIPE
-                        ) as process:
+                    command, universal_newlines=True, stdin=subprocess.PIPE
+                ) as process:
                     process.communicate(input=new_clipboard_contents)
 
     def get_selection_attr(self, attr):

--- a/ranger/config/commands.py
+++ b/ranger/config/commands.py
@@ -1981,11 +1981,22 @@ class yank(Command):
         selection = self.get_selection_attr(mode)
 
         new_clipboard_contents = "\n".join(selection)
-        for command in clipboard_commands:
-            with subprocess.Popen(
-                command, universal_newlines=True, stdin=subprocess.PIPE
-            ) as process:
-                process.communicate(input=new_clipboard_contents)
+        if len(clipboard_commands) < 1:
+
+            import base64
+
+            tty_num = subprocess.check_output(["tty"]).strip()
+            with open(tty_num, 'wb') as stdout:
+                base64Content = b'\033]52;c;' + \
+                        base64.b64encode(new_clipboard_contents.encode('utf-8')) + \
+                        b'\a'
+                stdout.write(base64Content)
+        else:
+            for command in clipboard_commands:
+                with subprocess.Popen(
+                        command, universal_newlines=True, stdin=subprocess.PIPE
+                        ) as process:
+                    process.communicate(input=new_clipboard_contents)
 
     def get_selection_attr(self, attr):
         return [getattr(item, attr) for item in


### PR DESCRIPTION
<!-- Provide a descriptive summary of the changes in the title above -->

#### ISSUE TYPE
<!-- Pick relevant types and delete the rest -->
- Improvement/feature implementation

#### RUNTIME ENVIRONMENT
<!-- Details of your runtime environment -->
<!-- Retrieve Python/ranger version and locale with `ranger -\-version` -->
- Operating system and version: Linux 5.13.4
- Terminal emulator and version: **alacritty** 0.8.0
- Python version: 3.9.6
- Ranger version/commit: master(5e2e95)
- Locale: en_US

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled --
- [X] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [X] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
<!-- Describe the changes in detail -->
For now, OCS-52 working as a fallback copying option.
That mean, you can copy filename-related staff via ssh or without xclip/xsel and other utilities.

#### MOTIVATION AND CONTEXT
<!-- Why are these changes required? -->
<!-- What problems do these changes solve? -->
<!-- Link to relevant issues -->
#1861 and #2404

#### TESTING
<!-- What tests have been run? -->
<!-- How does the changes affect other areas of the codebase? -->
I tested that on alacritty, e.g that works without xclip/xsel and onther utilities for me. But I didn't test that on ssh yet.
But I ask everybody to test that anywhere else, please.

#### IMAGES / VIDEOS<!-- Only if relevant -->
<!-- Link or embed images and videos of screenshots, sketches etc. -->
