### PR TITLE
runner/shell command: add -l flag to clear screen before running command

### DIFF
--- a/doc/ranger.1
+++ b/doc/ranger.1
@@ -550,6 +550,7 @@ command: (for example \f(CW\*(C`:shell \-w df\*(C'\fR)
 .Vb 3
 \& p   Redirect output to the pager
 \& s   Silent mode.  Output will be discarded.
+\& l   Clear console before invoking command
 \& w   Wait for an Enter\-press when the process is done
 .Ve
 .PP

--- a/doc/ranger.pod
+++ b/doc/ranger.pod
@@ -486,6 +486,7 @@ command: (for example C<:shell -w df>)
 
  p   Redirect output to the pager
  s   Silent mode.  Output will be discarded.
+ l   Clear console before invoking command
  w   Wait for an Enter-press when the process is done
 
 By default, all the flags are off unless otherwise specified in F<rc.conf> key

--- a/ranger/core/runner.py
+++ b/ranger/core/runner.py
@@ -16,6 +16,7 @@ s: silent mode. output will be discarded.
 f: fork the process.
 p: redirect output to the pager
 c: run only the current file (not handled here)
+l: clear screen before running
 w: wait for enter-press afterwards
 r: run application with root privilege (requires sudo)
 t: run application in a new terminal window
@@ -165,6 +166,7 @@ class Runner(object):  # pylint: disable=too-few-public-methods
 
         toggle_ui = True
         pipe_output = False
+        clear_screen = False
         wait_for_enter = False
         devnull = None
 
@@ -203,6 +205,8 @@ class Runner(object):  # pylint: disable=too-few-public-methods
         if 'f' in context.flags:
             toggle_ui = False
             context.wait = False
+        if 'l' in context.flags:
+            clear_screen = True
         if 'w' in context.flags:
             if not pipe_output and context.wait:  # <-- sanity check
                 wait_for_enter = True
@@ -240,6 +244,8 @@ class Runner(object):  # pylint: disable=too-few-public-methods
             process = None
             self.fm.signal_emit('runner.execute.before',
                                 popen_kws=popen_kws, context=context)
+            if clear_screen:
+                Popen(['cls' if os.name == 'nt' else 'clear'])
             try:
                 if 'f' in context.flags and 'r' not in context.flags:
                     # This can fail and return False if os.fork() is not


### PR DESCRIPTION
This adds a flag to clear the screen before invoking a command.