### PR TITLE
browsercolumn: Fix separator depth

### DIFF
--- a/ranger/gui/widgets/browsercolumn.py
+++ b/ranger/gui/widgets/browsercolumn.py
@@ -399,7 +399,7 @@ class BrowserColumn(Pager):  # pylint: disable=too-many-instance-attributes
                 infostringlen = self._total_len(infostring)
                 if space - infostringlen > 2:
                     sep = [" ", []] if predisplay_right else []
-                    predisplay_right = infostring + sep + predisplay_right
+                    predisplay_right = infostring + [sep] + predisplay_right
                     space -= infostringlen + len(sep)
 
             textstring = self._draw_text_display(text, space)


### PR DESCRIPTION
It looks like the separator is being unexpectedly flattened by the list
concatenation.

Fixes: #2641