### PR TITLE
Escaping whitespace in arguments

### DIFF
--- a/ranger/api/commands.py
+++ b/ranger/api/commands.py
@@ -114,8 +114,8 @@ class Command(FileManagerAware):
         args_list = line.split()
         for index, arg in enumerate(args_list):
             if index > 0:
-                if args_list[index-1][-1] == '\\':
-                    args_list[index-1] = args_list[index-1][:-1] + ' ' + arg
+                if args_list[index - 1][-1] == '\\':
+                    args_list[index - 1] = args_list[index - 1][:-1] + ' ' + arg
                     args_list.pop(index)
 
         self.args = args_list

--- a/ranger/api/commands.py
+++ b/ranger/api/commands.py
@@ -111,7 +111,15 @@ class Command(FileManagerAware):
 
     def init_line(self, line):
         self.line = line
-        self.args = line.split()
+        args_list = line.split()
+        for index, arg in enumerate(args_list):
+            if index > 0:
+                if args_list[index-1][-1] == '\\':
+                    args_list[index-1] = args_list[index-1][:-1] + ' ' + arg
+                    args_list.pop(index)
+
+        self.args = args_list
+
         try:
             self.firstpart = line[:line.rindex(' ') + 1]
         except ValueError:


### PR DESCRIPTION
<!-- Provide a descriptive summary of the changes in the title above -->

#### ISSUE TYPE
<!-- Pick relevant types and delete the rest -->
- Bug fix

#### RUNTIME ENVIRONMENT
<!-- Details of your runtime environment -->
<!-- Retrieve Python/ranger version and locale with `ranger -\-version` -->
- Operating system and version: Arch Linux
- Terminal emulator and version: urxvt v9.26, (+ tmux 3.2a)
- Python version: 3.10.1
- Ranger version/commit: ranger-master v1.9.3
- Locale: None.None

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [x] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [x] All changes follow the code style **[REQUIRED]**
- [x] All new and existing tests pass **[REQUIRED]**
- [ ] Changes require config files to be updated
    - [ ] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
<!-- Describe the changes in detail -->
This patch adds the possibility of escaping of space character as "\ " to arguments.

#### MOTIVATION AND CONTEXT
<!-- Why are these changes required? -->
<!-- What problems do these changes solve? -->
<!-- Link to relevant issues -->
fixes #2470 
This is useful for scenarios where the a directory name containing whitespace is passed as an argument.
 
#### TESTING
<!-- What tests have been run? -->
<!-- How does the changes affect other areas of the codebase? -->
The code is tested with `make test_py` and the output shows `rated 9.85/10`.

#### IMAGES / VIDEOS<!-- Only if relevant -->
<!-- Link or embed images and videos of screenshots, sketches etc. -->
