### PR TITLE
the exception TypeError is raised if the entry is not a unicode string

### DIFF
--- a/ranger/container/tags.py
+++ b/ranger/container/tags.py
@@ -96,7 +96,7 @@ class Tags(FileManagerAware):
         for path, tag in self.tags.items():
             if tag == self.default_tag:
                 # COMPAT: keep the old format if the default tag is used
-                fobj.write(path + '\n')
+                fobj.write(path.decode('utf-8', 'ignore') + '\n')
             elif tag in ALLOWED_KEYS:
                 fobj.write('{0}:{1}\n'.format(tag, path))
 

--- a/ranger/gui/widgets/console.py
+++ b/ranger/gui/widgets/console.py
@@ -84,7 +84,7 @@ class Console(Widget):  # pylint: disable=too-many-instance-attributes,too-many-
                     for entry in self.history_backup:
                         try:
                             fobj.write(entry + '\n')
-                        except UnicodeEncodeError:
+                        except (UnicodeEncodeError, TypeError):
                             pass
             except (OSError, IOError) as ex:
                 self.fm.notify(


### PR DESCRIPTION
ranger would crash very sporadically on exit (leaving the terminal in raw mode) because of unicode exception. the except doesn't catch typeerror. I think this does what is originally intended.