### PR TITLE
Acknowledge and report the exit status of the rifle'd commands

### DIFF
--- a/ranger/ext/rifle.py
+++ b/ranger/ext/rifle.py
@@ -18,6 +18,7 @@ from __future__ import (absolute_import, division, print_function)
 
 import os.path
 import re
+import shlex
 from subprocess import PIPE, CalledProcessError
 import sys
 
@@ -512,7 +513,7 @@ class Rifle(object):  # pylint: disable=too-many-instance-attributes
                     ) as process:
                         exit_code = process.wait()
                         if exit_code != 0:
-                            raise CalledProcessError(exit_code, cmd)
+                            raise CalledProcessError(exit_code, shlex.join(cmd))
             finally:
                 self.hook_after_executing(command, self._mimetype, self._app_flags)
 

--- a/ranger/ext/rifle.py
+++ b/ranger/ext/rifle.py
@@ -18,7 +18,7 @@ from __future__ import (absolute_import, division, print_function)
 
 import os.path
 import re
-from subprocess import PIPE
+from subprocess import PIPE, CalledProcessError
 import sys
 
 
@@ -510,7 +510,9 @@ class Rifle(object):  # pylint: disable=too-many-instance-attributes
                     with Popen23(
                         cmd, env=self.hook_environment(os.environ)
                     ) as process:
-                        process.wait()
+                        exit_code = process.wait()
+                        if exit_code != 0:
+                            raise CalledProcessError(exit_code, cmd)
             finally:
                 self.hook_after_executing(command, self._mimetype, self._app_flags)
 
@@ -589,9 +591,11 @@ def main():  # pylint: disable=too-many-locals
         number = 0
         label = options.p
 
+    exit_code = 0
+
     if options.w is not None and not options.l:
         with Popen23([options.w] + list(positional)) as process:
-            process.wait()
+            exit_code = process.wait()
     else:
         # Start up rifle
         rifle = Rifle(conf_path)
@@ -601,11 +605,17 @@ def main():  # pylint: disable=too-many-locals
             for count, cmd, label, flags in rifle.list_commands(positional):
                 print("%d:%s:%s:%s" % (count, label or '', flags, cmd))
         else:
-            result = rifle.execute(positional, number=number, label=label, flags=options.f)
-            if result == ASK_COMMAND:
-                # TODO: implement interactive asking for file type?
-                print("Unknown file type: %s" %
-                      rifle.get_mimetype(positional[0]))
+            try:
+                result = rifle.execute(positional, number=number, label=label, flags=options.f)
+            except CalledProcessError as ex:
+                exit_code = ex.returncode
+            else:
+                if result == ASK_COMMAND:
+                    # TODO: implement interactive asking for file type?
+                    print("Unknown file type: %s" %
+                          rifle.get_mimetype(positional[0]))
+
+    sys.exit(exit_code)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
#### ISSUE TYPE
<!-- Pick relevant types and delete the rest -->
- Improvement/feature implementation

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [X] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [X] All changes follow the code style **[REQUIRED]**
- [X] All new and existing tests pass **[REQUIRED]**
- [ ] Changes require config files to be updated
    - [ ] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
<!-- Describe the changes in detail -->

Currently `rifle` completely ignores the exit status of the commands it runs, even if it does wait for them (it's obviously not viable otherwise). This patch makes `rifle(1)` (the commandline application) exit with the same status the command did, and makes `rifle` the module raise `subprocess.CalledProcessError`, so it's displayed in the `ranger` status line.

#### MOTIVATION AND CONTEXT
<!-- Why are these changes required? -->
<!-- What problems do these changes solve? -->
<!-- Link to relevant issues -->

As it stands, it was impossible to inspect whether the commands executed by `rifle` were successful or not.

#### TESTING
<!-- What tests have been run? -->
<!-- How does the changes affect other areas of the codebase? -->

The errors are no longer swallowed and instead are reported back in the manner described above. If someone relied on them being swallowed, it might break their use case (but maybe for the better).