### PR TITLE
lint: fix tests for pylint

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -13,7 +13,23 @@ max-branches=16
 [FORMAT]
 max-line-length = 99
 enable=no-absolute-import,old-division
-disable=cyclic-import,duplicate-code,fixme,import-outside-toplevel,locally-disabled,locally-enabled,missing-docstring,no-else-break,no-else-continue,no-else-raise,no-else-return,raise-missing-from,redefined-variable-type,stop-iteration-return,super-with-arguments,useless-object-inheritance
+disable=cyclic-import,
+        duplicate-code,
+        fixme,
+        import-outside-toplevel,
+        locally-disabled,
+        locally-enabled,
+        missing-docstring,
+        no-else-break,
+        no-else-continue,
+        no-else-raise,
+        no-else-return,
+        raise-missing-from,
+        redefined-variable-type,
+        stop-iteration-return,
+        super-with-arguments,
+        useless-object-inheritance,
+        consider-using-f-string
 
 [TYPECHECK]
 ignored-classes=ranger.core.actions.Actions

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,6 +1,8 @@
 [MASTER]
 init-hook='import sys; sys.path.append("tests/pylint")'
 load-plugins=py2_compat
+# Min Python version to use for version dependend checks.
+py-version=2.7
 
 [BASIC]
 good-names=i,j,k,n,x,y,ex,Run,_,fm,ui,fg,bg
@@ -12,7 +14,7 @@ max-branches=16
 
 [FORMAT]
 max-line-length = 99
-enable=no-absolute-import,old-division
+enable=no-absolute-import,old-division,using-f-string-in-unsupported-version
 disable=cyclic-import,
         duplicate-code,
         fixme,

--- a/.pylintrc
+++ b/.pylintrc
@@ -2,7 +2,7 @@
 init-hook='import sys; sys.path.append("tests/pylint")'
 load-plugins=py2_compat
 # Min Python version to use for version dependend checks.
-py-version=2.7
+py-version=2.6
 
 [BASIC]
 good-names=i,j,k,n,x,y,ex,Run,_,fm,ui,fg,bg

--- a/ranger/config/.pylintrc
+++ b/ranger/config/.pylintrc
@@ -1,3 +1,7 @@
+[MASTER]
+# Min Python version to use for version dependend checks.
+py-version=2.7
+
 [BASIC]
 good-names=i,j,k,n,ex,Run,_,fm,ui,fg,bg
 class-rgx=[a-z][a-z0-9_]{1,30}$
@@ -5,6 +9,7 @@ class-rgx=[a-z][a-z0-9_]{1,30}$
 [FORMAT]
 max-line-length = 99
 max-module-lines=3000
+enable=using-f-string-in-unsupported-version
 disable=duplicate-code,
         fixme,
         import-outside-toplevel,

--- a/ranger/config/.pylintrc
+++ b/ranger/config/.pylintrc
@@ -5,4 +5,12 @@ class-rgx=[a-z][a-z0-9_]{1,30}$
 [FORMAT]
 max-line-length = 99
 max-module-lines=3000
-disable=duplicate-code,fixme,import-outside-toplevel,locally-disabled,locally-enabled,missing-docstring,no-else-return,super-with-arguments
+disable=duplicate-code,
+        fixme,
+        import-outside-toplevel,
+        locally-disabled,
+        locally-enabled,
+        missing-docstring,
+        no-else-return,
+        super-with-arguments,
+        consider-using-f-string

--- a/ranger/config/.pylintrc
+++ b/ranger/config/.pylintrc
@@ -1,6 +1,6 @@
 [MASTER]
 # Min Python version to use for version dependend checks.
-py-version=2.7
+py-version=2.6
 
 [BASIC]
 good-names=i,j,k,n,ex,Run,_,fm,ui,fg,bg

--- a/ranger/container/file.py
+++ b/ranger/container/file.py
@@ -86,7 +86,7 @@ class File(FileSystemObject):
             return True
         if PREVIEW_BLACKLIST.search(self.basename):
             return False
-        if self.path == '/dev/core' or self.path == '/proc/kcore':
+        if self.path in ('/dev/core', '/proc/kcore'):
             return False
         if self.is_binary():
             return False

--- a/ranger/core/loader.py
+++ b/ranger/core/loader.py
@@ -192,7 +192,7 @@ class CommandLoader(  # pylint: disable=too-many-instance-attributes
             try:
                 stdin.write(self.input)
             except IOError as ex:
-                if ex.errno != errno.EPIPE and ex.errno != errno.EINVAL:
+                if ex.errno not in (errno.EPIPE, errno.EINVAL):
                     raise
             stdin.close()
         if self.silent and not self.read:  # pylint: disable=too-many-nested-blocks

--- a/ranger/ext/img_display.py
+++ b/ranger/ext/img_display.py
@@ -643,7 +643,7 @@ class KittyImageDisplayer(ImageDisplayer, FileManagerAware):
             image = image.resize((int(scale * image.width), int(scale * image.height)),
                                  self.backend.LANCZOS)
 
-        if image.mode != 'RGB' and image.mode != 'RGBA':
+        if image.mode not in ('RGB', 'RGBA'):
             image = image.convert('RGB')
         # start_x += ((box[0] - image.width) // 2) // self.pix_row
         # start_y += ((box[1] - image.height) // 2) // self.pix_col

--- a/ranger/ext/vcs/vcs.py
+++ b/ranger/ext/vcs/vcs.py
@@ -463,10 +463,10 @@ class VcsThread(threading.Thread):  # pylint: disable=too-many-instance-attribut
             self.paused.set()
             self._advance.wait()
             self._awoken.wait()
-            if self.__stop.isSet():
+            if self.__stop.is_set():
                 self.stopped.set()
                 return
-            if not self._advance.isSet():
+            if not self._advance.is_set():
                 continue
             self._awoken.clear()
             self.paused.clear()
@@ -491,7 +491,7 @@ class VcsThread(threading.Thread):  # pylint: disable=too-many-instance-attribut
         self._advance.set()
         self._awoken.set()
         self.stopped.wait(1)
-        return self.stopped.isSet()
+        return self.stopped.is_set()
 
     def pause(self):
         """Pause thread"""

--- a/tests/pylint/py2_compat.py
+++ b/tests/pylint/py2_compat.py
@@ -51,6 +51,12 @@ class Py2CompatibilityChecker(BaseChecker):
                   "Python 2 subprocess.Popen objects were not contextmanagers,"
                   "popen23.Popen wraps them to enable use with"
                   "with-statements."),
+        "E4240": (
+            "F-strings are not supported before Python 3.6",
+            "using-f-string-in-unsupported-version",
+            "Used when the py-version set by the user is lower than 3.6 and "
+            "pylint encounters a f-string.",
+        ),
     }
     # This class variable declares the options
     # that are configurable by the user.
@@ -126,13 +132,17 @@ class Py2CompatibilityChecker(BaseChecker):
         for (cm, _) in node.items:
             if isinstance(cm, astroid.nodes.Call):
                 if ((isinstance(cm.func, astroid.nodes.Name)
-                    and cm.func.name.endswith("Popen")
-                    and (node.root().scope_lookup(node.root(), "Popen")[1][0]
-                         ).modname == "subprocess")
+                     and cm.func.name.endswith("Popen")
+                     and (node.root().scope_lookup(node.root(), "Popen")[1][0]
+                          ).modname == "subprocess")
                     or (isinstance(cm.func, astroid.nodes.Attribute)
                         and cm.func.expr == "subprocess"
                         and cm.func.attrname == "Popen")):
                     self.add_message("with-popen23", node=node, confidence=HIGH)
+
+    def visit_joinedstr(self, node):
+        """Make sure f-strings are not used"""
+        self.add_message("using-f-string-in-unsupported-version", node=node)
 
 
 def register(linter):

--- a/tests/pylint/py2_compat.py
+++ b/tests/pylint/py2_compat.py
@@ -51,12 +51,12 @@ class Py2CompatibilityChecker(BaseChecker):
                   "Python 2 subprocess.Popen objects were not contextmanagers,"
                   "popen23.Popen wraps them to enable use with"
                   "with-statements."),
-        "E4240": (
-            "F-strings are not supported before Python 3.6",
-            "using-f-string-in-unsupported-version",
-            "Used when the py-version set by the user is lower than 3.6 and "
-            "pylint encounters a f-string.",
-        ),
+        # "E4240": (
+        #     "F-strings are not supported before Python 3.6",
+        #     "using-f-string-in-unsupported-version",
+        #     "Used when the py-version set by the user is lower than 3.6 and "
+        #     "pylint encounters a f-string.",
+        # ),
     }
     # This class variable declares the options
     # that are configurable by the user.
@@ -140,9 +140,9 @@ class Py2CompatibilityChecker(BaseChecker):
                         and cm.func.attrname == "Popen")):
                     self.add_message("with-popen23", node=node, confidence=HIGH)
 
-    def visit_joinedstr(self, node):
-        """Make sure f-strings are not used"""
-        self.add_message("using-f-string-in-unsupported-version", node=node)
+    # def visit_joinedstr(self, node):
+    #     """Make sure f-strings are not used"""
+    #     self.add_message("using-f-string-in-unsupported-version", node=node)
 
 
 def register(linter):

--- a/tests/pylint/test_py2_compat.py
+++ b/tests/pylint/test_py2_compat.py
@@ -194,27 +194,27 @@ class TestPy2CompatibilityChecker(pylint.testutils.CheckerTestCase):
     #         self.checker.visit_XXX(first_import)
     #         self.checker.visit_XXX(second_import)
 
-    def test_using_f_string(self):
-        f_string_without_interpolation = astroid.extract_node("""
-        f"a simple f-string"
-        """)
+    # def test_using_f_string(self):
+    #     f_string_without_interpolation = astroid.extract_node("""
+    #     f"a simple f-string"
+    #     """)
 
-        f_string_with_interpolation = astroid.extract_node("""
-        f"a simple f-string {'with'} interpolation"
-        """)
+    #     f_string_with_interpolation = astroid.extract_node("""
+    #     f"a simple f-string {'with'} interpolation"
+    #     """)
 
-        with self.assertAddsMessages(
-            pylint.testutils.Message(
-                msg_id='using-f-string-in-unsupported-version',
-                node=f_string_without_interpolation,
-            ),
-        ):
-            self.checker.visit_joinedstr(f_string_without_interpolation)
+    #     with self.assertAddsMessages(
+    #         pylint.testutils.Message(
+    #             msg_id='using-f-string-in-unsupported-version',
+    #             node=f_string_without_interpolation,
+    #         ),
+    #     ):
+    #         self.checker.visit_joinedstr(f_string_without_interpolation)
 
-        with self.assertAddsMessages(
-            pylint.testutils.Message(
-                msg_id='using-f-string-in-unsupported-version',
-                node=f_string_with_interpolation,
-            ),
-        ):
-            self.checker.visit_joinedstr(f_string_with_interpolation)
+    #     with self.assertAddsMessages(
+    #         pylint.testutils.Message(
+    #             msg_id='using-f-string-in-unsupported-version',
+    #             node=f_string_with_interpolation,
+    #         ),
+    #     ):
+    #         self.checker.visit_joinedstr(f_string_with_interpolation)

--- a/tests/pylint/test_py2_compat.py
+++ b/tests/pylint/test_py2_compat.py
@@ -193,3 +193,28 @@ class TestPy2CompatibilityChecker(pylint.testutils.CheckerTestCase):
     #         self.checker.visit_XXX(only_import)
     #         self.checker.visit_XXX(first_import)
     #         self.checker.visit_XXX(second_import)
+
+    def test_using_f_string(self):
+        f_string_without_interpolation = astroid.extract_node("""
+        f"a simple f-string"
+        """)
+
+        f_string_with_interpolation = astroid.extract_node("""
+        f"a simple f-string {'with'} interpolation"
+        """)
+
+        with self.assertAddsMessages(
+            pylint.testutils.Message(
+                msg_id='using-f-string-in-unsupported-version',
+                node=f_string_without_interpolation,
+            ),
+        ):
+            self.checker.visit_joinedstr(f_string_without_interpolation)
+
+        with self.assertAddsMessages(
+            pylint.testutils.Message(
+                msg_id='using-f-string-in-unsupported-version',
+                node=f_string_with_interpolation,
+            ),
+        ):
+            self.checker.visit_joinedstr(f_string_with_interpolation)


### PR DESCRIPTION
<!-- Provide a descriptive summary of the changes in the title above -->

#### ISSUE TYPE
<!-- Pick relevant types and delete the rest -->
- Improvement/feature implementation

#### RUNTIME ENVIRONMENT
<!-- Details of your runtime environment -->
<!-- Retrieve Python/ranger version and locale with `ranger -\-version` -->
- Operating system and version: Ubuntu 20.04 LTS
- Terminal emulator and version: GNOME Terminal
- Python version: 3.9.7
- Ranger version/commit: master
- Locale: en_US.UTF-8

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [X] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [X] All changes follow the code style **[REQUIRED]**
- [X] All new and existing tests pass **[REQUIRED]**
- [ ] Changes require config files to be updated
    - [ ] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
<!-- Describe the changes in detail -->

1. apply code suggestions from `pylint`.
2. disable `consider-using-f-string` in `pylint`. (f-string is not compatible with Python 2.7 and Python 3.1~3.5)

#### MOTIVATION AND CONTEXT
<!-- Why are these changes required? -->
<!-- What problems do these changes solve? -->
<!-- Link to relevant issues -->

Make the test pass since `pylint` upgrade. Even the tests is not pass in master version with the latest `pylint`.

#### TESTING
<!-- What tests have been run? -->
<!-- How does the changes affect other areas of the codebase? -->

`make test`
