### PR TITLE
GHActions: Refrain from installing PyLint for tests

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -28,7 +28,9 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -r requirements.txt
+        # We need to ignore PyLint because we can't install the one we need for
+        # Python 2.7 and 3.5
+        pip install -r <(grep -v pylint requirements.txt)
     - name: Flake8 and test
       run: |
         make test_flake8 test_doctest test_other


### PR DESCRIPTION
Not all versions of Python we test with support installing the PyLint
version we need and the tests don't require PyLint anyway, so no need to
install any version of PyLint at all.