### PR TITLE
fix w3m method in 32bit

### DIFF
--- a/ranger/ext/img_display.py
+++ b/ranger/ext/img_display.py
@@ -187,6 +187,9 @@ class W3MImageDisplayer(ImageDisplayer, FileManagerAware):
             self.initialize()
         input_gen = self._generate_w3m_input(path, start_x, start_y, width,
                                              height)
+        self.process.stdin.write(input_gen)
+        self.process.stdin.flush()
+        self.process.stdout.readline()
 
         # Mitigate the issue with the horizontal black bars when
         # selecting some images on some systems. 2 milliseconds seems
@@ -195,11 +198,10 @@ class W3MImageDisplayer(ImageDisplayer, FileManagerAware):
             from time import sleep
             sleep(self.fm.settings.w3m_delay)
 
-        self.process.stdin.write(input_gen)
-        self.process.stdin.flush()
-        self.process.stdout.readline()
+        #HACK workaround for w3mimgdisplay memory leak
         self.quit()
         self.is_initialized = False
+        #HACK
 
     def clear(self, start_x, start_y, width, height):
         if not self.is_initialized or self.process.poll() is not None:


### PR DESCRIPTION
fix #2423
This is the proposed solution. Moving the delay after self.process .
It needs some testing, i don't know if that breaks the "horizontal black bars" mitigation.