### PR TITLE
Fix width calculation when line numbers are enabled

### DIFF
--- a/ranger/gui/widgets/browsercolumn.py
+++ b/ranger/gui/widgets/browsercolumn.py
@@ -275,7 +275,7 @@ class BrowserColumn(Pager):  # pylint: disable=too-many-instance-attributes
 
         # Set the size of the linum text field to the number of digits in the
         # visible files in directory.
-        linum_text_len = len(str(self.scroll_begin + self.hei))
+        linum_text_len = len(str(self.scroll_begin + self.hei - 1))
         linum_format = "{0:>" + str(linum_text_len) + "}"
 
         selected_i = self._get_index_of_selected_file()

--- a/ranger/gui/widgets/browsercolumn.py
+++ b/ranger/gui/widgets/browsercolumn.py
@@ -321,7 +321,7 @@ class BrowserColumn(Pager):  # pylint: disable=too-many-instance-attributes
                    drawn.path in copied, tagged_marker, drawn.infostring,
                    drawn.vcsstatus, drawn.vcsremotestatus, self.target.has_vcschild,
                    self.fm.do_cut, current_linemode.name, metakey, active_pane,
-                   self.settings.line_numbers, linum_text_len)
+                   self.settings.line_numbers.lower(), linum_text_len)
 
             # Check if current line has not already computed and cached
             if key in drawn.display_data:

--- a/ranger/gui/widgets/browsercolumn.py
+++ b/ranger/gui/widgets/browsercolumn.py
@@ -283,14 +283,17 @@ class BrowserColumn(Pager):  # pylint: disable=too-many-instance-attributes
         scroll_end = self.scroll_begin + self.hei - 1
         distance_to_top = selected_i - self.scroll_begin
         distance_to_bottom = scroll_end - selected_i
+        one_indexed_offset = 1 if self.settings.one_indexed else 0
 
         if self.settings.line_numbers.lower() == "relative":
             linum_text_len = nr_of_digits(max(distance_to_top,
                                               distance_to_bottom))
             if not self.settings.relative_current_zero:
-                linum_text_len = max(nr_of_digits(selected_i), linum_text_len)
+                linum_text_len = max(nr_of_digits(selected_i
+                                                  + one_indexed_offset),
+                                     linum_text_len)
         else:
-            linum_text_len = nr_of_digits(scroll_end)
+            linum_text_len = nr_of_digits(scroll_end + one_indexed_offset)
         linum_format = "{0:>" + str(linum_text_len) + "}"
 
         for line in range(self.hei):

--- a/ranger/gui/widgets/browsercolumn.py
+++ b/ranger/gui/widgets/browsercolumn.py
@@ -280,7 +280,7 @@ class BrowserColumn(Pager):  # pylint: disable=too-many-instance-attributes
         def nr_of_digits(number):
             return len(str(number))
 
-        scroll_end = self.scroll_begin + self.hei - 1
+        scroll_end = self.scroll_begin + min(self.hei, len(self.target)) - 1
         distance_to_top = selected_i - self.scroll_begin
         distance_to_bottom = scroll_end - selected_i
         one_indexed_offset = 1 if self.settings.one_indexed else 0

--- a/ranger/gui/widgets/browsercolumn.py
+++ b/ranger/gui/widgets/browsercolumn.py
@@ -273,12 +273,20 @@ class BrowserColumn(Pager):  # pylint: disable=too-many-instance-attributes
 
         copied = [f.path for f in self.fm.copy_buffer]
 
+        selected_i = self._get_index_of_selected_file()
+
         # Set the size of the linum text field to the number of digits in the
         # visible files in directory.
-        linum_text_len = len(str(self.scroll_begin + self.hei - 1))
+        scroll_end = self.scroll_begin + self.hei - 1
+        if self.settings.line_numbers.lower() == "relative":
+            linum_text_len = len(str(max(selected_i - self.scroll_begin,
+                                         scroll_end - selected_i)))
+            if not self.settings.relative_current_zero:
+                linum_text_len = max(len(str(selected_i)), linum_text_len)
+        else:
+            linum_text_len = len(str(scroll_end))
         linum_format = "{0:>" + str(linum_text_len) + "}"
 
-        selected_i = self._get_index_of_selected_file()
         for line in range(self.hei):
             i = line + self.scroll_begin
 

--- a/ranger/gui/widgets/browsercolumn.py
+++ b/ranger/gui/widgets/browsercolumn.py
@@ -307,7 +307,7 @@ class BrowserColumn(Pager):  # pylint: disable=too-many-instance-attributes
                    drawn.path in copied, tagged_marker, drawn.infostring,
                    drawn.vcsstatus, drawn.vcsremotestatus, self.target.has_vcschild,
                    self.fm.do_cut, current_linemode.name, metakey, active_pane,
-                   self.settings.line_numbers)
+                   self.settings.line_numbers, linum_text_len)
 
             # Check if current line has not already computed and cached
             if key in drawn.display_data:

--- a/ranger/gui/widgets/browsercolumn.py
+++ b/ranger/gui/widgets/browsercolumn.py
@@ -374,15 +374,16 @@ class BrowserColumn(Pager):  # pylint: disable=too-many-instance-attributes
             try:
                 infostringdata = current_linemode.infostring(drawn, metadata)
                 if infostringdata:
-                    infostring.append([" " + infostringdata + " ",
+                    infostring.append([" " + infostringdata,
                                        ["infostring"]])
             except NotImplementedError:
                 infostring = self._draw_infostring_display(drawn, space)
             if infostring:
                 infostringlen = self._total_len(infostring)
                 if space - infostringlen > 2:
-                    predisplay_right = infostring + predisplay_right
-                    space -= infostringlen
+                    sep = [" ", []] if predisplay_right else []
+                    predisplay_right = infostring + sep + predisplay_right
+                    space -= infostringlen + len(sep)
 
             textstring = self._draw_text_display(text, space)
             textstringlen = self._total_len(textstring)
@@ -448,7 +449,7 @@ class BrowserColumn(Pager):  # pylint: disable=too-many-instance-attributes
         infostring_display = []
         if self.display_infostring and drawn.infostring \
                 and self.settings.display_size_in_main_column:
-            infostring = str(drawn.infostring) + " "
+            infostring = str(drawn.infostring)
             if len(infostring) <= space:
                 infostring_display.append([infostring, ['infostring']])
         return infostring_display

--- a/ranger/gui/widgets/browsercolumn.py
+++ b/ranger/gui/widgets/browsercolumn.py
@@ -277,14 +277,20 @@ class BrowserColumn(Pager):  # pylint: disable=too-many-instance-attributes
 
         # Set the size of the linum text field to the number of digits in the
         # visible files in directory.
+        def nr_of_digits(number):
+            return len(str(number))
+
         scroll_end = self.scroll_begin + self.hei - 1
+        distance_to_top = selected_i - self.scroll_begin
+        distance_to_bottom = scroll_end - selected_i
+
         if self.settings.line_numbers.lower() == "relative":
-            linum_text_len = len(str(max(selected_i - self.scroll_begin,
-                                         scroll_end - selected_i)))
+            linum_text_len = nr_of_digits(max(distance_to_top,
+                                              distance_to_bottom))
             if not self.settings.relative_current_zero:
-                linum_text_len = max(len(str(selected_i)), linum_text_len)
+                linum_text_len = max(nr_of_digits(selected_i), linum_text_len)
         else:
-            linum_text_len = len(str(scroll_end))
+            linum_text_len = nr_of_digits(scroll_end)
         linum_format = "{0:>" + str(linum_text_len) + "}"
 
         for line in range(self.hei):

--- a/ranger/gui/widgets/browsercolumn.py
+++ b/ranger/gui/widgets/browsercolumn.py
@@ -212,7 +212,7 @@ class BrowserColumn(Pager):  # pylint: disable=too-many-instance-attributes
 
     def _format_line_number(self, linum_format, i, selected_i):
         line_number = i
-        if self.settings.line_numbers == 'relative':
+        if self.settings.line_numbers.lower() == 'relative':
             line_number = abs(selected_i - i)
             if not self.settings.relative_current_zero and line_number == 0:
                 if self.settings.one_indexed:
@@ -312,7 +312,10 @@ class BrowserColumn(Pager):  # pylint: disable=too-many-instance-attributes
             # Check if current line has not already computed and cached
             if key in drawn.display_data:
                 # Recompute line numbers because they can't be reliably cached.
-                if self.main_column and self.settings.line_numbers != 'false':
+                if (
+                    self.main_column
+                    and self.settings.line_numbers.lower() != 'false'
+                ):
                     line_number_text = self._format_line_number(linum_format,
                                                                 i,
                                                                 selected_i)
@@ -337,7 +340,7 @@ class BrowserColumn(Pager):  # pylint: disable=too-many-instance-attributes
             space = self.wid
 
             # line number field
-            if self.settings.line_numbers != 'false':
+            if self.settings.line_numbers.lower() != 'false':
                 if self.main_column and space - linum_text_len > 2:
                     line_number_text = self._format_line_number(linum_format,
                                                                 i,


### PR DESCRIPTION
This fixes the width of files being off whenever a line number with an extra digit appears,
 shifting the width one item too early, shifting relative line numbers more than necessary and a trailing space on the file size.

@NoSuck, I created this PR because you did not seem interested in continuing discussion/development on PR #2346 after @markus-bauer's comments. Thank you for bringing the issue to my attention! A review of this PR would be really welcome.
 
 @markus-bauer, thank you for digging into this issue.  I'd appreciate a review. I considered your suggestion to replace `line_numbers` with `linum_text_len` in the key but it seemed like improperly overloading the meaning of that variable and I don't really see any harm in making this key a little bigger.

In the last commit I did add a fix related to the width to be used when relative line numbers are enabled, which is necessarily nearly always smaller. This has introduced enough logic in setting `linum_text_len` that we could just as easily set it to zero and have that be synonymous with disabling line numbers. If there's a reason for doing so. I don't think making the key one item bigger is much of a problem but maybe I'm wrong?