### PR TITLE
Check for --apparent-size before invoking on cwd.

### DIFF
--- a/ranger/config/rc.conf
+++ b/ranger/config/rc.conf
@@ -467,8 +467,8 @@ map g? cd /usr/share/doc/ranger
 
 # External Programs
 map E  edit
-map du shell -p (du --max-depth=1 --human-readable --apparent-size || du -d 1 -h) 2>/dev/null
-map dU shell -p (du --max-depth=1 --human-readable --apparent-size || du -d 1 -h) 2>/dev/null | sort -rh
+map du shell -p du -d 1 -h "$(2>/dev/null >&2 du --apparent-size /dev/null && echo --apparent-size || echo --)"
+map dU shell -p du -d 1 -h "$(2>/dev/null >&2 du --apparent-size /dev/null && echo --apparent-size || echo --)" | sort -rh
 map yp yank path
 map yd yank dir
 map yn yank name

--- a/ranger/config/rc.conf
+++ b/ranger/config/rc.conf
@@ -467,8 +467,8 @@ map g? cd /usr/share/doc/ranger
 
 # External Programs
 map E  edit
-map du shell -p du -d 1 -h "$(2>/dev/null >&2 du --apparent-size /dev/null && echo --apparent-size || echo --)"
-map dU shell -p du -d 1 -h "$(2>/dev/null >&2 du --apparent-size /dev/null && echo --apparent-size || echo --)" | sort -rh
+map du shell -p du -d 1 -h "$(2>/dev/null >&2 du --apparent-size /dev/null && printf '%s\n' --apparent-size || printf '%s\n' --)"
+map dU shell -p du -d 1 -h "$(2>/dev/null >&2 du --apparent-size /dev/null && printf '%s\n' --apparent-size || printf '%s\n' --)" | sort -rh
 map yp yank path
 map yd yank dir
 map yn yank name


### PR DESCRIPTION
In general, it is possible for du to emit output and still return failure.

Previously, this resulted in duplicate entries on systems that support both long
and short options (since both parts of the AND-OR are run).

Here, we prevent duplicates by only having one outputting du invocation, at the
cost of extra assumptions:

- /dev/null is readable and length 0.
- Short options are always supported.

---

#### ISSUE TYPE

- Bug fix

#### RUNTIME ENVIRONMENT

- Operating system and version: Linux 5.17.0-1-amd64
- Terminal emulator and version: xterm 372-1
- Python version: 3.10
- Ranger version/commit: ranger-master 391f061cb0b0cfa8266c0651f2a6d948f22e01dd
- Locale: ugh

#### CHECKLIST

- [x] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [x] All changes follow the code style **[REQUIRED]**
- [x] All new and existing tests pass **[REQUIRED]**
- [ ] Changes require config files to be updated
    - [ ] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION

See above.

#### MOTIVATION AND CONTEXT

See above. Pull #2427 relevant.

#### TESTING

`make test` with dependencies prescribed by `HACKING.md`.
