### PR TITLE
fix possible ranger process blocks with f.read => os.read(f.fineno())

### DIFF
--- a/ranger/core/loader.py
+++ b/ranger/core/loader.py
@@ -223,7 +223,9 @@ class CommandLoader(  # pylint: disable=too-many-instance-attributes
                             if read:
                                 self.fm.notify(read, bad=True)
                         elif robjs == process.stdout:
-                            read = robjs.read(512)
+                            # plain `robjs.read(512)` might block (even indefinitely)
+                            # so use raw os.read() instead
+                            read = os.read(robjs.fileno(), 512)
                             if read:
                                 if read_stdout is None:
                                     read_stdout = read


### PR DESCRIPTION
fix #1787

While reading from a process stdout ranger uses a blocking `read(512)` which causes indefinite block if the process doesn't finish and stops to send bytes to its output. This patch changes reading with `os.read(512)` which may read `up to N=512` bytes and so make ranger not to block. 

More information is in the description below.

#### ISSUE TYPE
- Bug fix

#### RUNTIME ENVIRONMENT
- Operating system and version: 
```
$ sw_vers
ProductName:	macOS
ProductVersion:	11.2.2
BuildVersion:	20D80
```
- Terminal emulator and version: iTerm2 
- Python version: 
- Ranger version/commit: 
- Locale: 
```
$ ranger --version
ranger version: ranger-master v1.9.3-429-g9169f6ac
Python version: 3.10.0 (default, Oct 12 2021, 22:37:59) [Clang 13.0.0 (clang-1300.0.29.3)]
Locale: None.UTF-8
```


#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [X] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [X] All changes follow the code style **[REQUIRED]**
- [X] All new and existing tests pass **[REQUIRED]**

#### DESCRIPTION
<!-- Describe the changes in detail -->

I experienced an indefinite block if I constantly press `down` in the https://github.com/Canop/broot directory . The process tree after the block is like this:
```
$ pstree | less
...
|   \-+= 02212 ilya /opt/homebrew/bin/bash -l
 |     \-+= 25578 ilya /opt/homebrew/Cellar/python@3.10/3.10.0_2/Frameworks/Python.framework/Versions/3.10/Resources/Python.app/Contents/MacOS/Python /Users/ilya/opt/src/ranger/ranger_debug
gee/ranger
 |       |--- 25633 ilya (bash)
 |       |--- 25642 ilya (bash)
 |       |--- 25651 ilya (bash)
 |       |-+- 25660 ilya bash /Users/ilya/opt/src/ranger/git/ranger/data/scope.sh /Users/ilya/opt/src/broot/git/Cargo.lock 96 43 /Users/ilya/.cache/ranger/5ab4edf18b9fc38c064bff633489ab29117ca475.jpg True
 |       | \--- 25668 ilya bat --color=always --style=plain -- /Users/ilya/opt/src/broot/git/Cargo.lock
 |       |--- 25669 ilya (bash)
 |       \--- 25678 ilya bash /Users/ilya/opt/src/ranger/git/ranger/data/scope.sh /Users/ilya/opt/src/broot/git/CHANGELOG.md 96 43 /Users/ilya/.cache/ranger/f7b237a3b874d739ab18d50d88033c2a  
```
After killing `scope.sh CHANGELOG.md` (manually, by me) the ranger process proceeds to work ok. Under debugger I found out where the ranger is blocked, it is the line `robjs.read(512)`.

To see a difference in the behaviour between os.read(512) and `.read(512)` I used this code:
```
diff --git a/ranger/core/loader.py b/ranger/core/loader.py
index ce04967c..fe2c32d6 100644
--- a/ranger/core/loader.py
+++ b/ranger/core/loader.py
@@ -23,6 +23,9 @@ from ranger.ext.safe_path import get_safe_path
 from ranger.ext.signals import SignalDispatcher
 from ranger.ext.human_readable import human_readable

+from logging import getLogger
+logger = getLogger(__name__)
+

 class Loadable(object):
     paused = False
@@ -219,7 +222,12 @@ class CommandLoader(  # pylint: disable=too-many-instance-attributes
                         elif robjs == process.stdout:
                             # plain `robjs.read(512)` might block (even indefinitely)
                             # so use raw os.read() instead
-                            read = os.read(robjs.fileno(), 512)
+                            #read = os.read(robjs.fileno(), 512)
+                            read = robjs.read(512)
+
+                            if len(read) != 512:
+                                logger.info(f"read: {len(read)} instead of 512, {self.args}")
+
                             if read:
                                 if read_stdout is None:
                                     read_stdout = read
``` 

The original behaviour (`robjs.read(512)`, the ranger process was blocked by scope.sh but proceeded after manual kill of scope.sh process):
```
06:22:11 INFO read: 379 instead of 512, ['/Users/ilya/opt/src/ranger/git/ranger/data/scope.sh', '/Users/ilya/opt/src/broot/git/.gitignore', '96', '43', '/Users/ilya/.cache/ranger/1607333c93
06:22:12 INFO read: 364 instead of 512, ['/Users/ilya/opt/src/ranger/git/ranger/data/scope.sh', '/Users/ilya/opt/src/broot/git/README.md', '96', '43', '/Users/ilya/.cache/ranger/6b7ea1274fa
06:22:12 INFO read: 237 instead of 512, ['/Users/ilya/opt/src/ranger/git/ranger/data/scope.sh', '/Users/ilya/opt/src/broot/git/documentation.md', '96', '43', '/Users/ilya/.cache/ranger/1306
06:23:34 INFO read: 326 instead of 512, ['/Users/ilya/opt/src/ranger/git/ranger/data/scope.sh', '/Users/ilya/opt/src/broot/git/CHANGELOG.md', '96', '43', '/Users/ilya/.cache/ranger/f7b237a3
06:25:14 INFO read: 184 instead of 512, ['/Users/ilya/opt/src/ranger/git/ranger/data/scope.sh', '/Users/ilya/opt/src/broot/git/Cargo.lock', '96', '43', '/Users/ilya/.cache/ranger/5ab4edf18b  
```
It means that read(512) failed to receive bytes in full only if those bytes were the last ones from stdout.

The fixed behaviour (`os.read(robjs.fileno(), 512)`, the ranger process is not blocked and scope.sh processes may be killed from `task view` list):
```
06:04:31 INFO read: 148 instead of 512, ['/Users/ilya/opt/src/ranger/git/ranger/data/scope.sh', '/Users/ilya/opt/src/broot/git/CHANGELOG.md', '96', '43', '/Users/ilya/.cache/ranger/f7b237a3
06:04:31 INFO read: 269 instead of 512, ['/Users/ilya/opt/src/ranger/git/ranger/data/scope.sh', '/Users/ilya/opt/src/broot/git/CHANGELOG.md', '96', '43', '/Users/ilya/.cache/ranger/f7b237a3
06:04:31 INFO read: 89 instead of 512, ['/Users/ilya/opt/src/ranger/git/ranger/data/scope.sh', '/Users/ilya/opt/src/broot/git/CHANGELOG.md', '96', '43', '/Users/ilya/.cache/ranger/f7b237a3b
06:04:31 INFO read: 36 instead of 512, ['/Users/ilya/opt/src/ranger/git/ranger/data/scope.sh', '/Users/ilya/opt/src/broot/git/CHANGELOG.md', '96', '43', '/Users/ilya/.cache/ranger/f7b237a3b
06:04:31 INFO read: 119 instead of 512, ['/Users/ilya/opt/src/ranger/git/ranger/data/scope.sh', '/Users/ilya/opt/src/broot/git/CHANGELOG.md', '96', '43', '/Users/ilya/.cache/ranger/f7b237a3
06:04:31 INFO read: 202 instead of 512, ['/Users/ilya/opt/src/ranger/git/ranger/data/scope.sh', '/Users/ilya/opt/src/broot/git/CHANGELOG.md', '96', '43', '/Users/ilya/.cache/ranger/f7b237a3
06:04:31 INFO read: 69 instead of 512, ['/Users/ilya/opt/src/ranger/git/ranger/data/scope.sh', '/Users/ilya/opt/src/broot/git/CHANGELOG.md', '96', '43', '/Users/ilya/.cache/ranger/f7b237a3b
06:04:31 INFO read: 109 instead of 512, ['/Users/ilya/opt/src/ranger/git/ranger/data/scope.sh', '/Users/ilya/opt/src/broot/git/CHANGELOG.md', '96', '43', '/Users/ilya/.cache/ranger/f7b237a3
06:04:31 INFO read: 227 instead of 512, ['/Users/ilya/opt/src/ranger/git/ranger/data/scope.sh', '/Users/ilya/opt/src/broot/git/CHANGELOG.md', '96', '43', '/Users/ilya/.cache/ranger/f7b237a3
06:04:31 INFO read: 1 instead of 512, ['/Users/ilya/opt/src/ranger/git/ranger/data/scope.sh', '/Users/ilya/opt/src/broot/git/CHANGELOG.md', '96', '43', '/Users/ilya/.cache/ranger/f7b237a3b8
06:04:31 INFO read: 202 instead of 512, ['/Users/ilya/opt/src/ranger/git/ranger/data/scope.sh', '/Users/ilya/opt/src/broot/git/CHANGELOG.md', '96', '43', '/Users/ilya/.cache/ranger/f7b237a3
06:04:31 INFO read: 139 instead of 512, ['/Users/ilya/opt/src/ranger/git/ranger/data/scope.sh', '/Users/ilya/opt/src/broot/git/CHANGELOG.md', '96', '43', '/Users/ilya/.cache/ranger/f7b237a3
06:04:31 INFO read: 271 instead of 512, ['/Users/ilya/opt/src/ranger/git/ranger/data/scope.sh', '/Users/ilya/opt/src/broot/git/CHANGELOG.md', '96', '43', '/Users/ilya/.cache/ranger/f7b237a3
06:04:31 INFO read: 94 instead of 512, ['/Users/ilya/opt/src/ranger/git/ranger/data/scope.sh', '/Users/ilya/opt/src/broot/git/CHANGELOG.md', '96', '43', '/Users/ilya/.cache/ranger/f7b237a3b
06:04:31 INFO read: 202 instead of 512, ['/Users/ilya/opt/src/ranger/git/ranger/data/scope.sh', '/Users/ilya/opt/src/broot/git/CHANGELOG.md', '96', '43', '/Users/ilya/.cache/ranger/f7b237a3
06:04:31 INFO read: 69 instead of 512, ['/Users/ilya/opt/src/ranger/git/ranger/data/scope.sh', '/Users/ilya/opt/src/broot/git/CHANGELOG.md', '96', '43', '/Users/ilya/.cache/ranger/f7b237a3b
06:04:31 INFO read: 157 instead of 512, ['/Users/ilya/opt/src/ranger/git/ranger/data/scope.sh', '/Users/ilya/opt/src/broot/git/CHANGELOG.md', '96', '43', '/Users/ilya/.cache/ranger/f7b237a3
06:04:31 INFO read: 271 instead of 512, ['/Users/ilya/opt/src/ranger/git/ranger/data/scope.sh', '/Users/ilya/opt/src/broot/git/CHANGELOG.md', '96', '43', '/Users/ilya/.cache/ranger/f7b237a3
06:04:31 INFO read: 68 instead of 512, ['/Users/ilya/opt/src/ranger/git/ranger/data/scope.sh', '/Users/ilya/opt/src/broot/git/CHANGELOG.md', '96', '43', '/Users/ilya/.cache/ranger/f7b237a3b
```

This output is much more verbose I left only those lines related to one file. 
This output means that ranger process reads as much bytes from the scope.sh process as it can without being blocked and it happens a lot of times (as expected).