### PR TITLE
Add viewnior in rifle config

### DIFF
--- a/ranger/config/rifle.conf
+++ b/ranger/config/rifle.conf
@@ -185,6 +185,8 @@ ext sla,  has scribus,      X, flag f = scribus -- "$@"
 #-------------------------------------------
 # Images
 #-------------------------------------------
+mime ^image, has viewnior,  X, flag f = viewnior -- "$@"
+
 mime ^image/svg, has inkscape, X, flag f = inkscape -- "$@"
 mime ^image/svg, has display,  X, flag f = display -- "$@"
 


### PR DESCRIPTION
<!-- Provide a descriptive summary of the changes in the title above -->

#### ISSUE TYPE
<!-- Pick relevant types and delete the rest -->
- Improvement/feature implementation

#### RUNTIME ENVIRONMENT

Unrelevant here.

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [x] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [x] All changes follow the code style **[REQUIRED]**
- [x] All new and existing tests pass **[REQUIRED]**
- [x] Changes require config files to be updated
    - [x] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
<!-- Describe the changes in detail -->

I added viewnior as one of the default image openers.

Note: I added it even above the SVG's one because viewnior supports svg images.

#### MOTIVATION AND CONTEXT
<!-- Why are these changes required? -->
<!-- What problems do these changes solve? -->
<!-- Link to relevant issues -->

If you use viewnior as image viewer and have no other one installed, which was my case, the image opens with gimp, which, it goes without saying, is not practical.