### PR TITLE
Feat: ANSI escape codes support for browsercolumn

### DIFF
--- a/ranger/gui/ansi.py
+++ b/ranger/gui/ansi.py
@@ -20,6 +20,9 @@ reset = '\x1b[0m'
 
 
 def split_ansi_from_text(ansi_text):
+    if isinstance(ansi_text, WideString):
+        ansi_text = ansi_text.string
+
     return ansi_re.split(ansi_text)
 
 # For information on the ANSI codes see
@@ -119,6 +122,10 @@ def char_len(ansi_text):
     >>> char_len("")
     0
     """
+
+    if isinstance(ansi_text, WideString):
+        ansi_text = ansi_text.string
+
     return len(WideString(ansi_re.sub('', ansi_text)))
 
 

--- a/ranger/gui/widgets/browsercolumn.py
+++ b/ranger/gui/widgets/browsercolumn.py
@@ -13,8 +13,10 @@ from os.path import splitext
 from ranger.ext.widestring import WideString
 from ranger.core import linemode
 
-from . import Widget
-from .pager import Pager
+from ranger.gui import ansi
+from ranger.gui.color import get_color
+from ranger.gui.widgets import Widget
+from ranger.gui.widgets.pager import Pager
 
 
 def hook_before_drawing(fsobject, color_list):
@@ -117,9 +119,27 @@ class BrowserColumn(Pager):  # pylint: disable=too-many-instance-attributes
             self.win.move(line, 0)
         except curses.error:
             return
+
         for entry in commands:
             text, attr = entry
-            self.addstr(text, attr)
+            if isinstance(attr, tuple):
+                fg, bg, attr = attr
+                last_attr = curses.color_pair(get_color(fg, bg)) | attr
+            else:
+                fg = bg = None
+                last_attr = attr
+
+            for chunk in ansi.text_with_fg_bg_attr(text):
+                if isinstance(chunk, tuple):
+                    ansi_fg, ansi_bg, ansi_attr = chunk
+                    if attr & curses.A_REVERSE != 0:
+                        ansi_fg, ansi_bg = ansi_bg, ansi_fg
+                    if ansi_fg == -1 and fg is not None:
+                        ansi_fg = fg
+                    if ansi_bg == -1 and bg is not None:
+                        ansi_bg = bg
+                    last_attr = curses.color_pair(get_color(ansi_fg, ansi_bg)) | ansi_attr | attr
+                self.addstr(chunk, last_attr)
 
     def has_preview(self):
         if self.target is None:
@@ -424,7 +444,7 @@ class BrowserColumn(Pager):  # pylint: disable=too-many-instance-attributes
 
             predisplay = predisplay_left + predisplay_right
             for txt, color in predisplay:
-                attr = self.settings.colorscheme.get_attr(*(this_color + color))
+                attr = self.settings.colorscheme.get(*(this_color + color))
                 display_data.append([txt, attr])
 
             self.execute_curses_batch(line, display_data)
@@ -437,18 +457,22 @@ class BrowserColumn(Pager):  # pylint: disable=too-many-instance-attributes
 
     @staticmethod
     def _total_len(predisplay):
-        return sum(len(WideString(s)) for s, _ in predisplay)
+        return sum(ansi.char_len(s) for s, _ in predisplay)
 
     def _draw_text_display(self, text, space):
         bidi_text = self.bidi_transpose(text)
         wtext = WideString(bidi_text)
         wext = WideString(splitext(bidi_text)[1])
         wellip = WideString(self.ellipsis[self.settings.unicode_ellipsis])
-        if len(wtext) > space:
-            wtext = wtext[:max(1, space - len(wext) - len(wellip))] + wellip + wext
+        wtext_len = ansi.char_len(wtext)
+        wext_len = ansi.char_len(wext)
+        wellip_len = ansi.char_len(wellip)
+        if wext_len  > space:
+            wtext = ansi.char_slice(wtext, 0, max(1, space - wext_len - wellip_len))
+            wtext += wellip + wext
         # Truncate again if still too long.
-        if len(wtext) > space:
-            wtext = wtext[:max(0, space - len(wellip))] + wellip
+        if wtext_len > space:
+            wtext = ansi.char_slice(wtext, 0, max(0, space - wellip_len)) + wellip
 
         return [[str(wtext), []]]
 


### PR DESCRIPTION
<!-- Provide a descriptive summary of the changes in the title above -->

#### ISSUE TYPE
<!-- Pick relevant types and delete the rest -->
- Improvement/feature implementation
- Breaking changes

#### RUNTIME ENVIRONMENT
<!-- Details of your runtime environment -->
<!-- Retrieve Python/ranger version and locale with `ranger -\-version` -->
- Operating system and version: Ubuntu 20.04 LTS
- Terminal emulator and version: GNOME Terminal
- Python version: `3.9.6`
- Ranger version/commit: `master` 
- Locale: `en_US.UTF-8`

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [X] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [X] All changes follow the code style **[REQUIRED]**
- [X] All new and existing tests pass **[REQUIRED]**
- [ ] Changes require config files to be updated
    - [ ] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
<!-- Describe the changes in detail -->

Enable ANSI escape codes in browser columns. Closes #2349.

#### MOTIVATION AND CONTEXT
<!-- Why are these changes required? -->
<!-- What problems do these changes solve? -->
<!-- Link to relevant issues -->

See https://github.com/ranger/ranger/issues/2349#issue-912723347 and alexanderjeurissen/ranger_devicons#23.

#### TESTING
<!-- What tests have been run? -->
<!-- How does the changes affect other areas of the codebase? -->

The existing tests `make test` and the visual test in the demo below.

#### IMAGES / VIDEOS<!-- Only if relevant -->
<!-- Link or embed images and videos of screenshots, sketches etc. -->

Demo using [`devicons`](https://github.com/alexanderjeurissen/ranger_devicons) linemode with a random icon color:

```python
@ranger.api.register_linemode
class DevIconsLinemode(ranger.core.linemode.LinemodeBase):
  name = "devicons"
  uses_metadata = False

  def filetitle(self, file, metadata):
    icon = devicon(file)
    if file.is_directory:
      random.seed(42)
    else:
      random.seed(hash(icon))
    return SEPARATOR.join(('\x1b[3{}m'.format(random.randint(0, 7)), icon , '\x1b[0m', file.relative_path))
```

![Screenshot](https://user-images.githubusercontent.com/16078332/132706145-7db90534-3a54-4332-94a9-0351c9ea3f7b.png)

![screencast](https://user-images.githubusercontent.com/16078332/132702836-33a96bd1-0670-4e35-96e5-97886ff737e3.gif)
