### PR TITLE
Make display of directory size in linemodes less misleading

### DIFF
--- a/ranger/core/linemode.py
+++ b/ranger/core/linemode.py
@@ -130,7 +130,14 @@ class SizeMtimeLinemode(LinemodeBase):
     def infostring(self, fobj, metadata):
         if fobj.stat is None:
             return '?'
-        return "%s %s" % (human_readable(fobj.size),
+        if fobj.is_directory and not fobj.cumulative_size_calculated:
+            if fobj.size is None:
+                sizestring = ''
+            else:
+                sizestring = fobj.size
+        else:
+            sizestring = human_readable(fobj.size)
+        return "%s %s" % (sizestring,
                           datetime.fromtimestamp(fobj.stat.st_mtime).strftime("%Y-%m-%d %H:%M"))
 
 
@@ -155,5 +162,11 @@ class SizeHumanReadableMtimeLinemode(LinemodeBase):
     def infostring(self, fobj, metadata):
         if fobj.stat is None:
             return '?'
-        size = human_readable(fobj.size)
-        return "%s %11s" % (size, human_readable_time(fobj.stat.st_mtime))
+        if fobj.is_directory and not fobj.cumulative_size_calculated:
+            if fobj.size is None:
+                sizestring = ''
+            else:
+                sizestring = fobj.size
+        else:
+            sizestring = human_readable(fobj.size)
+        return "%s %11s" % (sizestring, human_readable_time(fobj.stat.st_mtime))


### PR DESCRIPTION
.. because when the cumulative size of a directory has not yet been
determined, its size is actually the number of direct children.
So displaying byte suffixes in that case is incorrect.