### PR TITLE
Fix manpage error and use the right license file

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,6 +1,6 @@
 name: Shellcheck scope.sh
 
-on: 
+on:
   push:
     paths:
       - '.github/workflows/shellcheck.yml'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@ This log documents changes between stable versions.
 * Improved configurability of syntax highlighting previews
 * Improved coverage of unofficial MIME types, mostly audio formats
 * Improved documentation of `multipane` viewmode
-* Improved documentation of optional dependencies 
+* Improved documentation of optional dependencies
 * Improved documentation on `copymap`
 * Improved documentation on `tab_shift`
 * Improved documentation on `w3m_offset`

--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,7 @@
                     GNU GENERAL PUBLIC LICENSE
                        Version 3, 29 June 2007
 
- Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
  Everyone is permitted to copy and distribute verbatim copies
  of this license document, but changing it is not allowed.
 
@@ -645,7 +645,7 @@ the "copyright" line and a pointer to where the full notice is found.
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 Also add information on how to contact you by electronic and paper mail.
 
@@ -664,11 +664,11 @@ might be different; for a GUI interface, you would use an "about box".
   You should also get your employer (if you work as a programmer) or school,
 if any, to sign a "copyright disclaimer" for the program, if necessary.
 For more information on this, and how to apply and follow the GNU GPL, see
-<http://www.gnu.org/licenses/>.
+<https://www.gnu.org/licenses/>.
 
   The GNU General Public License does not permit incorporating your program
 into proprietary programs.  If your program is a subroutine library, you
 may consider it more useful to permit linking proprietary applications with
 the library.  If this is what you want to do, use the GNU Lesser General
 Public License instead of this License.  But first, please read
-<http://www.gnu.org/philosophy/why-not-lgpl.html>.
+<https://www.gnu.org/licenses/why-not-lgpl.html>.

--- a/doc/ranger.1
+++ b/doc/ranger.1
@@ -631,7 +631,7 @@ Reload everything
 Toggle \fIfreeze_files\fR setting.  When active (indicated by a cyan \fI\s-1FROZEN\s0\fR
 message in the status bar), directories and files will not be loaded, improving
 performance when all the files you need are already loaded.  This does not
-affect file previews, which can be toggled with \fIzI\fR.  Also try disabling the
+affect file previews, which can be toggled with \fIzp\fR.  Also try disabling the
 preview of directories with \fIzP\fR.
 .IP "^L" 14
 .IX Item "^L"
@@ -947,7 +947,7 @@ with the preview column being as large as the other columns combined.
 .IP "confirm_on_delete [string]" 4
 .IX Item "confirm_on_delete [string]"
 Ask for a confirmation when running the \*(L"delete\*(R" command?  Valid values are
-\&\*(L"always\*(R" (default), \*(L"never\*(R", \*(L"multiple\*(R". With \*(L"multiple\*(R", ranger will ask only
+\&\*(L"always\*(R", \*(L"never\*(R", \*(L"multiple\*(R" (default). With \*(L"multiple\*(R", ranger will ask only
 if you delete multiple files at once.
 .IP "dirname_in_tabs [bool]" 4
 .IX Item "dirname_in_tabs [bool]"

--- a/doc/ranger.pod
+++ b/doc/ranger.pod
@@ -578,7 +578,7 @@ Reload everything
 Toggle I<freeze_files> setting.  When active (indicated by a cyan I<FROZEN>
 message in the status bar), directories and files will not be loaded, improving
 performance when all the files you need are already loaded.  This does not
-affect file previews, which can be toggled with I<zI>.  Also try disabling the
+affect file previews, which can be toggled with I<zp>.  Also try disabling the
 preview of directories with I<zP>.
 
 =item ^L
@@ -994,7 +994,7 @@ with the preview column being as large as the other columns combined.
 =item confirm_on_delete [string]
 
 Ask for a confirmation when running the "delete" command?  Valid values are
-"always" (default), "never", "multiple". With "multiple", ranger will ask only
+"always", "never", "multiple" (default). With "multiple", ranger will ask only
 if you delete multiple files at once.
 
 =item dirname_in_tabs [bool]

--- a/doc/rifle.pod
+++ b/doc/rifle.pod
@@ -72,7 +72,7 @@ rifle shares configuration files with ranger, though ranger is not required in
 order to use rifle. The default configuration file F<rifle.conf> is expected
 to be at F<~/.config/ranger/rifle.conf>. However, this can be overridden with
 the B<-c> option. Note that due to the nature of the configuration, rifle will
-only read one file, it will not read the defaults in addition. 
+only read one file, it will not read the defaults in addition.
 
 This file specifies patterns for determining the commands to open files with.
 The syntax is described in the comments of the default F<rifle.conf> that ships


### PR DESCRIPTION
#### ISSUE TYPE
- Bug fix

#### CHECKLIST
- [x] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [x] All changes follow the code style **[REQUIRED]**
- [x] All new and existing tests pass **[REQUIRED]**

#### DESCRIPTION
Use the same license file as distributed by gnu.org, and fix two errors in manpage.

#### MOTIVATION AND CONTEXT
The manpage error confused me for a bit, and the right license file uses https instead of http.

#### TESTING
No changes in test coverage.