### PR TITLE
ui: Fix crash when TMUX not in environment

### DIFF
--- a/ranger/gui/ui.py
+++ b/ranger/gui/ui.py
@@ -51,12 +51,12 @@ def _setup_mouse(signal):
 
 
 def _in_tmux():
-    return (os.environ.get('TMUX')
+    return (os.environ.get("TMUX", "")
             and 'tmux' in get_executables())
 
 
 def _in_screen():
-    return ('screen' in os.environ['TERM']
+    return ('screen' in os.environ.get("TERM", "")
             and 'screen' in get_executables())
 
 


### PR DESCRIPTION
Made a mistake when merging #2201. If the "TMUX" key isn't in the
environment dictionary we'll get a KeyError. Providing an empty string
default should fix the problem.

I applied the same logic to the check for screen because TERM isn't
guaranteed to be in the environment either, though this verges os
malicious.