### PR TITLE
Disabled pandoc file previews for ods/odp files to fix possible memory issues

### DIFF
--- a/ranger/data/scope.sh
+++ b/ranger/data/scope.sh
@@ -80,11 +80,15 @@ handle_extension() {
             exit 1;;
 
         ## OpenDocument
-        odt|ods|odp|sxw)
+        odt|sxw)
             ## Preview as text conversion
             odt2txt "${FILE_PATH}" && exit 5
             ## Preview as markdown conversion
             pandoc -s -t markdown -- "${FILE_PATH}" && exit 5
+            exit 1;;
+        ods|odp)
+            ## Preview as text conversion (unsupported by pandoc for markdown)
+            odt2txt "${FILE_PATH}" && exit 5
             exit 1;;
 
         ## XLSX


### PR DESCRIPTION
See #2518. The ods and odp filetypes do not appear to be supported by pandoc. When odt2txt is not installed on the system, ods and odp file previews are run via pandoc. Pandoc, however, does not seem to support these files, and memory usage may increase uncontrollably.

This fix changes `scope.sh` to handle ods and odp files separately from OpenOffice odt files, eliminating the pandoc fallback to preview.

#### ISSUE TYPE
- Bug fix

#### RUNTIME ENVIRONMENT
  -  Operating system and version: 5.15.6-2-MANJARO
  -  Terminal emulator and version: kitty 0.23.1
  -  Python version: Python version: 3.9.9 (main, Nov 20 2021, 21:30:06) [GCC 11.1.0]
  -  Ranger version/commit: aur/ranger-git 1.9.3.26.g4bb83b37-1 (+146 0.04) (Installed: 1.9.3.387.g7e6a0aa6-1)
  -  Locale: en_US.UTF-8


#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [x] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [x] All changes follow the code style **[REQUIRED]**
- [x] All new and existing tests pass **[REQUIRED]**
- [x] Changes require config files to be updated
    - [x] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION

This fix changes `scope.sh` to handle ods and odp files separately from OpenOffice odt files, eliminating the pandoc fallback to preview.


#### MOTIVATION AND CONTEXT

#2518 
As is, it seems that if pandoc runs on odp/ods files, system memory will be consumed in the background until system crash or pandoc is killed. It's easy to miss as a user, so this fix prevents the scenario.


#### TESTING
<!-- What tests have been run? -->
<!-- How does the changes affect other areas of the codebase? -->
Tested previews of ods and odp files with and without odt2txt using this code. Without odt2txt, previews as no longer generated, as desired.
