### PR TITLE
rifle_sxiv: more correct fallback and add more img support.

### DIFF
--- a/examples/rifle_sxiv.sh
+++ b/examples/rifle_sxiv.sh
@@ -33,7 +33,7 @@ tmp="$TMPDIR/sxiv_rifle_$$"
 
 listfiles () {
     find -L "///${1%/*}" \( ! -path "///${1%/*}" -prune \) -type f -print |
-      grep -iE '\.(jpe?g|png|gif|webp|tiff|bmp)$' |
+      grep -iE '\.(jpe?g|png|gif|svg|webp|tiff|heif|avif|ico|bmp)$' |
       sort | tee "$tmp"
 }
 

--- a/examples/rifle_sxiv.sh
+++ b/examples/rifle_sxiv.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# Compatible with ranger 1.6.0 through 1.7.*
+# Compatible with ranger 1.6.0 through 1.9.*
 #
 # This script searches image files in a directory, opens them all with sxiv and
 # sets the first argument to the first image displayed by sxiv.
@@ -12,20 +12,20 @@
 #
 # Implementation note: the script tries to be POSIX compliant both in terms of
 # shell syntax and calls being made to external utilities, such as grep or find.
-# This makes it portable across many unix like systems, although it may not be
+# This makes it portable across many unix-like systems, although it may not be
 # the cleanest or fastest approach.
 #
-# First, using case statement to get absolute path is quicker than calling
-# 'realpath' because it would fork a whole process, which is slow.
+# First, using a case statement to get the absolute path is quicker than
+# calling 'realpath' because it would fork an entire process, which is slow.
 #
 # Second, we need to append a file list to sxiv, which can only be done
-# properly in three ways: arrays (which are not POSIX).
-# \0 separated strings; but assigning \0 to a variable is not POSIX either
-# so we cannot store the result of listfiles to a variable.
-#
-# The third approach is to store the result to a tmpfile and using `-i` to feed
-# the list to sxiv. This is the fastest approach since we won't have to call
-# listfiles twice.
+# properly in three ways:
+# - arrays (which are not POSIX).
+# - \0 separated strings; but assigning \0 to a variable is not POSIX either
+#   so we cannot store the result of listfiles in a variable.
+# - The third approach is to store the result to a tempfile and use `-i` to
+#   feed the list to sxiv. This is the fastest approach since we won't have to
+#   call listfiles twice.
 
 
 TMPDIR="${TMPDIR:-/tmp}"
@@ -41,7 +41,7 @@ listfiles () {
 }
 
 open_img () {
-    # only go through listfiles() if the file has a valid img extension
+    # Only go through listfiles() if the file has a valid img extension
     if echo "$1" | is_img_extension >/dev/null 2>&1; then
         trap 'rm -f $tmp' EXIT
         count="$(listfiles "$1" | grep -nF "$1")"
@@ -49,8 +49,8 @@ open_img () {
     if [ -n "$count" ]; then
         sxiv -i -n "${count%%:*}" -- < "$tmp"
     else
-        # fallback incase file didn't have a valid extension, or we couldn't
-        # find it inside the list
+        # Fallback in case the file didn't have a valid extension, or we
+        # couldn't find it inside the list
         sxiv -- "$@"
     fi
 }


### PR DESCRIPTION
#### ISSUE TYPE
- Bug fix
- Improvement/feature implementation

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [x] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [x] All changes follow the code style **[REQUIRED]**
- [x] All new and existing tests pass **[REQUIRED]**
      (Ran shellcheck and it doesn't report any problems)
- [ ] Changes require config files to be updated
    - [ ] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

### add some more image extensions

Imlib2 v1.8.0 adds loaders for svg, heif and avif.
ico support seems to have been there for a while.
add all these to known image extensions.

### properly fallback on non-valid extensions

originally we checked the extension to make sure the argument is an
image to avoid edge cases like this:

	./a        # is a dir
	./a.jpg

where running `rifle_sxiv a` would open up `a.jpg` instead of `a` the
directory.

however the is_img function was not correct as it would fail on upper
case extensions, such as `a.JPG`.

instead of doing extension check in two places, now we just have a
is_img_extension() function which checks for extension
case-insensitively via grep.

in short:

* this checks the extension case-insensitively
* reduces some code duplication
* sxiv will print an error msg for invalid files instead of the script
silently exiting

this is probably a tad bit slower, but IMO worth the trade.
