### PR TITLE
rc.conf: map for chmod use --

### DIFF
--- a/ranger/config/rc.conf
+++ b/ranger/config/rc.conf
@@ -623,17 +623,17 @@ map m<bg>   draw_bookmarks
 copymap m<bg>  um<bg> `<bg> '<bg> p`<bg> p'<bg>
 
 # Generate all the chmod bindings with some python help:
-eval for arg in "rwxXst": cmd("map +u{0} shell -f chmod u+{0} %s".format(arg))
-eval for arg in "rwxXst": cmd("map +g{0} shell -f chmod g+{0} %s".format(arg))
-eval for arg in "rwxXst": cmd("map +o{0} shell -f chmod o+{0} %s".format(arg))
-eval for arg in "rwxXst": cmd("map +a{0} shell -f chmod a+{0} %s".format(arg))
-eval for arg in "rwxXst": cmd("map +{0}  shell -f chmod +{0} %s".format(arg))
+eval for arg in "rwxXst": cmd("map +u{0} shell -f chmod u+{0} -- %s".format(arg))
+eval for arg in "rwxXst": cmd("map +g{0} shell -f chmod g+{0} -- %s".format(arg))
+eval for arg in "rwxXst": cmd("map +o{0} shell -f chmod o+{0} -- %s".format(arg))
+eval for arg in "rwxXst": cmd("map +a{0} shell -f chmod a+{0} -- %s".format(arg))
+eval for arg in "rwxXst": cmd("map +{0}  shell -f chmod +{0} -- %s".format(arg))
 
-eval for arg in "rwxXst": cmd("map -u{0} shell -f chmod u-{0} %s".format(arg))
-eval for arg in "rwxXst": cmd("map -g{0} shell -f chmod g-{0} %s".format(arg))
-eval for arg in "rwxXst": cmd("map -o{0} shell -f chmod o-{0} %s".format(arg))
-eval for arg in "rwxXst": cmd("map -a{0} shell -f chmod a-{0} %s".format(arg))
-eval for arg in "rwxXst": cmd("map -{0}  shell -f chmod -{0} %s".format(arg))
+eval for arg in "rwxXst": cmd("map -u{0} shell -f chmod u-{0} -- %s".format(arg))
+eval for arg in "rwxXst": cmd("map -g{0} shell -f chmod g-{0} -- %s".format(arg))
+eval for arg in "rwxXst": cmd("map -o{0} shell -f chmod o-{0} -- %s".format(arg))
+eval for arg in "rwxXst": cmd("map -a{0} shell -f chmod a-{0} -- %s".format(arg))
+eval for arg in "rwxXst": cmd("map -{0}  shell -f chmod -{0} -- %s".format(arg))
 
 # ===================================================================
 # == Define keys for the console


### PR DESCRIPTION
use chmod with "--" to support filenames starting with "-"

This PR changes the maps for `chmod` calls and inserts `--` in front of the filenames. Why? In order to support filenames that start with minus "`-`". Without `--` chmod tries to interpret the filename's characters after the "`-`" as chmod flags.

#### ISSUE TYPE
- Improvement/feature implementation

#### RUNTIME ENVIRONMENT
- Operating system and version:  Fedora 35
- Terminal emulator and version: Mate Terminal 1.26.0
- Python version: 3.10.0
- Ranger version/commit:  1.9.3
- Locale: en_GB.UTF-8

#### CHECKLIST
- [X] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [X] All changes follow the code style **[REQUIRED]**
- [X] All new and existing tests pass **[REQUIRED]**
- [X] Changes require config files to be updated
    - [X] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated
