### PR TITLE
manpage_completion_test: Change interpreter directive

### DIFF
--- a/tests/manpage_completion_test.py
+++ b/tests/manpage_completion_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 from __future__ import (absolute_import, division, print_function)
 


### PR DESCRIPTION
On systems that do not put Python at `/usr/bin/python` the original shebang line causes a cryptic error from make saying the file doesn't exist but it's actually the interpreter not being found. `/usr/bin/env` should be more pervasive and respect venvs and such.