### PR TITLE
Adds a preview for ELF files using readelf

### DIFF
--- a/ranger/data/scope.sh
+++ b/ranger/data/scope.sh
@@ -339,6 +339,11 @@ handle_mime() {
             mediainfo "${FILE_PATH}" && exit 5
             exiftool "${FILE_PATH}" && exit 5
             exit 1;;
+            
+        ## ELF files (executables and shared objects)
+        application/x-executable | application/x-pie-executable | application/x-sharedlib)
+            readelf -WCa "${FILE_PATH}" && exit 5
+            exit 1;;
     esac
 }
 


### PR DESCRIPTION
<!-- Provide a descriptive summary of the changes in the title above -->

#### ISSUE TYPE
- Improvement/feature implementation

#### RUNTIME ENVIRONMENT
<!-- Details of your runtime environment -->
<!-- Retrieve Python/ranger version and locale with `ranger -\-version` -->
- Operating system and version: Arch Linux 5.13.10-arch1-1
- Terminal emulator and version: Konsole 21.08.1
- Python version: 3.9.7
- Ranger version/commit: 1.9.3
- Locale: en_US.UTF-8

#### CHECKLIST
- [X] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [X] All changes follow the code style **[REQUIRED]**
- [X] All new and existing tests pass **[REQUIRED]**
- [ ] Changes require config files to be updated
    - [ ] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated


#### DESCRIPTION

This adds a clause to `scope.sh`'s mimetype switch statement for `application/x-executable`, `application/x-pie-executable`, and `application/x-sharedlib` to invoke `readelf -WCa`. This allows the user to view, among other things, the various sections of the executable, shared libraries it includes, and any symbols inside the file.


#### MOTIVATION AND CONTEXT
<!-- Why are these changes required? -->
This allows users to see basic information about an ELF file from the command line, allowing users to see what functions an executable or library offers or relies on.
<!-- What problems do these changes solve? -->
<!-- Link to relevant issues -->

I'm also interested in a similar function for PE files, but I do not know of any PE file readers that don't have a heavy cost to run (e.g. radare2)


#### TESTING
<!-- What tests have been run? -->
`make test` runs without issue.
<!-- How does the changes affect other areas of the codebase? -->


#### IMAGES / VIDEOS<!-- Only if relevant -->
<!-- Link or embed images and videos of screenshots, sketches etc. -->
![image](https://user-images.githubusercontent.com/5661700/132968024-39c8de35-bd21-44f2-a6b5-9d2611f80375.png)
