### PR TITLE
SIXEL image previewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ For enhanced file previews (with `scope.sh`):
 
 * `img2txt` (from `caca-utils`) for ASCII-art image previews
 * `w3mimgdisplay`, `ueberzug`, `mpv`, `iTerm2`, `kitty`, `terminology` or `urxvt` for image previews
-* `convert` (from `imagemagick`) to auto-rotate images
+* `convert` (from `imagemagick`) to auto-rotate images and for image previews
 * `rsvg-convert` (from [`librsvg`](https://wiki.gnome.org/Projects/LibRsvg))
   for SVG previews
 * `ffmpeg`, or `ffmpegthumbnailer` for video thumbnails

--- a/doc/ranger.1
+++ b/doc/ranger.1
@@ -309,7 +309,7 @@ are automatically used when available but completely optional.
 \&\f(CW\*(C`w3mimgdisplay\*(C'\fR, \f(CW\*(C`ueberzug\*(C'\fR, \f(CW\*(C`mpv\*(C'\fR, \f(CW\*(C`iTerm2\*(C'\fR, \f(CW\*(C`kitty\*(C'\fR, \f(CW\*(C`terminology\*(C'\fR or
 \&\f(CW\*(C`urxvt\*(C'\fR for image previews
 .IP "\-" 2
-\&\f(CW\*(C`convert\*(C'\fR (from \f(CW\*(C`imagemagick\*(C'\fR) to auto-rotate images
+\&\f(CW\*(C`convert\*(C'\fR (from \f(CW\*(C`imagemagick\*(C'\fR) to auto-rotate images and for image previews
 .IP "\-" 2
 \&\f(CW\*(C`rsvg\-convert\*(C'\fR (from \f(CW\*(C`librsvg\*(C'\fR) for \s-1SVG\s0 previews
 .IP "\-" 2
@@ -367,6 +367,19 @@ To enable this feature, set the option \f(CW\*(C`preview_images_method\*(C'\fR t
 This feature relies on the dimensions of the terminal's font.  By default, a
 width of 8 and height of 11 are used.  To use other values, set the options
 \&\f(CW\*(C`iterm2_font_width\*(C'\fR and \f(CW\*(C`iterm2_font_height\*(C'\fR to the desired values.
+.PP
+\fIsixel\fR
+.IX Subsection "sixel"
+.PP
+\&\s-1SIXEL\s0 is the industry standard for displaying images in terminals.
+.PP
+Most mainstream terminal emulators include \s-1SIXEL\s0 support, for example:
+programs based on \s-1VTE\s0 >=0.68 (eg. \s-1GNOME\s0 Terminal), iTerm2, Mintty, etc.
+.PP
+To enable this feature, install the program \f(CW\*(C`convert\*(C'\fR (from \f(CW\*(C`imagemagick\*(C'\fR)
+and set the option \f(CW\*(C`preview_images_method\*(C'\fR to sixel.
+.PP
+Preferred dithering method can be specified by setting \f(CW\*(C`sixel_dithering\*(C'\fR.
 .PP
 \fIkitty\fR
 .IX Subsection "kitty"
@@ -1231,6 +1244,17 @@ Increase it in case of experiencing display corruption.
 Offset in pixels for the inner border of the terminal. Some terminals require
 the offset to be specified explicitly, among others st and UXterm, some don't
 like urxvt.
+.IP "sixel_dithering [string]" 4
+.IX Item "sixel_dithering [string]"
+One of dithering methods supported by \f(CW\*(C`convert\*(C'\fR, used for \s-1SIXEL\s0 image previews.
+.Sp
+\&\f(CW\*(C`convert\*(C'\fR currently supports the following dithering methods:
+.Sp
+.Vb 3
+\& None             No dithering
+\& Riemersma        Dithering along a Hilbert curve with restricted error proliferation
+\& FloydSteinberg   Error diffusion dithering
+.Ve
 .IP "wrap_plaintext_previews [bool]" 4
 .IX Item "wrap_plaintext_previews [bool]"
 Whether or not to wrap long lines in the pager, this includes previews of plain

--- a/doc/ranger.1
+++ b/doc/ranger.1
@@ -133,7 +133,7 @@
 .\" ========================================================================
 .\"
 .IX Title "RANGER 1"
-.TH RANGER 1 "ranger-1.9.3" "2023-03-10" "ranger manual"
+.TH RANGER 1 "ranger-1.9.3" "2023-04-05" "ranger manual"
 .\" For nroff, turn off justification.  Always turn off hyphenation; it makes
 .\" way too many mistakes in technical documents.
 .if n .ad l
@@ -371,13 +371,11 @@ width of 8 and height of 11 are used.  To use other values, set the options
 \fIsixel\fR
 .IX Subsection "sixel"
 .PP
-\&\s-1SIXEL\s0 is the industry standard for displaying images in terminals.
+This works in most terminal emulators, including all terminals based on \s-1VTE\s0 >=0.68
+(e.g. \s-1GNOME\s0 Terminal), iTerm2, MinTTY, WezTerm and many others.
 .PP
-Most mainstream terminal emulators include \s-1SIXEL\s0 support, for example:
-programs based on \s-1VTE\s0 >=0.68 (eg. \s-1GNOME\s0 Terminal), iTerm2, Mintty, etc.
-.PP
-To enable this feature, install the program \f(CW\*(C`convert\*(C'\fR (from \f(CW\*(C`imagemagick\*(C'\fR)
-and set the option \f(CW\*(C`preview_images_method\*(C'\fR to sixel.
+To enable this feature, install \f(CW\*(C`imagemagick\*(C'\fR and set the option
+\&\f(CW\*(C`preview_images_method\*(C'\fR to sixel.
 .PP
 Preferred dithering method can be specified by setting \f(CW\*(C`sixel_dithering\*(C'\fR.
 .PP

--- a/doc/ranger.pod
+++ b/doc/ranger.pod
@@ -235,7 +235,7 @@ C<urxvt> for image previews
 
 =item -
 
-C<convert> (from C<imagemagick>) to auto-rotate images
+C<convert> (from C<imagemagick>) to auto-rotate images and for image previews
 
 =item -
 
@@ -325,6 +325,18 @@ To enable this feature, set the option C<preview_images_method> to iterm2.
 This feature relies on the dimensions of the terminal's font.  By default, a
 width of 8 and height of 11 are used.  To use other values, set the options
 C<iterm2_font_width> and C<iterm2_font_height> to the desired values.
+
+=head3 sixel
+
+SIXEL is the industry standard for displaying images in terminals.
+
+Most mainstream terminal emulators include SIXEL support, for example:
+programs based on VTE >=0.68 (eg. GNOME Terminal), iTerm2, Mintty, etc.
+
+To enable this feature, install the program C<convert> (from C<imagemagick>)
+and set the option C<preview_images_method> to sixel.
+
+Preferred dithering method can be specified by setting C<sixel_dithering>.
 
 =head3 kitty
 
@@ -1331,6 +1343,16 @@ Increase it in case of experiencing display corruption.
 Offset in pixels for the inner border of the terminal. Some terminals require
 the offset to be specified explicitly, among others st and UXterm, some don't
 like urxvt.
+
+=item sixel_dithering [string]
+
+One of dithering methods supported by C<convert>, used for SIXEL image previews.
+
+C<convert> currently supports the following dithering methods:
+
+ None             No dithering
+ Riemersma        Dithering along a Hilbert curve with restricted error proliferation
+ FloydSteinberg   Error diffusion dithering
 
 =item wrap_plaintext_previews [bool]
 

--- a/doc/ranger.pod
+++ b/doc/ranger.pod
@@ -328,13 +328,11 @@ C<iterm2_font_width> and C<iterm2_font_height> to the desired values.
 
 =head3 sixel
 
-SIXEL is the industry standard for displaying images in terminals.
+This works in most terminal emulators, including all terminals based on VTE >=0.68
+(e.g. GNOME Terminal), iTerm2, MinTTY, WezTerm and many others.
 
-Most mainstream terminal emulators include SIXEL support, for example:
-programs based on VTE >=0.68 (eg. GNOME Terminal), iTerm2, Mintty, etc.
-
-To enable this feature, install the program C<convert> (from C<imagemagick>)
-and set the option C<preview_images_method> to sixel.
+To enable this feature, install C<imagemagick> and set the option
+C<preview_images_method> to sixel.
 
 Preferred dithering method can be specified by setting C<sixel_dithering>.
 

--- a/doc/rifle.1
+++ b/doc/rifle.1
@@ -133,7 +133,7 @@
 .\" ========================================================================
 .\"
 .IX Title "RIFLE 1"
-.TH RIFLE 1 "rifle-1.9.3" "2022-10-19" "rifle manual"
+.TH RIFLE 1 "rifle-1.9.3" "2020-11-08" "rifle manual"
 .\" For nroff, turn off justification.  Always turn off hyphenation; it makes
 .\" way too many mistakes in technical documents.
 .if n .ad l

--- a/doc/rifle.1
+++ b/doc/rifle.1
@@ -133,7 +133,7 @@
 .\" ========================================================================
 .\"
 .IX Title "RIFLE 1"
-.TH RIFLE 1 "rifle-1.9.3" "2020-11-08" "rifle manual"
+.TH RIFLE 1 "rifle-1.9.3" "2022-10-19" "rifle manual"
 .\" For nroff, turn off justification.  Always turn off hyphenation; it makes
 .\" way too many mistakes in technical documents.
 .if n .ad l

--- a/ranger/config/rc.conf
+++ b/ranger/config/rc.conf
@@ -92,6 +92,11 @@ set preview_images false
 #   Previews images in full color in the terminology terminal emulator.
 #   Supports a wide variety of formats, even vector graphics like svg.
 #
+# * sixel:
+#   Previews images using the SIXEL protocol. This requires "convert"
+#   from "imagemagick" and works consistently across many popular
+#   terminals.
+#
 # * urxvt:
 #   Preview images in full color using urxvt image backgrounds. This
 #   requires using urxvt compiled with pixbuf support.
@@ -125,6 +130,11 @@ set w3m_offset 0
 # Default iTerm2 font size (see: preview_images_method: iterm2)
 set iterm2_font_width 8
 set iterm2_font_height 11
+
+# Dithering mode for SIXEL previews.  One of:
+# None, Riemersma, FloydSteinberg
+# (see: preview_images_method: sixel)
+set sixel_dithering FloydSteinberg
 
 # Use a unicode "..." character to mark cut-off filenames?
 set unicode_ellipsis false

--- a/ranger/config/rc.conf
+++ b/ranger/config/rc.conf
@@ -93,9 +93,7 @@ set preview_images false
 #   Supports a wide variety of formats, even vector graphics like svg.
 #
 # * sixel:
-#   Previews images using the SIXEL protocol. This requires "convert"
-#   from "imagemagick" and works consistently across many popular
-#   terminals.
+#   Previews images using the SIXEL protocol. This requires "imagemagick".
 #
 # * urxvt:
 #   Preview images in full color using urxvt image backgrounds. This

--- a/ranger/container/settings.py
+++ b/ranger/container/settings.py
@@ -100,6 +100,7 @@ ALLOWED_SETTINGS = {
     'wrap_plaintext_previews': bool,
     'wrap_scroll': bool,
     'xterm_alt_key': bool,
+    'sixel_dithering': str,
 }
 
 ALLOWED_VALUES = {
@@ -112,8 +113,8 @@ ALLOWED_VALUES = {
     'nested_ranger_warning': ['true', 'false', 'error'],
     'one_indexed': [False, True],
     'preview_images_method': ['w3m', 'iterm2', 'terminology',
-                              'urxvt', 'urxvt-full', 'kitty',
-                              'ueberzug'],
+                              'sixel', 'urxvt', 'urxvt-full',
+                              'kitty', 'ueberzug'],
     'vcs_backend_bzr': ['disabled', 'local', 'enabled'],
     'vcs_backend_git': ['enabled', 'disabled', 'local'],
     'vcs_backend_hg': ['disabled', 'local', 'enabled'],

--- a/ranger/core/actions.py
+++ b/ranger/core/actions.py
@@ -1029,6 +1029,7 @@ class Actions(  # pylint: disable=too-many-instance-attributes,too-many-public-m
     def update_preview(self, path):
         try:
             del self.previews[path]
+            self.signal_emit('preview.cleared', path=path)
         except KeyError:
             return False
         self.ui.need_redraw = True

--- a/ranger/ext/img_display.py
+++ b/ranger/ext/img_display.py
@@ -16,15 +16,13 @@ import curses
 import errno
 import fcntl
 import os
-import shlex
 import struct
 import sys
 import warnings
 import json
 import mmap
-import shutil
 import threading
-from subprocess import Popen, PIPE, check_call, check_output, CalledProcessError
+from subprocess import Popen, PIPE, check_call, CalledProcessError
 from collections import defaultdict, namedtuple
 
 import termios
@@ -35,21 +33,14 @@ from tempfile import gettempdir, NamedTemporaryFile, TemporaryFile
 from ranger import PY3
 from ranger.core.shared import FileManagerAware, SettingsAware
 from ranger.ext.popen23 import Popen23
+from ranger.ext.which import which
 
 
-def _which(cmd):
-    if PY3:
-        return shutil.which(cmd)
-
-    try:
-        return check_output(["which", cmd])
-    except CalledProcessError:
-        return None
-
-
-if _which("magick"):
-    MAGICK_CONVERT_CMD_BASE = ("magick", "convert")
+if which("magick"):
+    # Magick >= 7
+    MAGICK_CONVERT_CMD_BASE = ("magick",)
 else:
+    # Magick < 7
     MAGICK_CONVERT_CMD_BASE = ("convert",)
 
 
@@ -478,7 +469,7 @@ class SixelImageDisplayer(ImageDisplayer, FileManagerAware):
             fit_height = font_height * height
 
             sixel_dithering = self.fm.settings.sixel_dithering
-            cached = TemporaryFile("w+")
+            cached = TemporaryFile("w+", prefix=path.replace(os.sep, "-"))
 
             environ = dict(os.environ)
             environ.setdefault("MAGICK_OCL_DEVICE", "true")

--- a/ranger/ext/img_display.py
+++ b/ranger/ext/img_display.py
@@ -377,7 +377,8 @@ class ITerm2ImageDisplayer(ImageDisplayer, FileManagerAware):
         font_height = self.fm.settings.iterm2_font_height
 
         return image_fit_width(
-                width, height, max_cols, max_rows, font_width, font_height)
+            width, height, max_cols, max_rows, font_width, font_height
+        )
 
     @staticmethod
     def _encode_image_content(path):
@@ -454,7 +455,11 @@ class SixelImageDisplayer(ImageDisplayer, FileManagerAware):
 
     def _clear_cache(self, path):
         if os.path.exists(path):
-            self.cache = {ce: cd for ce, cd in self.cache.items() if ce.inode != os.stat(path).st_ino}
+            self.cache = {
+                ce: cd
+                for ce, cd in self.cache.items()
+                if ce.inode != os.stat(path).st_ino
+            }
 
     def _sixel_cache(self, path, width, height):
         stat = os.stat(path)
@@ -471,15 +476,20 @@ class SixelImageDisplayer(ImageDisplayer, FileManagerAware):
             environ = dict(os.environ)
             environ.setdefault("MAGICK_OCL_DEVICE", "true")
             try:
-                check_call([*MAGICK_CONVERT_CMD_BASE, path + "[0]",
-                            "-geometry", "{0}x{1}>"
-                            .format(fit_width, fit_height),
-                             "-dither", sixel_dithering,
-                             "sixel:-"],
-                           stdout=cached,
-                           stderr=DEVNULL,
-                           env=environ,
-                           )
+                check_call(
+                    [
+                        *MAGICK_CONVERT_CMD_BASE,
+                        path + "[0]",
+                        "-geometry",
+                        "{0}x{1}>".format(fit_width, fit_height),
+                        "-dither",
+                        sixel_dithering,
+                        "sixel:-",
+                    ],
+                    stdout=cached,
+                    stderr=DEVNULL,
+                    env=environ,
+                )
             except CalledProcessError:
                 raise ImageDisplayError("ImageMagick failed processing the SIXEL image")
             except FileNotFoundError:

--- a/ranger/ext/img_display.py
+++ b/ranger/ext/img_display.py
@@ -32,7 +32,7 @@ from tempfile import gettempdir, NamedTemporaryFile, TemporaryFile
 
 from ranger import PY3
 from ranger.core.shared import FileManagerAware, SettingsAware
-from ranger.ext.popen23 import Popen23
+from ranger.ext.popen23 import Popen23, DEVNULL
 from ranger.ext.which import which
 
 
@@ -480,7 +480,7 @@ class SixelImageDisplayer(ImageDisplayer, FileManagerAware):
                              "-dither", sixel_dithering,
                              "sixel:-"],
                            stdout=cached,
-                           stderr=PIPE,
+                           stderr=DEVNULL,
                            env=environ,
                            )
             except CalledProcessError:

--- a/ranger/ext/img_display.py
+++ b/ranger/ext/img_display.py
@@ -6,7 +6,7 @@
 """Interface for drawing images into the console
 
 This module provides functions to draw images in the terminal using supported
-implementations, which are currently w3m, iTerm2 and urxvt.
+implementations.
 """
 
 from __future__ import (absolute_import, division, print_function)
@@ -16,18 +16,20 @@ import curses
 import errno
 import fcntl
 import os
+import shlex
 import struct
 import sys
 import warnings
 import json
+import mmap
 import threading
-from subprocess import Popen, PIPE
-from collections import defaultdict
+from subprocess import Popen, PIPE, check_call, CalledProcessError
+from collections import defaultdict, namedtuple
 
 import termios
 from contextlib import contextmanager
 import codecs
-from tempfile import gettempdir, NamedTemporaryFile
+from tempfile import gettempdir, NamedTemporaryFile, TemporaryFile
 
 from ranger import PY3
 from ranger.core.shared import FileManagerAware, SettingsAware
@@ -64,6 +66,47 @@ def move_cur(to_y, to_x):
     # on python2 stdout is already in binary mode, in python3 is accessed via buffer
     bin_stdout = getattr(sys.stdout, 'buffer', sys.stdout)
     bin_stdout.write(tparm)
+
+
+def get_terminal_size():
+    farg = struct.pack("HHHH", 0, 0, 0, 0)
+    fd_stdout = sys.stdout.fileno()
+    fretint = fcntl.ioctl(fd_stdout, termios.TIOCGWINSZ, farg)
+    return struct.unpack("HHHH", fretint)
+
+
+def get_font_dimensions():
+    """
+    Get the height and width of a character displayed in the terminal in
+    pixels.
+    """
+    rows, cols, xpixels, ypixels = get_terminal_size()
+    return (xpixels // cols), (ypixels // rows)
+
+
+def image_fit_width(width, height, max_cols, max_rows, font_width=None, font_height=None):
+    if font_width is None or font_height is None:
+        font_width, font_height = get_font_dimensions()
+
+    max_width = font_width * max_cols
+    max_height = font_height * max_rows
+    if height > max_height:
+        if width > max_width:
+            width_scale = max_width / width
+            height_scale = max_height / height
+            min_scale = min(width_scale, height_scale)
+            max_scale = max(width_scale, height_scale)
+            if width * max_scale <= max_width and height * max_scale <= max_height:
+                return width * max_scale
+            return width * min_scale
+
+        scale = max_height / height
+        return width * scale
+    elif width > max_width:
+        scale = max_width / width
+        return width * scale
+
+    return width
 
 
 class ImageDisplayError(Exception):
@@ -324,25 +367,11 @@ class ITerm2ImageDisplayer(ImageDisplayer, FileManagerAware):
         return text
 
     def _fit_width(self, width, height, max_cols, max_rows):
-        max_width = self.fm.settings.iterm2_font_width * max_cols
-        max_height = self.fm.settings.iterm2_font_height * max_rows
-        if height > max_height:
-            if width > max_width:
-                width_scale = max_width / width
-                height_scale = max_height / height
-                min_scale = min(width_scale, height_scale)
-                max_scale = max(width_scale, height_scale)
-                if width * max_scale <= max_width and height * max_scale <= max_height:
-                    return width * max_scale
-                return width * min_scale
+        font_width = self.fm.settings.iterm2_font_width
+        font_height = self.fm.settings.iterm2_font_height
 
-            scale = max_height / height
-            return width * scale
-        elif width > max_width:
-            scale = max_width / width
-            return width * scale
-
-        return width
+        return image_fit_width(
+                width, height, max_cols, max_rows, font_width, font_height)
 
     @staticmethod
     def _encode_image_content(path):
@@ -401,6 +430,87 @@ class ITerm2ImageDisplayer(ImageDisplayer, FileManagerAware):
             else:
                 return 0, 0
         return width, height
+
+
+_CacheableSixelImage = namedtuple("_CacheableSixelImage", ("width", "height", "inode"))
+
+_CachedSixelImage = namedtuple("_CachedSixelImage", ("image", "fh"))
+
+
+@register_image_displayer("sixel")
+class SixelImageDisplayer(ImageDisplayer, FileManagerAware):
+    """Implementation of ImageDisplayer using SIXEL."""
+
+    def __init__(self):
+        self.win = None
+        self.cache = {}
+        self.fm.signal_bind('preview.cleared', lambda signal: self._clear_cache(signal.path))
+
+    def _clear_cache(self, path):
+        if os.path.exists(path):
+            self.cache = {ce: cd for ce, cd in self.cache.items() if ce.inode != os.stat(path).st_ino}
+
+    def _sixel_cache(self, path, width, height):
+        stat = os.stat(path)
+        cacheable = _CacheableSixelImage(width, height, stat.st_ino)
+
+        if cacheable not in self.cache:
+            font_width, font_height = get_font_dimensions()
+            fit_width = font_width * width
+            fit_height = font_height * height
+
+            sixel_dithering = self.fm.settings.sixel_dithering
+            cached = TemporaryFile("w+")
+
+            try:
+                check_call(["convert", path + "[0]",
+                            "-geometry", "{0}x{1}>"
+                            .format(fit_width, fit_height),
+                             "-dither", sixel_dithering,
+                             "sixel:-"],
+                           stdout=cached,
+                           stderr=PIPE)
+            except CalledProcessError:
+                raise ImageDisplayError("ImageMagick failed processing the SIXEL image")
+            except FileNotFoundError:
+                raise ImageDisplayError("SIXEL image previews require ImageMagick")
+            finally:
+                cached.flush()
+
+            if os.fstat(cached.fileno()).st_size == 0:
+                raise ImageDisplayError("ImageMagick produced an empty SIXEL image file")
+
+            self.cache[cacheable] = _CachedSixelImage(mmap.mmap(cached.fileno(), 0), cached)
+
+        return self.cache[cacheable].image
+
+    def draw(self, path, start_x, start_y, width, height):
+        if self.win is None:
+            self.win = self.fm.ui.win.subwin(height, width, start_y, start_x)
+        else:
+            self.win.mvwin(start_y, start_x)
+            self.win.resize(height, width)
+
+        with temporarily_moved_cursor(start_y, start_x):
+            sixel = self._sixel_cache(path, width, height)[:]
+            if PY3:
+                sys.stdout.buffer.write(sixel)
+            else:
+                sys.stdout.write(sixel)
+            sys.stdout.flush()
+
+    def clear(self, start_x, start_y, width, height):
+        if self.win is not None:
+            self.win.clear()
+            self.win.refresh()
+
+            self.win = None
+
+        self.fm.ui.win.redrawwin()
+
+    def quit(self):
+        self.clear(0, 0, 0, 0)
+        self.cache = {}
 
 
 @register_image_displayer("terminology")

--- a/ranger/ext/img_display.py
+++ b/ranger/ext/img_display.py
@@ -466,7 +466,7 @@ class SixelImageDisplayer(ImageDisplayer, FileManagerAware):
             fit_height = font_height * height
 
             sixel_dithering = self.fm.settings.sixel_dithering
-            cached = TemporaryFile("w+", prefix=path.replace(os.sep, "-"))
+            cached = TemporaryFile("w+", prefix="ranger", suffix=path.replace(os.sep, "-"))
 
             environ = dict(os.environ)
             environ.setdefault("MAGICK_OCL_DEVICE", "true")

--- a/ranger/ext/img_display.py
+++ b/ranger/ext/img_display.py
@@ -104,18 +104,15 @@ def image_fit_width(width, height, max_cols, max_rows, font_width=None, font_hei
             width_scale = max_width / width
             height_scale = max_height / height
             min_scale = min(width_scale, height_scale)
-            max_scale = max(width_scale, height_scale)
-            if width * max_scale <= max_width and height * max_scale <= max_height:
-                return width * max_scale
             return width * min_scale
-
-        scale = max_height / height
-        return width * scale
+        else:
+            scale = max_height / height
+            return width * scale
     elif width > max_width:
         scale = max_width / width
         return width * scale
-
-    return width
+    else:
+        return width
 
 
 class ImageDisplayError(Exception):

--- a/ranger/ext/popen23.py
+++ b/ranger/ext/popen23.py
@@ -14,9 +14,11 @@ except ImportError:
     PY3 = version_info[0] >= 3
 
 if PY3:
+    # pylint: disable=ungrouped-imports,unused-import
     from subprocess import DEVNULL
 else:
     import os
+    # pylint: disable=consider-using-with
     DEVNULL = open(os.devnull, "wb")
 
 

--- a/ranger/ext/popen23.py
+++ b/ranger/ext/popen23.py
@@ -13,6 +13,12 @@ except ImportError:
     from sys import version_info
     PY3 = version_info[0] >= 3
 
+if PY3:
+    from subprocess import DEVNULL
+else:
+    import os
+    DEVNULL = open(os.devnull, "wb")
+
 
 # COMPAT: Python 2 (and Python <=3.2) subprocess.Popen objects aren't
 #         context managers. We don't care about early Python 3 but we do want

--- a/ranger/ext/which.py
+++ b/ranger/ext/which.py
@@ -1,0 +1,18 @@
+# This file is part of ranger, the console file manager.
+# License: GNU GPL version 3, see the file "AUTHORS" for details.
+
+from __future__ import (absolute_import, division, print_function)
+
+import shutil
+from subprocess import check_output, CalledProcessError
+from ranger import PY3
+
+
+def which(cmd):
+    if PY3:
+        return shutil.which(cmd)
+
+    try:
+        return check_output(["command", "-v", cmd])
+    except CalledProcessError:
+        return None


### PR DESCRIPTION
Fixes #723; Replaces #2234.

#### ISSUE TYPE
- Improvement/feature implementation

#### RUNTIME ENVIRONMENT
- Operating system and version: Generic GNU/Linux; macOS
- Terminal emulator and version: GNOME Terminal (latest Git commit) + VTE from the latest Git commit; mlterm 3.9.2; iTerm2
- Python version: CPython 3.11.1 and 2.7.16
- Ranger version/commit: N/A
- Locale: N/A

#### CHECKLIST
- [x] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [x] All changes follow the code style **[REQUIRED]**
- [x] All new and existing tests pass **[REQUIRED]**
- [x] Changes require config files to be updated
    - [x] Config files have been updated
- [x] Changes require documentation to be updated
    - [x] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION

Implements an image preview module for SIXEL-capable terminals.
Properly clears preview area (VTE-ready).

#### MOTIVATION AND CONTEXT

#2234 provides a PoC implementation of a SIXEL image previewer.
It however did not dispose of expired images properly, which turns out to be an issue in some implementations (namely VTE).

SIXEL support is to be stabilized in the next release of VTE and will soon hit major Linux distributions such as Ubuntu, so it might be high time to finally get this done.

#### TESTING

This appears to have already garnered some users, for example at https://aur.archlinux.org/packages/ranger-sixel-git.

As of February 2023, lots of people have confirmed that this patch does indeed do the job in its current form.