### PR TITLE
pylint: Pin to 2.13.9

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -5,10 +5,12 @@ on:
     paths:
       - '.github/workflows/pylint.yml'
       - '**.py'
+      - 'requirements.txt'
   pull_request:
     paths:
       - '.github/workflows/pylint.yml'
       - '**.py'
+      - 'requirements.txt'
 
 jobs:
   test_pylint:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 flake8
-pylint
+pylint==2.13.9 # Newer versions drop the python3 port checker, which we need
 pytest


### PR DESCRIPTION
As of 2.14.0 PyLint dropped the python3 port checker. This means many of
the features we want to disable, because we need syntax compatible with
Python 2 are gone and we can no longer disable the checks.