### PR TITLE
add TaskView.task_remove_all() and keybinding (dD)

### DIFF
--- a/ranger/config/rc.conf
+++ b/ranger/config/rc.conf
@@ -751,6 +751,7 @@ copytmap <PAGEUP>   p  b  <C-B>
 tmap J          eval -q fm.ui.taskview.task_move(-1)
 tmap K          eval -q fm.ui.taskview.task_move(0)
 tmap dd         eval -q fm.ui.taskview.task_remove()
+tmap dD         eval -q fm.ui.taskview.task_remove_all()
 tmap <pagedown> eval -q fm.ui.taskview.task_move(-1)
 tmap <pageup>   eval -q fm.ui.taskview.task_move(0)
 tmap <delete>   eval -q fm.ui.taskview.task_remove()

--- a/ranger/gui/widgets/taskview.py
+++ b/ranger/gui/widgets/taskview.py
@@ -80,6 +80,9 @@ class TaskView(Widget, Accumulator):
         if self.fm.loader.queue:
             self.fm.loader.remove(index=i)
 
+    def task_remove_all(self):
+        self.fm.loader.destroy()
+
     def task_move(self, to, i=None):  # pylint: disable=invalid-name
         if i is None:
             i = self.pointer


### PR DESCRIPTION
- this patch adds the function task_remove_all() to the TaskView class
- when called, it will delete all tasks in the queue
- it adds the keybinding "dD" to the taskview interface to call the function

<!-- Provide a descriptive summary of the changes in the title above -->

#### ISSUE TYPE
- Improvement/feature implementation


#### RUNTIME ENVIRONMENT
<!-- Details of your runtime environment -->
<!-- Retrieve Python/ranger version and locale with `ranger -\-version` -->
- Operating system and version: 
- Terminal emulator and version: 
- Python version: 
- Ranger version/commit: 
- Locale: 

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [X] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [X] All changes follow the code style **[REQUIRED]**
- [X] All new and existing tests pass **[REQUIRED]**
- [X] Changes require config files to be updated
    - [X] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
<!-- Describe the changes in detail -->


#### MOTIVATION AND CONTEXT
<!-- Why are these changes required? -->
<!-- What problems do these changes solve? -->
<!-- Link to relevant issues -->
resolves #2527


#### TESTING
<!-- What tests have been run? -->
<!-- How does the changes affect other areas of the codebase? -->
I did run "make test" before and after the patch to ensure that nothing changed. It calculated the same score both times (9.37/10).


#### IMAGES / VIDEOS<!-- Only if relevant -->
<!-- Link or embed images and videos of screenshots, sketches etc. -->
