### PR TITLE
PyLint: Deal with new lints

### DIFF
--- a/ranger/core/runner.py
+++ b/ranger/core/runner.py
@@ -235,9 +235,11 @@ class Runner(object):  # pylint: disable=too-few-public-methods
 
         if toggle_ui:
             self._activate_ui(False)
+
+        error = None
+        process = None
+
         try:
-            error = None
-            process = None
             self.fm.signal_emit('runner.execute.before',
                                 popen_kws=popen_kws, context=context)
             try:

--- a/ranger/ext/accumulator.py
+++ b/ranger/ext/accumulator.py
@@ -3,6 +3,8 @@
 
 from __future__ import (absolute_import, division, print_function)
 
+from abc import abstractmethod
+
 from ranger.ext.direction import Direction
 
 
@@ -90,8 +92,8 @@ class Accumulator(object):
     def sync_index(self, **kw):
         self.move_to_obj(self.pointed_obj, **kw)
 
-    @staticmethod
-    def get_list():
+    @abstractmethod
+    def get_list(self):
         """OVERRIDE THIS"""
         return []
 

--- a/ranger/gui/colorscheme.py
+++ b/ranger/gui/colorscheme.py
@@ -27,6 +27,7 @@ set colorscheme yourschemename
 from __future__ import (absolute_import, division, print_function)
 
 import os.path
+from abc import abstractmethod
 from curses import color_pair
 from io import open
 
@@ -72,8 +73,8 @@ class ColorScheme(object):
         fg, bg, attr = self.get(*flatten(keys))
         return attr | color_pair(get_color(fg, bg))
 
-    @staticmethod
-    def use(_):
+    @abstractmethod
+    def use(self, context):
         """Use the colorscheme to determine the (fg, bg, attr) tuple.
 
         Override this method in your own colorscheme.

--- a/tests/pylint/test_py2_compat.py
+++ b/tests/pylint/test_py2_compat.py
@@ -28,6 +28,7 @@ class TestPy2CompatibilityChecker(pylint.testutils.CheckerTestCase):
                 node=oldstyle_class,
                 confidence=HIGH,
             ),
+            ignore_position=True,
         ):
             self.checker.visit_classdef(oldstyle_class)
 
@@ -60,6 +61,7 @@ class TestPy2CompatibilityChecker(pylint.testutils.CheckerTestCase):
                 node=print_function_call,
                 confidence=HIGH,
             ),
+            ignore_position=True,
         ):
             self.checker.visit_call(print_function_call)
 
@@ -100,6 +102,7 @@ class TestPy2CompatibilityChecker(pylint.testutils.CheckerTestCase):
                 node=early_print_function_call,
                 confidence=HIGH,
             ),
+            ignore_position=True,
         ):
             self.checker.visit_call(early_print_function_call)
 
@@ -117,6 +120,7 @@ class TestPy2CompatibilityChecker(pylint.testutils.CheckerTestCase):
                 node=implicit_format_spec,
                 confidence=HIGH,
             ),
+            ignore_position=True,
         ):
             self.checker.visit_call(implicit_format_spec)
 
@@ -141,6 +145,7 @@ class TestPy2CompatibilityChecker(pylint.testutils.CheckerTestCase):
                 node=with_Popen,
                 confidence=HIGH,
             ),
+            ignore_position=True,
         ):
             self.checker.visit_with(with_subprocess_Popen)
             self.checker.visit_with(with_Popen)
@@ -160,6 +165,7 @@ class TestPy2CompatibilityChecker(pylint.testutils.CheckerTestCase):
                 node=f_string,
                 confidence=HIGH,
             ),
+            ignore_position=True,
         ):
             self.checker.visit_joinedstr(f_string)
         with self.assertNoMessages():


### PR DESCRIPTION
PyLint has grown stricter yet. The changes are minor and we don't care about the exact line positions of the py2_compat errors so we're ignoring those.