### PR TITLE
Added support for Right-To-Left languages in the title bar

### DIFF
--- a/ranger/gui/displayable.py
+++ b/ranger/gui/displayable.py
@@ -8,6 +8,12 @@ import curses
 from ranger.core.shared import FileManagerAware
 from ranger.gui.curses_shortcuts import CursesShortcuts
 
+try:
+    from bidi.algorithm import get_display  # pylint: disable=import-error
+    HAVE_BIDI = True
+except ImportError:
+    HAVE_BIDI = False
+
 
 class Displayable(  # pylint: disable=too-many-instance-attributes
         FileManagerAware, CursesShortcuts):
@@ -208,6 +214,11 @@ class Displayable(  # pylint: disable=too-many-instance-attributes
 
     def __str__(self):
         return self.__class__.__name__
+
+    def bidi_transpose(self, text):
+        if self.settings.bidi_support and HAVE_BIDI:
+            return get_display(text)
+        return text
 
 
 class DisplayableContainer(Displayable):

--- a/ranger/gui/widgets/browsercolumn.py
+++ b/ranger/gui/widgets/browsercolumn.py
@@ -10,12 +10,6 @@ import stat
 from time import time
 from os.path import splitext
 
-try:
-    from bidi.algorithm import get_display  # pylint: disable=import-error
-    HAVE_BIDI = True
-except ImportError:
-    HAVE_BIDI = False
-
 from ranger.ext.widestring import WideString
 from ranger.core import linemode
 
@@ -424,13 +418,8 @@ class BrowserColumn(Pager):  # pylint: disable=too-many-instance-attributes
     def _total_len(predisplay):
         return sum([len(WideString(s)) for s, _ in predisplay])
 
-    def _bidi_transpose(self, text):
-        if self.settings.bidi_support and HAVE_BIDI:
-            return get_display(text)
-        return text
-
     def _draw_text_display(self, text, space):
-        bidi_text = self._bidi_transpose(text)
+        bidi_text = self.bidi_transpose(text)
         wtext = WideString(bidi_text)
         wext = WideString(splitext(bidi_text)[1])
         wellip = WideString(self.ellipsis[self.settings.unicode_ellipsis])

--- a/ranger/gui/widgets/titlebar.py
+++ b/ranger/gui/widgets/titlebar.py
@@ -114,12 +114,14 @@ class TitleBar(Widget):
             else:
                 clr = 'directory'
 
-            bar.add(path.basename, clr, directory=path)
+            bidi_basename = self.bidi_transpose(path.basename)
+            bar.add(bidi_basename, clr, directory=path)
             bar.add('/', clr, fixed=True, directory=path)
 
         if self.fm.thisfile is not None and \
                 self.settings.show_selection_in_titlebar:
-            bar.add(self.fm.thisfile.relative_path, 'file')
+            bidi_file_path = self.bidi_transpose(self.fm.thisfile.relative_path)
+            bar.add(bidi_file_path, 'file')
 
     def _get_right_part(self, bar):
         # TODO: fix that pressed keys are cut off when chaining CTRL keys


### PR DESCRIPTION
#### ISSUE TYPE
- Improvement/feature implementation

#### RUNTIME ENVIRONMENT
- Operating system and version: Manjaro Linux x86_64
- Terminal emulator and version: Alacritty
- Python version: Python 3.9.6
- Ranger version/commit: 1.9.3
- Locale: EN-US

#### CHECKLIST
- [X] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [X] All changes follow the code style **[REQUIRED]**
- [X] All new and existing tests pass **[REQUIRED]**
- [ ] Changes require config files to be updated
    - [ ] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
This pull request is expanding the BIDI feature from a previous pull request, which enables correct display of file names and folders with Hebrew/Arabic characters to also work in the ranger title bar.


#### MOTIVATION AND CONTEXT
I have been using ranger for quite sometime now and the mishandle of Hebrew file names really began to annoy my eyes. This addition makes the experience of browsing over files in Hebrew a lot smoother for me.


#### TESTING
I ran all of the python tests and verified the output.