### PR TITLE
ui: Guard terminal capabalities

### DIFF
--- a/ranger/gui/ui.py
+++ b/ranger/gui/ui.py
@@ -381,11 +381,14 @@ class UI(  # pylint: disable=too-many-instance-attributes,too-many-public-method
             try:
                 fixed_cwd = cwd.encode('utf-8', 'surrogateescape'). \
                     decode('utf-8', 'replace')
-                escapes = [
-                    curses.tigetstr('tsl').decode('latin-1'),
-                    ESCAPE_ICON_TITLE
-                ]
-                bel = curses.tigetstr('fsl').decode('latin-1')
+                titlecap = curses.tigetstr('tsl')
+                escapes = (
+                    [titlecap.decode("latin-1")]
+                    if titlecap is not None
+                    else [] + [ESCAPE_ICON_TITLE]
+                )
+                belcap = curses.tigetstr('fsl')
+                bel = belcap.decode('latin-1') if belcap is not None else ""
                 fmt_tups = [(e, fixed_cwd, bel) for e in escapes]
             except UnicodeError:
                 pass


### PR DESCRIPTION
We call `decode` on the result of calls to `tigetstr` but that returns
`None` if the current terminfo does not support the capability we ask
for.

Fixes #2587