### PR TITLE
Process forking was broken when satisfying pylint's consider-using-with

### DIFF
--- a/ranger/ext/img_display.py
+++ b/ranger/ext/img_display.py
@@ -32,6 +32,7 @@ from tempfile import NamedTemporaryFile
 
 from ranger import PY3
 from ranger.core.shared import FileManagerAware, SettingsAware
+from ranger.ext.popen23 import Popen23
 
 W3MIMGDISPLAY_ENV = "W3MIMGDISPLAY_PATH"
 W3MIMGDISPLAY_OPTIONS = []
@@ -167,7 +168,7 @@ class W3MImageDisplayer(ImageDisplayer, FileManagerAware):
         fretint = fcntl.ioctl(fd_stdout, termios.TIOCGWINSZ, farg)
         rows, cols, xpixels, ypixels = struct.unpack("HHHH", fretint)
         if xpixels == 0 and ypixels == 0:
-            with Popen(
+            with Popen23(
                 [self.binary_path, "-test"],
                 stdout=PIPE,
                 universal_newlines=True,

--- a/ranger/ext/popen23.py
+++ b/ranger/ext/popen23.py
@@ -1,0 +1,60 @@
+# This file is part of ranger, the console file manager.
+# License: GNU GPL version 3, see the file "AUTHORS" for details.
+
+from __future__ import absolute_import
+
+from contextlib import contextmanager
+
+from subprocess import Popen, TimeoutExpired
+
+try:
+    from ranger import PY3
+except ImportError:
+    from sys import version_info
+    PY3 = version_info[0] >= 3
+
+
+# COMPAT: Python 2 (and Python <=3.2) subprocess.Popen objects aren't
+#         context managers. We don't care about early Python 3 but we do want
+#         to wrap Python 2's Popen. There's no harm in always using this Popen
+#         but it is only necessary when used with with-statements. This can be
+#         removed once we ditch Python 2 support.
+@contextmanager
+def Popen23(*args, **kwargs):  # pylint: disable=invalid-name
+    if PY3:
+        yield Popen(*args, **kwargs)
+        return
+    else:
+        popen2 = Popen(*args, **kwargs)
+    try:
+        yield popen2
+    finally:
+        # From Lib/subprocess.py Popen.__exit__:
+        if popen2.stdout:
+            popen2.stdout.close()
+        if popen2.stderr:
+            popen2.stderr.close()
+        try:  # Flushing a BufferedWriter may raise an error
+            if popen2.stdin:
+                popen2.stdin.close()
+        except KeyboardInterrupt:
+            # https://bugs.python.org/issue25942
+            # In the case of a KeyboardInterrupt we assume the SIGINT
+            # was also already sent to our child processes.  We can't
+            # block indefinitely as that is not user friendly.
+            # If we have not already waited a brief amount of time in
+            # an interrupted .wait() or .communicate() call, do so here
+            # for consistency.
+            # pylint: disable=protected-access
+            if popen2._sigint_wait_secs > 0:
+                try:
+                    # pylint: disable=no-member
+                    popen2._wait(timeout=popen2._sigint_wait_secs)
+                except TimeoutExpired:
+                    pass
+            popen2._sigint_wait_secs = 0  # Note that this has been done.
+            # pylint: disable=lost-exception
+            return  # resume the KeyboardInterrupt
+        finally:
+            # Wait for the process to terminate, to avoid zombies.
+            popen2.wait()

--- a/ranger/ext/popen23.py
+++ b/ranger/ext/popen23.py
@@ -5,7 +5,7 @@ from __future__ import absolute_import
 
 from contextlib import contextmanager
 
-from subprocess import Popen, TimeoutExpired
+from subprocess import Popen
 
 try:
     from ranger import PY3
@@ -37,24 +37,6 @@ def Popen23(*args, **kwargs):  # pylint: disable=invalid-name
         try:  # Flushing a BufferedWriter may raise an error
             if popen2.stdin:
                 popen2.stdin.close()
-        except KeyboardInterrupt:
-            # https://bugs.python.org/issue25942
-            # In the case of a KeyboardInterrupt we assume the SIGINT
-            # was also already sent to our child processes.  We can't
-            # block indefinitely as that is not user friendly.
-            # If we have not already waited a brief amount of time in
-            # an interrupted .wait() or .communicate() call, do so here
-            # for consistency.
-            # pylint: disable=protected-access
-            if popen2._sigint_wait_secs > 0:
-                try:
-                    # pylint: disable=no-member
-                    popen2._wait(timeout=popen2._sigint_wait_secs)
-                except TimeoutExpired:
-                    pass
-            popen2._sigint_wait_secs = 0  # Note that this has been done.
-            # pylint: disable=lost-exception
-            return  # resume the KeyboardInterrupt
         finally:
             # Wait for the process to terminate, to avoid zombies.
             popen2.wait()

--- a/ranger/ext/popen_forked.py
+++ b/ranger/ext/popen_forked.py
@@ -6,6 +6,7 @@ from __future__ import (absolute_import, division, print_function)
 import os
 from subprocess import Popen
 
+
 def Popen_forked(*args, **kwargs):  # pylint: disable=invalid-name
     """Forks process and runs Popen with the given args and kwargs.
 

--- a/ranger/ext/popen_forked.py
+++ b/ranger/ext/popen_forked.py
@@ -4,8 +4,7 @@
 from __future__ import (absolute_import, division, print_function)
 
 import os
-import subprocess
-
+from subprocess import Popen
 
 def Popen_forked(*args, **kwargs):  # pylint: disable=invalid-name
     """Forks process and runs Popen with the given args and kwargs.
@@ -21,9 +20,7 @@ def Popen_forked(*args, **kwargs):  # pylint: disable=invalid-name
         with open(os.devnull, 'r') as null_r, open(os.devnull, 'w') as null_w:
             kwargs['stdin'] = null_r
             kwargs['stdout'] = kwargs['stderr'] = null_w
-            with subprocess.Popen(*args, **kwargs):
-                # Just to enable using with
-                pass
+            Popen(*args, **kwargs)  # pylint: disable=consider-using-with
         os._exit(0)  # pylint: disable=protected-access
     else:
         os.wait()

--- a/ranger/ext/rifle.py
+++ b/ranger/ext/rifle.py
@@ -146,8 +146,7 @@ except ImportError:
             ) as null_w:
                 kwargs["stdin"] = null_r
                 kwargs["stdout"] = kwargs["stderr"] = null_w
-                with Popen(*args, **kwargs):
-                    pass
+                Popen(*args, **kwargs)  # pylint: disable=consider-using-with
             os._exit(0)  # pylint: disable=protected-access
         return True
 

--- a/ranger/ext/spawn.py
+++ b/ranger/ext/spawn.py
@@ -4,7 +4,10 @@
 from __future__ import (absolute_import, division, print_function)
 
 from os import devnull
-from subprocess import Popen, PIPE, CalledProcessError
+from subprocess import PIPE, CalledProcessError
+
+from ranger.ext.popen23 import Popen23
+
 ENCODING = 'utf-8'
 
 
@@ -28,11 +31,11 @@ def check_output(popenargs, **kwargs):
     kwargs.setdefault('shell', isinstance(popenargs, str))
 
     if 'stderr' in kwargs:
-        with Popen(popenargs, **kwargs) as process:
+        with Popen23(popenargs, **kwargs) as process:
             stdout, _ = process.communicate()
     else:
         with open(devnull, mode='w') as fd_devnull:
-            with Popen(popenargs, stderr=fd_devnull, **kwargs) as process:
+            with Popen23(popenargs, stderr=fd_devnull, **kwargs) as process:
                 stdout, _ = process.communicate()
 
     if process.returncode != 0:

--- a/tests/pylint/py2_compat.py
+++ b/tests/pylint/py2_compat.py
@@ -128,10 +128,10 @@ class Py2CompatibilityChecker(BaseChecker):
                 if ((isinstance(cm.func, astroid.nodes.Name)
                     and cm.func.name.endswith("Popen")
                     and (node.root().scope_lookup(node.root(), "Popen")[1][0]
-                        ).modname == "subprocess")
+                         ).modname == "subprocess")
                     or (isinstance(cm.func, astroid.nodes.Attribute)
-                    and cm.func.expr == "subprocess"
-                    and cm.func.attrname == "Popen")):
+                        and cm.func.expr == "subprocess"
+                        and cm.func.attrname == "Popen")):
                     self.add_message("with-popen23", node=node, confidence=HIGH)
 
 

--- a/tests/pylint/test_py2_compat.py
+++ b/tests/pylint/test_py2_compat.py
@@ -115,6 +115,32 @@ class TestPy2CompatibilityChecker(pylint.testutils.CheckerTestCase):
         ):
             self.checker.visit_call(implicit_format_spec)
 
+    def test_with_Popen(self):
+        with_subprocess_Popen, with_Popen, with_Popen23 = astroid.extract_node("""
+        import subprocess
+        with subprocess.Popen(): #@
+            pass
+
+        from subprocess import Popen
+        with Popen(): #@
+            pass
+
+        from ranger.ext.popen23 import Popen23
+        with Popen23(): #@
+            pass
+        """)
+
+        with self.assertAddsMessages(
+            pylint.testutils.Message(
+                msg_id='with-popen23',
+                node=with_Popen,
+            ),
+        ):
+            self.checker.visit_with(with_subprocess_Popen)
+            self.checker.visit_with(with_Popen)
+        with self.assertNoMessages():
+            self.checker.visit_with(with_Popen23)
+
     # # These checks still exist as old-division and no-absolute-import
     # def test_division_without_import(self):
     #     division = astroid.extract_node("""


### PR DESCRIPTION
I've reverted the relevant with-statement transformations.

I also noticed that `with Popen():` isn't compatible with Python 2 so I added a wrapper and a pylint check to fix it and make sure it doesn't happen again.