### PR TITLE
sxiv-rifle: add webp and performance improvement

### DIFF
--- a/examples/rifle_sxiv.sh
+++ b/examples/rifle_sxiv.sh
@@ -19,9 +19,11 @@
 # not work in dash and others), so we cannot store the result of listfiles to a
 # variable.
 
+tmp="/tmp/sxiv_rifle_$$"
+
 listfiles () {
     find -L "///${target%/*}" -maxdepth 1 -type f -iregex \
-      '.*\.\(jpe?g\|png\|gif\|webp\|tiff\|bmp\)$' -print0 | sort -z
+      '.*\.\(jpe?g\|png\|gif\|webp\|tiff\|bmp\)$' -print | sort | tee "$tmp"
 }
 
 is_img () {
@@ -39,10 +41,11 @@ case "$1" in
     *)  target="$PWD/$1" ;;
 esac
 
-is_img "$target" && count="$(listfiles | grep -m 1 -ZznF "$target")"
+trap "rm -f $tmp" EXIT
+is_img "$target" && count="$(listfiles | grep -nF "$target")"
 
 if [ -n "$count" ]; then
-    listfiles | xargs -0 sxiv -n "${count%%:*}" --
+    sxiv -i -n "${count%%:*}" -- < "$tmp"
 else
     sxiv -- "$@" # fallback
 fi

--- a/examples/rifle_sxiv.sh
+++ b/examples/rifle_sxiv.sh
@@ -19,10 +19,9 @@
 # 'realpath' because it would fork a whole process, which is slow.
 #
 # Second, we need to append a file list to sxiv, which can only be done
-# properly in three ways: arrays (which are not POSIX) or \0 sperated strings.
-# Unfortunately, assigning \0 to a variable is not POSIX either (will not work
-# in dash and others), so we cannot store the result of listfiles to a
-# variable.
+# properly in three ways: arrays (which are not POSIX).
+# \0 separated strings; but assigning \0 to a variable is not POSIX either
+# so we cannot store the result of listfiles to a variable.
 #
 # The third approach is to store the result to a tmpfile and using `-i` to feed
 # the list to sxiv. This is the fastest approach since we won't have to call

--- a/examples/rifle_sxiv.sh
+++ b/examples/rifle_sxiv.sh
@@ -14,8 +14,10 @@
 tmp="/tmp/sxiv_rifle_$$"
 
 listfiles () {
-    find -L "///${1%/*}" -maxdepth 1 -type f -iregex \
-      '.*\.\(jpe?g\|png\|gif\|webp\|tiff\|bmp\)$' -print | sort | tee "$tmp"
+    find -L "///${1%/*}" \( ! -path "///${1%/*}" -prune \) -type f \
+      \( -name '*.jpg' -o -name '*.jpeg' -o -name '*.png' -o -name '*.gif' \
+      -o -name '*.webp' -o -name '*.tiff' -o -name '*.bmp' \) -print |
+      sort | tee "$tmp"
 }
 
 is_img () {

--- a/examples/rifle_sxiv.sh
+++ b/examples/rifle_sxiv.sh
@@ -31,10 +31,10 @@ case "$1" in
     *)  target="$PWD/$1" ;;
 esac
 
-[ -f "$target" ] && count="$(listfiles | grep -m 1 -ZznF "$target" | cut -d: -f1)"
+[ -f "$target" ] && count="$(listfiles | grep -m 1 -ZznF "$target")"
 
 if [ -n "$count" ]; then
-    listfiles | xargs -0 sxiv -n "$count" --
+    listfiles | xargs -0 sxiv -n "${count%%:*}" --
 else
     sxiv -- "$@" # fallback
 fi

--- a/examples/rifle_sxiv.sh
+++ b/examples/rifle_sxiv.sh
@@ -21,7 +21,7 @@
 
 listfiles () {
     find -L "///${target%/*}" -maxdepth 1 -type f -iregex \
-      '.*\(jpe?g\|png\|gif\|webp\|tiff\|bmp\)$' -print0 | sort -z
+      '.*\.\(jpe?g\|png\|gif\|webp\|tiff\|bmp\)$' -print0 | sort -z
 }
 
 is_img () {

--- a/examples/rifle_sxiv.sh
+++ b/examples/rifle_sxiv.sh
@@ -14,6 +14,20 @@
 # shell syntax and calls being made to external utilities, such as grep or find.
 # This makes it portable across many unix like systems, although it may not be
 # the cleanest or fastest approach.
+#
+# First, using case statement to get absolute path is quicker than calling
+# 'realpath' because it would fork a whole process, which is slow.
+#
+# Second, we need to append a file list to sxiv, which can only be done
+# properly in three ways: arrays (which are not POSIX) or \0 sperated strings.
+# Unfortunately, assigning \0 to a variable is not POSIX either (will not work
+# in dash and others), so we cannot store the result of listfiles to a
+# variable.
+#
+# The third approach is to store the result to a tmpfile and using `-i` to feed
+# the list to sxiv. This is the fastest approach since we won't have to call
+# listfiles twice.
+
 
 tmp="/tmp/sxiv_rifle_$$"
 

--- a/examples/rifle_sxiv.sh
+++ b/examples/rifle_sxiv.sh
@@ -31,7 +31,7 @@ case "$1" in
     *)  target="$PWD/$1" ;;
 esac
 
-count="$(listfiles | grep -m 1 -ZznF "$target" | cut -d: -f1)"
+[ -f "$target" ] && count="$(listfiles | grep -m 1 -ZznF "$target" | cut -d: -f1)"
 
 if [ -n "$count" ]; then
     listfiles | xargs -0 sxiv -n "$count" --

--- a/examples/rifle_sxiv.sh
+++ b/examples/rifle_sxiv.sh
@@ -14,9 +14,8 @@
 tmp="/tmp/sxiv_rifle_$$"
 
 listfiles () {
-    find -L "///${1%/*}" \( ! -path "///${1%/*}" -prune \) -type f \
-      \( -iname '*.jpg' -o -iname '*.jpeg' -o -iname '*.png' -o -iname '*.gif' \
-      -o -iname '*.webp' -o -iname '*.tiff' -o -iname '*.bmp' \) -print |
+    find -L "///${1%/*}" \( ! -path "///${1%/*}" -prune \) -type f |
+      grep -iE '\.(jpe?g|png|gif|webp|tiff|bmp)$' |
       sort | tee "$tmp"
 }
 

--- a/examples/rifle_sxiv.sh
+++ b/examples/rifle_sxiv.sh
@@ -11,7 +11,7 @@
 #   mime ^image, has sxiv, X, flag f = path/to/this/script -- "$@"
 #
 # Implementation notes: this script is quite slow because of POSIX limitations
-# and portability concerns. First calling the shell function 'abspath' is
+# and portability concerns. First, using case statement to get absolute path is
 # quicker than calling 'realpath' because it would fork a whole process, which
 # is slow. Second, we need to append a file list to sxiv, which can only be done
 # properly in two ways: arrays (which are not POSIX) or \0 sperated
@@ -19,26 +19,18 @@
 # not work in dash and others), so we cannot store the result of listfiles to a
 # variable.
 
-if [ $# -eq 0 ]; then
-    echo "Usage: ${0##*/} PICTURES"
-    exit
-fi
-
-[ "$1" = '--' ] && shift
-
-abspath () {
-    case "$1" in
-        /*) printf "%s\n" "$1";;
-        *)  printf "%s\n" "$PWD/$1";;
-    esac
-}
-
 listfiles () {
-    find -L "$(dirname "$target")" -maxdepth 1 -type f -iregex \
+    find -L "${target%/*}" -maxdepth 1 -type f -iregex \
       '.*\(jpe?g\|bmp\|png\|gif\)$' -print0 | sort -z
 }
 
-target="$(abspath "$1")"
+[ "$1" = '--' ] && shift
+case "$1" in
+    "") echo "Usage: ${0##*/} PICTURES" >/dev/stderr && exit ;;
+    /*) target="$1" ;;
+    *)  target="$PWD/$1" ;;
+esac
+
 count="$(listfiles | grep -m 1 -ZznF "$target" | cut -d: -f1)"
 
 if [ -n "$count" ]; then

--- a/examples/rifle_sxiv.sh
+++ b/examples/rifle_sxiv.sh
@@ -20,7 +20,7 @@
 # variable.
 
 listfiles () {
-    find -L "${target%/*}" -maxdepth 1 -type f -iregex \
+    find -L "///${target%/*}" -maxdepth 1 -type f -iregex \
       '.*\(jpe?g\|bmp\|png\|gif\|webp\)$' -print0 | sort -z
 }
 

--- a/examples/rifle_sxiv.sh
+++ b/examples/rifle_sxiv.sh
@@ -14,7 +14,7 @@
 tmp="/tmp/sxiv_rifle_$$"
 
 listfiles () {
-    find -L "///${1%/*}" \( ! -path "///${1%/*}" -prune \) -type f |
+    find -L "///${1%/*}" \( ! -path "///${1%/*}" -prune \) -type f -print |
       grep -iE '\.(jpe?g|png|gif|webp|tiff|bmp)$' |
       sort | tee "$tmp"
 }

--- a/examples/rifle_sxiv.sh
+++ b/examples/rifle_sxiv.sh
@@ -10,6 +10,10 @@
 #
 #   mime ^image, has sxiv, X, flag f = path/to/this/script -- "$@"
 #
+# Implementation note: the script tries to be POSIX compliant both in terms of
+# shell syntax and calls being made to external utilities, such as grep or find.
+# This makes it portable across many unix like systems, although it may not be
+# the cleanest or fastest approach.
 
 tmp="/tmp/sxiv_rifle_$$"
 

--- a/examples/rifle_sxiv.sh
+++ b/examples/rifle_sxiv.sh
@@ -21,7 +21,7 @@
 
 listfiles () {
     find -L "${target%/*}" -maxdepth 1 -type f -iregex \
-      '.*\(jpe?g\|bmp\|png\|gif\)$' -print0 | sort -z
+      '.*\(jpe?g\|bmp\|png\|gif\|webp\)$' -print0 | sort -z
 }
 
 [ "$1" = '--' ] && shift

--- a/examples/rifle_sxiv.sh
+++ b/examples/rifle_sxiv.sh
@@ -35,6 +35,7 @@ is_img () {
 case "$1" in
     "") echo "Usage: ${0##*/} PICTURES" >/dev/stderr && exit ;;
     /*) target="$1" ;;
+    "~"/*) target="$HOME/${1#"~"/}" ;;
     *)  target="$PWD/$1" ;;
 esac
 

--- a/examples/rifle_sxiv.sh
+++ b/examples/rifle_sxiv.sh
@@ -21,12 +21,12 @@
 
 listfiles () {
     find -L "///${target%/*}" -maxdepth 1 -type f -iregex \
-      '.*\(jpe?g\|png\|gif\|webp\|bmp\)$' -print0 | sort -z
+      '.*\(jpe?g\|png\|gif\|webp\|tiff\|bmp\)$' -print0 | sort -z
 }
 
 is_img () {
     case "${1##*.}" in
-        "jpg"|"jpeg"|"png"|"gif"|"webp"|"bmp") return 0 ;;
+        "jpg"|"jpeg"|"png"|"gif"|"webp"|"tiff"|"bmp") return 0 ;;
         *) return 1 ;;
     esac
 }

--- a/examples/rifle_sxiv.sh
+++ b/examples/rifle_sxiv.sh
@@ -24,7 +24,7 @@ listfiles () {
       '.*\(jpe?g\|bmp\|png\|gif\|webp\)$' -print0 | sort -z
 }
 
-ispic () {
+is_img () {
     case "${1##*.}" in
         "jpg"|"jpeg"|"bmp"|"png"|"gif"|"webp") return 0 ;;
         *) return 1 ;;
@@ -38,7 +38,7 @@ case "$1" in
     *)  target="$PWD/$1" ;;
 esac
 
-ispic "$target" && count="$(listfiles | grep -m 1 -ZznF "$target")"
+is_img "$target" && count="$(listfiles | grep -m 1 -ZznF "$target")"
 
 if [ -n "$count" ]; then
     listfiles | xargs -0 sxiv -n "${count%%:*}" --

--- a/examples/rifle_sxiv.sh
+++ b/examples/rifle_sxiv.sh
@@ -24,6 +24,13 @@ listfiles () {
       '.*\(jpe?g\|bmp\|png\|gif\|webp\)$' -print0 | sort -z
 }
 
+ispic () {
+    case "${1##*.}" in
+        "jpg"|"jpeg"|"bmp"|"png"|"gif"|"webp") return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
 [ "$1" = '--' ] && shift
 case "$1" in
     "") echo "Usage: ${0##*/} PICTURES" >/dev/stderr && exit ;;
@@ -31,7 +38,7 @@ case "$1" in
     *)  target="$PWD/$1" ;;
 esac
 
-[ -f "$target" ] && count="$(listfiles | grep -m 1 -ZznF "$target")"
+ispic "$target" && count="$(listfiles | grep -m 1 -ZznF "$target")"
 
 if [ -n "$count" ]; then
     listfiles | xargs -0 sxiv -n "${count%%:*}" --

--- a/examples/rifle_sxiv.sh
+++ b/examples/rifle_sxiv.sh
@@ -29,7 +29,8 @@
 # listfiles twice.
 
 
-tmp="/tmp/sxiv_rifle_$$"
+TMPDIR="${TMPDIR:-/tmp}"
+tmp="$TMPDIR/sxiv_rifle_$$"
 
 listfiles () {
     find -L "///${1%/*}" \( ! -path "///${1%/*}" -prune \) -type f -print |

--- a/examples/rifle_sxiv.sh
+++ b/examples/rifle_sxiv.sh
@@ -15,8 +15,8 @@ tmp="/tmp/sxiv_rifle_$$"
 
 listfiles () {
     find -L "///${1%/*}" \( ! -path "///${1%/*}" -prune \) -type f \
-      \( -name '*.jpg' -o -name '*.jpeg' -o -name '*.png' -o -name '*.gif' \
-      -o -name '*.webp' -o -name '*.tiff' -o -name '*.bmp' \) -print |
+      \( -iname '*.jpg' -o -iname '*.jpeg' -o -iname '*.png' -o -iname '*.gif' \
+      -o -iname '*.webp' -o -iname '*.tiff' -o -iname '*.bmp' \) -print |
       sort | tee "$tmp"
 }
 

--- a/examples/rifle_sxiv.sh
+++ b/examples/rifle_sxiv.sh
@@ -21,12 +21,12 @@
 
 listfiles () {
     find -L "///${target%/*}" -maxdepth 1 -type f -iregex \
-      '.*\(jpe?g\|bmp\|png\|gif\|webp\)$' -print0 | sort -z
+      '.*\(jpe?g\|png\|gif\|webp\|bmp\)$' -print0 | sort -z
 }
 
 is_img () {
     case "${1##*.}" in
-        "jpg"|"jpeg"|"bmp"|"png"|"gif"|"webp") return 0 ;;
+        "jpg"|"jpeg"|"png"|"gif"|"webp"|"bmp") return 0 ;;
         *) return 1 ;;
     esac
 }


### PR DESCRIPTION
Hi,

I have been using the sxiv-rifle script as a wrapper around sxiv for a
long while now. There's a couple changes that can be made to improve the
performance of it. On my system I was able to achieve a 25% performance
increase, benchmarked with time (0.005 vs 0.004).

First of all, inside listfiles() we don't need to call `dirname`. Since
we already have the absolute path, we can just use parameter expansion.

Secondly, we don't need to call printf inside abspath(), we can directly
set the value to `"$target"`. In fact we can go one step further and
offload no arguments checking and abspath() into one case statement.

P.S. It should be noted that although I've been using this script, I
however don't use ranger myself. I do assume that this should be fine
since the logic of the script is mostly the same.

\- NRK

-- The above has been copy pasted from an email I sent to hut at the address found at [HACKING.md](https://github.com/ranger/ranger/blob/master/HACKING.md#patches). In reply I was told that this person is no longer working on ranger and either to make a pull request on github or use the mailing list instead. Maybe [HACKING.md](https://github.com/ranger/ranger/blob/master/HACKING.md#patches) should update the email address to the mailing list?


#### ISSUE TYPE
- Improvement/feature implementation

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [x] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [x] All changes follow the code style **[REQUIRED]**
- [x] All new and existing tests pass **[REQUIRED]**
``make test_shellcheck`` passes.
- [ ] Changes require config files to be updated
    - [ ] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated