### PR TITLE
Add rsvg-convert for SVG previews

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,8 @@ For enhanced file previews (with `scope.sh`):
 * `img2txt` (from `caca-utils`) for ASCII-art image previews
 * `w3mimgdisplay`, `ueberzug`, `mpv`, `iTerm2`, `kitty`, `terminology` or `urxvt` for image previews
 * `convert` (from `imagemagick`) to auto-rotate images
-* `rsvg-convert` (from `librsvg2-bin`) for SVG previews
+* `rsvg-convert` (from [`librsvg`](https://wiki.gnome.org/Projects/LibRsvg))
+  for SVG previews
 * `ffmpeg`, or `ffmpegthumbnailer` for video thumbnails
 * `highlight`, `bat` or `pygmentize` for syntax highlighting of code
 * `atool`, `bsdtar`, `unrar` and/or `7z` to preview archives

--- a/README.md
+++ b/README.md
@@ -89,7 +89,8 @@ For enhanced file previews (with `scope.sh`):
 
 * `img2txt` (from `caca-utils`) for ASCII-art image previews
 * `w3mimgdisplay`, `ueberzug`, `mpv`, `iTerm2`, `kitty`, `terminology` or `urxvt` for image previews
-* `convert` (from `imagemagick`) to auto-rotate images and for SVG previews
+* `convert` (from `imagemagick`) to auto-rotate images
+* `rsvg-convert` (from `librsvg2-bin`) for SVG previews
 * `ffmpeg`, or `ffmpegthumbnailer` for video thumbnails
 * `highlight`, `bat` or `pygmentize` for syntax highlighting of code
 * `atool`, `bsdtar`, `unrar` and/or `7z` to preview archives

--- a/doc/ranger.1
+++ b/doc/ranger.1
@@ -133,7 +133,7 @@
 .\" ========================================================================
 .\"
 .IX Title "RANGER 1"
-.TH RANGER 1 "ranger-1.9.3" "2021-11-13" "ranger manual"
+.TH RANGER 1 "ranger-1.9.3" "2022-02-05" "ranger manual"
 .\" For nroff, turn off justification.  Always turn off hyphenation; it makes
 .\" way too many mistakes in technical documents.
 .if n .ad l
@@ -308,7 +308,9 @@ are automatically used when available but completely optional.
 \&\f(CW\*(C`w3mimgdisplay\*(C'\fR, \f(CW\*(C`ueberzug\*(C'\fR, \f(CW\*(C`mpv\*(C'\fR, \f(CW\*(C`iTerm2\*(C'\fR, \f(CW\*(C`kitty\*(C'\fR, \f(CW\*(C`terminology\*(C'\fR or
 \&\f(CW\*(C`urxvt\*(C'\fR for image previews
 .IP "\-" 2
-\&\f(CW\*(C`convert\*(C'\fR (from \f(CW\*(C`imagemagick\*(C'\fR) to auto-rotate images and for \s-1SVG\s0 previews
+\&\f(CW\*(C`convert\*(C'\fR (from \f(CW\*(C`imagemagick\*(C'\fR) to auto-rotate images
+.IP "\-" 2
+\&\f(CW\*(C`rsvg\-convert\*(C'\fR (from \f(CW\*(C`librsvg\*(C'\fR) for \s-1SVG\s0 previews
 .IP "\-" 2
 \&\f(CW\*(C`ffmpegthumbnailer\*(C'\fR for video thumbnails
 .IP "\-" 2

--- a/doc/ranger.pod
+++ b/doc/ranger.pod
@@ -234,7 +234,7 @@ C<urxvt> for image previews
 
 =item -
 
-C<convert> (from C<imagemagick>) to auto-rotate images and for SVG previews
+C<convert> (from C<imagemagick>) to auto-rotate images
 
 =item -
 

--- a/doc/ranger.pod
+++ b/doc/ranger.pod
@@ -238,6 +238,10 @@ C<convert> (from C<imagemagick>) to auto-rotate images
 
 =item -
 
+C<rsvg-convert> (from C<librsvg>) for SVG previews
+
+=item -
+
 C<ffmpegthumbnailer> for video thumbnails
 
 =item -

--- a/ranger/data/scope.sh
+++ b/ranger/data/scope.sh
@@ -132,9 +132,10 @@ handle_image() {
     local mimetype="${1}"
     case "${mimetype}" in
         ## SVG
-        # image/svg+xml|image/svg)
-        #     convert -- "${FILE_PATH}" "${IMAGE_CACHE_PATH}" && exit 6
-        #     exit 1;;
+        image/svg+xml|image/svg)
+            rsvg-convert --keep-aspect-ratio --width "${DEFAULT_SIZE%x*}" "${FILE_PATH}" -o "${IMAGE_CACHE_PATH}.png" \
+                && mv "${IMAGE_CACHE_PATH}.png" "${IMAGE_CACHE_PATH}" \
+                && exit 6
 
         ## DjVu
         # image/vnd.djvu)

--- a/ranger/data/scope.sh
+++ b/ranger/data/scope.sh
@@ -136,6 +136,7 @@ handle_image() {
             rsvg-convert --keep-aspect-ratio --width "${DEFAULT_SIZE%x*}" "${FILE_PATH}" -o "${IMAGE_CACHE_PATH}.png" \
                 && mv "${IMAGE_CACHE_PATH}.png" "${IMAGE_CACHE_PATH}" \
                 && exit 6
+            exit 1;;
 
         ## DjVu
         # image/vnd.djvu)


### PR DESCRIPTION
<!-- Provide a descriptive summary of the changes in the title above -->

#### ISSUE TYPE
<!-- Pick relevant types and delete the rest -->
- Improvement/feature implementation

#### RUNTIME ENVIRONMENT
<!-- Details of your runtime environment -->
<!-- Retrieve Python/ranger version and locale with `ranger -\-version` -->
- Operating system and version: Pop!_OS 21.04 (based on Ubuntu)
- Terminal emulator and version: Terminator 2.1.0 (zsh 5.8 + tmux 3.1c)
- Python version: 3.9.5
- Ranger version/commit: 1.9.3
- Locale: en_US.UTF-8

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [x] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [x] All changes follow the code style **[REQUIRED]**
- [ ] All new and existing tests pass **[REQUIRED]**
    - **NOTE:** The tests in `master` don't pass for me even without these changes, but no *additional* tests fail with these changes ~~(I'm not even sure if `scope.sh` has tests)~~
- [ ] Changes require config files to be updated
    - [ ] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
<!-- Describe the changes in detail -->
`rsvg-convert` works much more reliably for SVGs than ImageMagick's `convert`, which freezes with large SVGs (seems to convert formats first, and resize only after that), and can drop out text during the conversion. Support for SVGs isn't great in ImageMagick, since it's a raster graphics program.

`rsvg-convert` only supports conversion to PNG. The image preview works fine with PNGs, but Ranger (more specifically w3mdisplay?) assumes/requires a .jpg extension, so the file is just renamed from `xxx.jpg.png` to `xxx.jpg`. It's a bit of an ugly hack, but it works, and it's faster than a second image conversion from PNG to JPEG (and vector graphics usually look better with PNG than with JPEG, which is meant more for photos).

On Ubuntu and Debian, `rsvg-convert` is in the `librsvg2-bin` package. If I remember (and read the existing code) correctly, `scope.sh` should handle things gracefully if a command (`rsvg-convert` in this case) isn't found?


#### MOTIVATION AND CONTEXT
<!-- Why are these changes required? -->
<!-- What problems do these changes solve? -->
<!-- Link to relevant issues -->

At least partially related issue: https://github.com/ranger/ranger/issues/1320 (see [my comment](https://github.com/ranger/ranger/issues/1320#issuecomment-733926546) in that issue)


#### TESTING
<!-- What tests have been run? -->
<!-- How does the changes affect other areas of the codebase? -->
The tests in `master` don't pass for me even without these changes, but no *additional* tests fail because of these changes.

~~I'm not even sure if `scope.sh` has tests, but~~ I've been using the code in this PR for a bit over a year with no issues.

**EDIT:**  
`scope.sh` does indeed have tests, and they're passing with the latest commit (I was lazy and used GitHub's web editor, but luckily `shellcheck` caught my mistake).

`test_pylint` doesn't pass for me in `master` (even without these changes), but the tests for `scope.sh` at least pass now (it's the only file I've modified in addition to README.md).

**EDIT 2:**
The only error from `test_pylint` was that it didn't recognize `unspecified-encoding` as an error/warning to disable in `pylint`.

After updating `pylint`, I get a lot more messages, mostly `C0209: consider-using-f-string` (convention, and only available since Python 3.6) with a few instances of `R1714: consider-using-in` (refactor). If I disable those in `.pylintrc`, `test_pylint` passes, but `test_pytest` starts failing with `AttributeError: module 'pylint.testutils' has no attribute 'Message'`...

So, the tests seem to be pretty dependent on the version of `pylint` in use (although to be fair, I might have gone from a really old version to a really new one). The CI environment probably uses a working version of `pylint`, but those tests still haven't finished. But none of the failures mentioned above are from my changes, I only changed `scope.sh` (and the readme).