### PR TITLE
FIx freezing when using genric file opener on mac

### DIFF
--- a/ranger/config/rifle.conf
+++ b/ranger/config/rifle.conf
@@ -276,8 +276,8 @@ label wallpaper, number 14, mime ^image, has feh, X = feh --bg-fill "$1"
 #-------------------------------------------
 # Generic file openers
 #-------------------------------------------
-label open, has xdg-open = xdg-open "$@"
-label open, has open     = open -- "$@"
+label open, has xdg-open     = xdg-open "$@"
+label open, has open, flag f = open -- "$@"
 
 # Define the editor for non-text files + pager as last action
               !mime ^text, !ext xml|json|csv|tex|py|pl|rb|rs|js|sh|php|dart  = ask


### PR DESCRIPTION
Without ```flag f```, ranger freezes. This commit solves the problem by adding the appropriated flag.

<!-- Provide a descriptive summary of the changes in the title above -->

#### ISSUE TYPE
<!-- Pick relevant types and delete the rest -->
- Bug fix

#### RUNTIME ENVIRONMENT
<!-- Details of your runtime environment -->
<!-- Retrieve Python/ranger version and locale with `ranger -\-version` -->
- Operating system and version: MacOS 11.6
- Terminal emulator and version: Kitty 0.23.1
- Python version: 3.9.7
- Ranger version/commit: ranger 1.9.3
- Locale: en_US.UTF-8

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [X] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [X] All changes follow the code style **[REQUIRED]**
- [X] All new and existing tests pass **[REQUIRED]**
- [X] Changes require config files to be updated
    - [X] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
<!-- Describe the changes in detail -->
This PR adds the appropriated flag (  for the MacOS generic on the rifle config file.

#### MOTIVATION AND CONTEXT
<!-- Why are these changes required? -->
<!-- What problems do these changes solve? -->
<!-- Link to relevant issues -->
Without the f flag, ranger freezes when opening a file using the generic opener on MacOS. This PR solves the problem.

#### TESTING
<!-- What tests have been run? -->
<!-- How does the changes affect other areas of the codebase? -->
Only the existing tests were run. 
The change only affects the Rifle config.


#### IMAGES / VIDEOS<!-- Only if relevant -->
<!-- Link or embed images and videos of screenshots, sketches etc. -->
