### PR TITLE
Fix command `du` on macOS

### DIFF
--- a/examples/rc_emacs.conf
+++ b/examples/rc_emacs.conf
@@ -331,8 +331,8 @@ map <C-x>g? cd /usr/share/doc/ranger
 
 # External Programs
 map <C-x><C-f>  edit
-map <C-x>du shell -p du --max-depth=1 -h --apparent-size
-map <C-x>dU shell -p du --max-depth=1 -h --apparent-size | sort -rh
+map <C-x>du shell -p du -d 1 -h
+map <C-x>dU shell -p du -d 1 -h | sort -rh
 map <C-x>wp shell -f echo -n %d/%f | xsel -i; xsel -o | xsel -i -b
 map <C-x>wd shell -f echo -n %d    | xsel -i; xsel -o | xsel -i -b
 map <C-x>wn shell -f echo -n %f    | xsel -i; xsel -o | xsel -i -b

--- a/examples/rc_emacs.conf
+++ b/examples/rc_emacs.conf
@@ -331,8 +331,8 @@ map <C-x>g? cd /usr/share/doc/ranger
 
 # External Programs
 map <C-x><C-f>  edit
-map <C-x>du shell -p du -d 1 -h
-map <C-x>dU shell -p du -d 1 -h | sort -rh
+map <C-x>du shell -p (du --max-depth=1 --human-readable --apparent-size || du -d 1 -h) 2>/dev/null
+map <C-x>dU shell -p (du --max-depth=1 --human-readable --apparent-size || du -d 1 -h) 2>/dev/null | sort -rh
 map <C-x>wp shell -f echo -n %d/%f | xsel -i; xsel -o | xsel -i -b
 map <C-x>wd shell -f echo -n %d    | xsel -i; xsel -o | xsel -i -b
 map <C-x>wn shell -f echo -n %f    | xsel -i; xsel -o | xsel -i -b

--- a/ranger/config/rc.conf
+++ b/ranger/config/rc.conf
@@ -467,8 +467,8 @@ map g? cd /usr/share/doc/ranger
 
 # External Programs
 map E  edit
-map du shell -p du -d 1 -h
-map dU shell -p du -d 1 -h | sort -rh
+map du shell -p (du --max-depth=1 --human-readable --apparent-size || du -d 1 -h) 2>/dev/null
+map dU shell -p (du --max-depth=1 --human-readable --apparent-size || du -d 1 -h) 2>/dev/null | sort -rh
 map yp yank path
 map yd yank dir
 map yn yank name

--- a/ranger/config/rc.conf
+++ b/ranger/config/rc.conf
@@ -467,8 +467,8 @@ map g? cd /usr/share/doc/ranger
 
 # External Programs
 map E  edit
-map du shell -p du --max-depth=1 -h --apparent-size
-map dU shell -p du --max-depth=1 -h --apparent-size | sort -rh
+map du shell -p du -d 1 -h
+map dU shell -p du -d 1 -h | sort -rh
 map yp yank path
 map yd yank dir
 map yn yank name


### PR DESCRIPTION
<!-- Provide a descriptive summary of the changes in the title above -->

#### ISSUE TYPE
<!-- Pick relevant types and delete the rest -->
- Bug fix

#### RUNTIME ENVIRONMENT
<!-- Details of your runtime environment -->
<!-- Retrieve Python/ranger version and locale with `ranger -\-version` -->
- Operating system and version: macOS Catalina
- Terminal emulator and version: iTerm 2
- Python version: `3.9.6`
- Ranger version/commit: `master@209b8a`
- Locale: `en_US.UTF-8`

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [X] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [X] All changes follow the code style **[REQUIRED]**
- [X] All new and existing tests pass **[REQUIRED]**
- [X] Changes require config files to be updated
    - [X] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
<!-- Describe the changes in detail -->

According to `du`'s manual page on macOS:

<img width="1034" alt="Screen Shot 2021-08-19 at 20 40 00" src="https://user-images.githubusercontent.com/16078332/130069856-97b9b132-53a7-4eb5-a96a-48d091f276b6.png">

Command `du` does not compatible with option `--max-depth` and `--apparent-size` on BSD-based systems.

#### MOTIVATION AND CONTEXT
<!-- Why are these changes required? -->
<!-- What problems do these changes solve? -->
<!-- Link to relevant issues -->

Change option `--max-depth` to `-d` and remove option `--apparent-size`.

#### TESTING
<!-- What tests have been run? -->
<!-- How does the changes affect other areas of the codebase? -->

None.