### PR TITLE
Fix some hotkeys referred in the manual

### DIFF
--- a/doc/ranger.1
+++ b/doc/ranger.1
@@ -988,8 +988,8 @@ on top of those for \fIdraw_borders\fR:
 .IX Item "draw_progress_bar_in_status_bar [bool]"
 Draw a progress bar in the status bar which displays the average state of all
 currently running tasks which support progress bars?
-.IP "flushinput [bool] <zi>" 4
-.IX Item "flushinput [bool] <zi>"
+.IP "flushinput [bool] <zI>" 4
+.IX Item "flushinput [bool] <zI>"
 Flush the input after each key hit?  One advantage is that when scrolling down
 with \*(L"j\*(R", ranger stops scrolling instantly when you release the key.  One
 disadvantage is that when you type commands blindly, some keys might get lost.
@@ -1094,8 +1094,8 @@ Preview directories in the preview column?
 .IP "preview_files [bool] <zp>" 4
 .IX Item "preview_files [bool] <zp>"
 Preview files in the preview column?
-.IP "preview_images [bool]" 4
-.IX Item "preview_images [bool]"
+.IP "preview_images [bool] <zi>" 4
+.IX Item "preview_images [bool] <zi>"
 Draw images inside the console with the external program w3mimgpreview?
 .IP "preview_images_method [string]" 4
 .IX Item "preview_images_method [string]"

--- a/doc/ranger.1
+++ b/doc/ranger.1
@@ -133,7 +133,7 @@
 .\" ========================================================================
 .\"
 .IX Title "RANGER 1"
-.TH RANGER 1 "ranger-1.9.3" "2021-09-05" "ranger manual"
+.TH RANGER 1 "ranger-1.9.3" "2021-11-13" "ranger manual"
 .\" For nroff, turn off justification.  Always turn off hyphenation; it makes
 .\" way too many mistakes in technical documents.
 .if n .ad l

--- a/doc/ranger.pod
+++ b/doc/ranger.pod
@@ -1040,7 +1040,7 @@ on top of those for I<draw_borders>:
 Draw a progress bar in the status bar which displays the average state of all
 currently running tasks which support progress bars?
 
-=item flushinput [bool] <zi>
+=item flushinput [bool] <zI>
 
 Flush the input after each key hit?  One advantage is that when scrolling down
 with "j", ranger stops scrolling instantly when you release the key.  One
@@ -1159,7 +1159,7 @@ Preview directories in the preview column?
 
 Preview files in the preview column?
 
-=item preview_images [bool]
+=item preview_images [bool] <zi>
 
 Draw images inside the console with the external program w3mimgpreview?
 


### PR DESCRIPTION
I detected a few hotkeys related to previews were mistakenly referred to in the manual. I hope this commit fixes it, but please double check.