### PR TITLE
Mention how to disable automatic jump on mark and tag commands in rc.conf

### DIFF
--- a/ranger/config/rc.conf
+++ b/ranger/config/rc.conf
@@ -389,6 +389,9 @@ map MH linemode sizehumanreadablemtime
 map Mt linemode metatitle
 
 # Tagging / Marking
+# The actions mark_files, tag_toggle, tag_remove, and tag_add automatically
+# jump down to the line below when used without the option all=True.
+# Add the option movedown=False if this is not desired.
 map t       tag_toggle
 map ut      tag_remove
 map "<any>  tag_toggle tag=%any


### PR DESCRIPTION
#### ISSUE TYPE
- Improvement/feature implementation

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [X] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [X] All changes follow the code style **[REQUIRED]**
- [X] All new and existing tests pass **[REQUIRED]**
- [X] Changes require config files to be updated
    - [X] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
By default, when the user presses Space, that marks a file and jumps to the new line. An undocumented side-effect is that we move down to the next like, equivalent to pressing j. This is not explained anywhere and figuring out how to disable it requires digging into the code of actions.py.
I added a comment to rc.conf that mentions how to change this.


#### MOTIVATION AND CONTEXT
The default functionality makes sense when we're selecting files going top to bottom.
_Space-Space-Space_
However, when going bottom to top, we need to issue two movement commands. One to counteract the implicit down movement caused by the selection, and another to move up.
_Space-kk-Space-kk-Space_

Some users, including myself, might prefer it being the same in both directions.


#### IMAGES / VIDEOS<!-- Only if relevant -->
Default functionality. Notice the screenkeys: Moving down is automatic, but moving up requires that I press k twice.
![Peek 2022-04-30 20-05](https://user-images.githubusercontent.com/59140312/166116246-05a900f0-327f-4d58-ba96-0bff14ebf184.gif)

After adding movedown=False. 
![Peek 2022-04-30 20-06](https://user-images.githubusercontent.com/59140312/166116249-ab4171e1-840c-45b9-b6c7-fda771ced791.gif)

