### PR TITLE
ext: fix getslice method for `WideString`

### DIFF
--- a/ranger/ext/widestring.py
+++ b/ranger/ext/widestring.py
@@ -124,15 +124,19 @@ class WideString(object):  # pylint: disable=too-few-public-methods
         >>> WideString("aモ")[0:1]
         <WideString 'a'>
         """
-        if stop is None or stop > len(self.chars):
-            stop = len(self.chars)
+        length = len(self)
+
+        if stop is None or stop > length:
+            stop = length
         if stop < 0:
-            stop = len(self.chars) + stop
-        if stop < 0:
-            return WideString("")
-        if start is None or start < 0:
+            stop = max(0, length + stop)
+        if start is None:
             start = 0
-        if stop < len(self.chars) and self.chars[stop] == '':
+        if start < 0:
+            start = max(0, length + start)
+        if start >= length or start >= stop:
+            return WideString("")
+        if stop < length and self.chars[stop] == '':
             if self.chars[start] == '':
                 return WideString(' ' + ''.join(self.chars[start:stop - 1]) + ' ')
             return WideString(''.join(self.chars[start:stop - 1]) + ' ')
@@ -140,7 +144,7 @@ class WideString(object):  # pylint: disable=too-few-public-methods
             return WideString(' ' + ''.join(self.chars[start:stop - 1]))
         return WideString(''.join(self.chars[start:stop]))
 
-    def __getitem__(self, i):
+    def __getitem__(self, item):
         """
         >>> WideString("asdf")[2]
         <WideString 'd'>
@@ -149,9 +153,10 @@ class WideString(object):  # pylint: disable=too-few-public-methods
         >>> WideString("……")[1]
         <WideString '…'>
         """
-        if isinstance(i, slice):
-            return self.__getslice__(i.start, i.stop)
-        return self.__getslice__(i, i + 1)
+        if isinstance(item, slice):
+            assert item.step is None or item.step == 1
+            return self.__getslice__(item.start, item.stop)
+        return self.__getslice__(item, item + 1)
 
     def __len__(self):
         """


### PR DESCRIPTION
<!-- Provide a descriptive summary of the changes in the title above -->

#### ISSUE TYPE
<!-- Pick relevant types and delete the rest -->
- Bug fix

#### RUNTIME ENVIRONMENT
<!-- Details of your runtime environment -->
<!-- Retrieve Python/ranger version and locale with `ranger -\-version` -->
- Operating system and version: Ubuntu 20.04 LTS
- Terminal emulator and version: GNOME Terminal
- Python version: 3.9.7
- Ranger version/commit: master
- Locale: en_US.UTF-8

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [X] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [X] All changes follow the code style **[REQUIRED]**
- [X] All new and existing tests pass **[REQUIRED]**
- [ ] Changes require config files to be updated
    - [ ] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
<!-- Describe the changes in detail -->

Fix issue for the `__getslice__` method with a slice that starts with negative `start`.

Current output:

```python
>>> s = WideString('一二三四五')
>>> s[-5:]
<WideString '一二三四五'>
```

Desired output:

```python
>>> s = WideString('一二三四五')
>>> s[-5:]
<WideString ' 四五'>
```

#### MOTIVATION AND CONTEXT
<!-- Why are these changes required? -->
<!-- What problems do these changes solve? -->
<!-- Link to relevant issues -->

Improve wide string support, especially for East Asian characters.

#### TESTING
<!-- What tests have been run? -->
<!-- How does the changes affect other areas of the codebase? -->

None.