### PR TITLE
Fix "Loader work process failed" error when copying dangling symlinks

### DIFF
--- a/ranger/ext/shutil_generatorized.py
+++ b/ranger/ext/shutil_generatorized.py
@@ -49,9 +49,9 @@ else:
             pass
 
         # follow symlinks (aka don't not follow symlinks)
-        follow = ((follow_symlinks  # pylint: disable=simplify-boolean-expression
-                   and os.path.exists(src))
-                  or not (os.path.islink(src) and os.path.islink(dst)))
+        follow = os.path.exists(src) and (
+            follow_symlinks or not (os.path.islink(src) and os.path.islink(dst))
+        )
         if follow:
             # use the real function if it exists
             def lookup(name):

--- a/ranger/ext/shutil_generatorized.py
+++ b/ranger/ext/shutil_generatorized.py
@@ -49,7 +49,8 @@ else:
             pass
 
         # follow symlinks (aka don't not follow symlinks)
-        follow = follow_symlinks or not (os.path.islink(src) and os.path.islink(dst))
+        follow = (follow_symlinks and os.path.exists(src)) \
+                or not (os.path.islink(src) and os.path.islink(dst))
         if follow:
             # use the real function if it exists
             def lookup(name):

--- a/ranger/ext/shutil_generatorized.py
+++ b/ranger/ext/shutil_generatorized.py
@@ -49,8 +49,9 @@ else:
             pass
 
         # follow symlinks (aka don't not follow symlinks)
-        follow = (follow_symlinks and os.path.exists(src)) \
-                or not (os.path.islink(src) and os.path.islink(dst))
+        follow = ((follow_symlinks  # pylint: disable=simplify-boolean-expression
+                   and os.path.exists(src))
+                  or not (os.path.islink(src) and os.path.islink(dst)))
         if follow:
             # use the real function if it exists
             def lookup(name):


### PR DESCRIPTION
#### ISSUE TYPE
- Bug fix

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [X] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [X] All changes follow the code style **[REQUIRED]**
- [x] All new and existing tests pass **[REQUIRED]**

#### DESCRIPTION
When copying folders that contain dangling symlinks, ranger throws an error message, although the copying itself seems to succeed. This change fixes it. Tried to fix the pylint complaints, not sure about the other tests.