### PR TITLE
Added vcs_aware to filter stack [WIP]

### DIFF
--- a/ranger/config/rc.conf
+++ b/ranger/config/rc.conf
@@ -599,6 +599,7 @@ copymap zf zz
 map .d filter_stack add type d
 map .f filter_stack add type f
 map .l filter_stack add type l
+map .g filter_stack add vcs_aware t
 map .m console filter_stack add mime%space
 map .n console filter_stack add name%space
 map .# console filter_stack add hash%space

--- a/ranger/container/directory.py
+++ b/ranger/container/directory.py
@@ -99,6 +99,10 @@ class InodeFilterConstants(object):  # pylint: disable=too-few-public-methods
     LINKS = 'l'
 
 
+class VcsAwareFilterConstants(object):  # pylint: disable=too-few-public-methods
+    TRACKED = 't'
+
+
 class Directory(  # pylint: disable=too-many-instance-attributes,too-many-public-methods
         FileSystemObject, Accumulator, Loadable):
     is_directory = True

--- a/ranger/core/filter_stack.py
+++ b/ranger/core/filter_stack.py
@@ -14,7 +14,7 @@ except ImportError:
 # pylint: enable=invalid-name
 from os.path import abspath
 
-from ranger.container.directory import accept_file, InodeFilterConstants
+from ranger.container.directory import accept_file, InodeFilterConstants, VcsAwareFilterConstants
 from ranger.core.shared import FileManagerAware
 from ranger.ext.hash import hash_chunks
 
@@ -192,6 +192,25 @@ class TypeFilter(BaseFilter):
 
     def __str__(self):
         return "<Filter: type == '{ft}'>".format(ft=self.filetype)
+
+
+@stack_filter("vcs_aware")
+class VcsAwareFilter(BaseFilter):
+    vcs_aware_to_function = {
+        VcsAwareFilterConstants.TRACKED:
+        (lambda fobj: fobj.vcsstatus in ['conflict', 'changed', 'changed', 'staged', 'ignored', 'sync']),
+    }
+
+    def __init__(self, vcstype):
+        if vcstype not in self.vcs_aware_to_function:
+            raise KeyError(vcstype)
+        self.vcstype = vcstype
+
+    def __call__(self, fobj):
+        return self.vcs_aware_to_function[self.vcstype](fobj)
+
+    def __str__(self):
+        return "<Filter: vcs_aware == '{ft}'>".format(ft=self.vcstype)
 
 
 @filter_combinator("or")


### PR DESCRIPTION
Added support to display files that are tracked by VCS and hides the rest

Filter stack based implementation of https://github.com/ranger/ranger/pull/1343
Fixes: #2547

**PR Status**:
This is only a basic implementation done for initial feedback.

#### ISSUE TYPE
- Improvement/feature implementation


#### RUNTIME ENVIRONMENT
<!-- Details of your runtime environment -->
<!-- Retrieve Python/ranger version and locale with `ranger -\-version` -->
- Operating system and version: 
- Terminal emulator and version: 
- Python version: 
- Ranger version/commit: 
- Locale: 

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [ ] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [ ] All changes follow the code style **[REQUIRED]**
- [ ] All new and existing tests pass **[REQUIRED]**
- [ ] Changes require config files to be updated
    - [ ] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
<!-- Describe the changes in detail -->


#### MOTIVATION AND CONTEXT
<!-- Why are these changes required? -->
<!-- What problems do these changes solve? -->
<!-- Link to relevant issues -->


#### TESTING
<!-- What tests have been run? -->
<!-- How does the changes affect other areas of the codebase? -->


#### IMAGES / VIDEOS<!-- Only if relevant -->
<!-- Link or embed images and videos of screenshots, sketches etc. -->
