### PR TITLE
Browsers - Save File option - use Ranger #2621

### DIFF
--- a/ranger/config/commands.py
+++ b/ranger/config/commands.py
@@ -2098,3 +2098,7 @@ class paste_ext(Command):
 
     def execute(self):
         return self.fm.paste(make_safe_path=paste_ext.make_safe_path)
+
+class wget(Command):
+    pass
+    # Browsers - Save File option - use Ranger 


### PR DESCRIPTION
Add wget/curl command for downloading files (Browsers - Save File option - use Ranger)

Fixes #2621
https://github.com/ranger/ranger/issues/2621#issue-1228896939

#### ISSUE TYPE
- Improvement/feature implementation 

#### CHECKLIST
- [x] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [ ] All changes follow the code style **[REQUIRED]**
- [ ] All new and existing tests pass **[REQUIRED]**
- [x] Changes require config files to be updated
    - [ ] Config files have been updated
- [x] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION, MOTIVATION, CONTEXT
New feature
Ability to download files from a URL without opening them in the browser/avoid the "save file" pop up
Add wget command
Add curl command
Add arg for output dir