### PR TITLE
better textual preview for jupyter notebooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ For enhanced file previews (with `scope.sh`):
 * `mediainfo` or `exiftool` for viewing information about media files
 * `odt2txt` for OpenDocument text files (`odt`, `ods`, `odp` and `sxw`)
 * `python` or `jq` for JSON files
+* `jupyter nbconvert` for Jupyter Notebooks
 * `fontimage` for font previews
 * `openscad` for 3D model previews (`stl`, `off`, `dxf`, `scad`, `csg`)
 

--- a/ranger/data/scope.sh
+++ b/ranger/data/scope.sh
@@ -108,7 +108,15 @@ handle_extension() {
             ;;
 
         ## JSON
-        json|ipynb)
+        json)
+            jq --color-output . "${FILE_PATH}" && exit 5
+            python -m json.tool -- "${FILE_PATH}" && exit 5
+            ;;
+
+        ## Jupyter Notebooks
+        ipynb)
+            jupyter nbconvert --to markdown "${FILE_PATH}" --stdout | env COLORTERM=8bit bat --color=always --style=plain --language=markdown && exit 5
+            jupyter nbconvert --to markdown "${FILE_PATH}" --stdout && exit 5
             jq --color-output . "${FILE_PATH}" && exit 5
             python -m json.tool -- "${FILE_PATH}" && exit 5
             ;;


### PR DESCRIPTION
<!-- Provide a descriptive summary of the changes in the title above -->

Breaking out jupyter notebooks from the json preview. The new preview uses `jupyter nbconvert` to output markdown and then `bat` to color it properly. Fallback without bat is available as is the previous json viewers in case `nbconvert` is missing.

#### ISSUE TYPE
<!-- Pick relevant types and delete the rest -->

- Improvement/feature implementation

#### RUNTIME ENVIRONMENT
<!-- Details of your runtime environment -->
<!-- Retrieve Python/ranger version and locale with `ranger -\-version` -->
- Operating system and version: 
- Terminal emulator and version: 
- Python version: 
- Ranger version/commit: 
- Locale: 

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [x] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [x] All changes follow the code style **[REQUIRED]**
- [ ] All new and existing tests pass **[REQUIRED]**
- [x] Changes require config files to be updated
    - [x] Config files have been updated
- [x] Changes require documentation to be updated
    - [x] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
<!-- Describe the changes in detail -->


#### MOTIVATION AND CONTEXT
<!-- Why are these changes required? -->
<!-- What problems do these changes solve? -->
<!-- Link to relevant issues -->

Makes jupyter notebooks readable in preview (the jsons are basically useless really).

#### TESTING
<!-- What tests have been run? -->
<!-- How does the changes affect other areas of the codebase? -->

I tested it on my computer and should not affect codebase.

#### IMAGES / VIDEOS<!-- Only if relevant -->
<!-- Link or embed images and videos of screenshots, sketches etc. -->

new preview:
![image](https://user-images.githubusercontent.com/6343487/147686925-9fe7e425-e73c-4861-ad35-75e77645eea3.png)

original preview:
![image](https://user-images.githubusercontent.com/6343487/147687374-aa01a55a-98c6-4d19-b224-a0429ec94350.png)

