### PR TITLE
Fix crash on human readable linemodes when entering directories invalid mtimes

### DIFF
--- a/ranger/ext/human_readable.py
+++ b/ranger/ext/human_readable.py
@@ -56,8 +56,11 @@ def human_readable(byte_count, separator=' ', use_binary=None):
 def human_readable_time(timestamp):
     """Convert a timestamp to an easily readable format.
     """
+    try:
+        date = datetime.fromtimestamp(timestamp)
+    except ValueError:
+        return '?'
     # Hard to test because it's relative to ``now()``
-    date = datetime.fromtimestamp(timestamp)
     datediff = datetime.now().date() - date.date()
     if datediff.days >= 365:
         return date.strftime("%-d %b %Y")

--- a/ranger/ext/human_readable.py
+++ b/ranger/ext/human_readable.py
@@ -58,7 +58,7 @@ def human_readable_time(timestamp):
     """
     try:
         date = datetime.fromtimestamp(timestamp)
-    except ValueError:
+    except (OSError, OverflowError, ValueError):
         return '?'
     # Hard to test because it's relative to ``now()``
     datediff = datetime.now().date() - date.date()


### PR DESCRIPTION
As detailed on #1020 and #1180 some buggy filesystems return invalid mtimes.
This has been accounted for in the status bar with #1487 but the problem still exists on the human readable line modes:

```
Current file: '/media/phone'

Traceback (most recent call last):
  File "/usr/lib/python3.10/site-packages/ranger/core/main.py", line 201, in main
    fm.loop()
  File "/usr/lib/python3.10/site-packages/ranger/core/fm.py", line 377, in loop
    ui.redraw()
  File "/usr/lib/python3.10/site-packages/ranger/gui/ui.py", line 333, in redraw
    self.draw()
  File "/usr/lib/python3.10/site-packages/ranger/gui/ui.py", line 360, in draw
    DisplayableContainer.draw(self)
  File "/usr/lib/python3.10/site-packages/ranger/gui/displayable.py", line 260, in draw
    displayable.draw()
  File "/usr/lib/python3.10/site-packages/ranger/gui/widgets/view_miller.py", line 100, in draw
    DisplayableContainer.draw(self)
  File "/usr/lib/python3.10/site-packages/ranger/gui/displayable.py", line 260, in draw
    displayable.draw()
  File "/usr/lib/python3.10/site-packages/ranger/gui/widgets/browsercolumn.py", line 189, in draw
    self._draw_directory()
  File "/usr/lib/python3.10/site-packages/ranger/gui/widgets/browsercolumn.py", line 375, in _draw_directory
    infostringdata = current_linemode.infostring(drawn, metadata)
  File "/usr/lib/python3.10/site-packages/ranger/core/linemode.py", line 159, in infostring
    return "%s %11s" % (size, human_readable_time(fobj.stat.st_mtime))
  File "/usr/lib/python3.10/site-packages/ranger/ext/human_readable.py", line 63, in human_readable_time
    date = datetime.fromtimestamp(timestamp)
ValueError: year 4442696 is out of range
```

This simple commit fixes it by returning `?` when mtime is invalid.

#### ISSUE TYPE
- Bug fix

#### RUNTIME ENVIRONMENT
- Operating system and version: Arch
- Terminal emulator and version: alacritty 0.9.0
- Python version: 3.10.1
- Ranger version/commit: 1.9.3
- Locale: en_US.UTF-8

#### CHECKLIST
- [X] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [X] All changes follow the code style **[REQUIRED]**
- [X] All new and existing tests pass **[REQUIRED]**
- [ ] Changes require config files to be updated
    - [ ] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated
