### PR TITLE
Fix flattened names

### DIFF
--- a/examples/plugin_linemode.py
+++ b/examples/plugin_linemode.py
@@ -17,7 +17,7 @@ from ranger.core.linemode import LinemodeBase
 class MyLinemode(LinemodeBase):
     name = "rot13"
 
-    def filetitle(self, fobj, metadata):
+    def filetitle(self, fobj, metadata, relative_base=None):
         return codecs.encode(fobj.relative_path, "rot_13")
 
     def infostring(self, fobj, metadata):

--- a/ranger/config/commands.py
+++ b/ranger/config/commands.py
@@ -140,16 +140,15 @@ class cd(Command):
         if self.arg(1) == '-r':
             self.shift()
             destination = os.path.realpath(self.rest(1))
-            if os.path.isfile(destination):
-                self.fm.select_file(destination)
-                return
         else:
             destination = self.rest(1)
 
         if not destination:
             destination = '~'
 
-        if destination == '-':
+        if os.path.isfile(destination):
+            self.fm.select_file(destination)
+        elif destination == '-':
             self.fm.enter_bookmark('`')
         else:
             self.fm.cd(destination)

--- a/ranger/container/directory.py
+++ b/ranger/container/directory.py
@@ -398,8 +398,8 @@ class Directory(  # pylint: disable=too-many-instance-attributes,too-many-public
 
                     if is_a_dir:
                         item = self.fm.get_directory(
-                             name, preload=stats, path_is_abs=True
-                         )
+                            name, preload=stats, path_is_abs=True
+                        )
                         item.load_if_outdated()
                         if item.vcs and item.vcs.track:
                             if item.vcs.is_root_pointer:

--- a/ranger/container/directory.py
+++ b/ranger/container/directory.py
@@ -265,10 +265,26 @@ class Directory(  # pylint: disable=too-many-instance-attributes,too-many-public
             hidden_filter_search = hidden_filter.search
 
             def hidden_filter_func(fobj):
-                for comp in fobj.relative_path.split(os.path.sep):
+                # Don't hide a directory we are in or on
+                if self.pointed_obj == fobj:
+                    return True
+                split_path = fobj.path.split(os.path.sep)
+                split_thisdir = self.fm.thisdir.path.split(os.path.sep)
+                if len(split_path) <= len(split_thisdir):
+                    # Can't use os.path.commonpath because that's Python 3.5+
+                    for path_piece, thisdir_piece in zip(
+                        split_path, split_thisdir
+                    ):
+                        if path_piece != thisdir_piece:
+                            break
+                    else:
+                        return True
+
+                for comp in fobj.relative_to(self.path).split(os.path.sep):
                     if hidden_filter_search(comp):
                         return False
                 return True
+
             filters.append(hidden_filter_func)
         if self.narrow_filter:
             # pylint: disable=unsupported-membership-test

--- a/ranger/container/directory.py
+++ b/ranger/container/directory.py
@@ -326,8 +326,6 @@ class Directory(  # pylint: disable=too-many-instance-attributes,too-many-public
         self.percent = 0
         self.load_if_outdated()
 
-        basename_is_rel_to = self.path if self.flat else None
-
         try:  # pylint: disable=too-many-nested-blocks
             if self.runnable:
                 yield
@@ -399,14 +397,10 @@ class Directory(  # pylint: disable=too-many-instance-attributes,too-many-public
                         is_a_dir = False
 
                     if is_a_dir:
-                        item = self.fm.get_directory(name, preload=stats, path_is_abs=True,
-                                                     basename_is_rel_to=basename_is_rel_to)
+                        item = self.fm.get_directory(
+                             name, preload=stats, path_is_abs=True
+                         )
                         item.load_if_outdated()
-                        if self.flat:
-                            item.relative_path = os.path.relpath(item.path, self.path)
-                        else:
-                            item.relative_path = item.basename
-                        item.relative_path_lower = item.relative_path.lower()
                         if item.vcs and item.vcs.track:
                             if item.vcs.is_root_pointer:
                                 has_vcschild = True
@@ -417,8 +411,7 @@ class Directory(  # pylint: disable=too-many-instance-attributes,too-many-public
                                         is_directory=True,
                                     )
                     else:
-                        item = File(name, preload=stats, path_is_abs=True,
-                                    basename_is_rel_to=basename_is_rel_to)
+                        item = File(name, preload=stats, path_is_abs=True)
                         item.load()
                         disk_usage += item.size
                         if self.vcs and self.vcs.track:

--- a/ranger/container/fsobject.py
+++ b/ranger/container/fsobject.py
@@ -53,7 +53,6 @@ def safe_path(path):
 class FileSystemObject(  # pylint: disable=too-many-instance-attributes,too-many-public-methods
         FileManagerAware, SettingsAware):
     basename = None
-    relative_path = None
     infostring = None
     path = None
     permissions = None
@@ -98,15 +97,11 @@ class FileSystemObject(  # pylint: disable=too-many-instance-attributes,too-many
          SizeHumanReadableMtimeLinemode]
     )
 
-    def __init__(self, path, preload=None, path_is_abs=False, basename_is_rel_to=None):
+    def __init__(self, path, preload=None, path_is_abs=False):
         if not path_is_abs:
             path = abspath(path)
         self.path = path
         self.basename = basename(path)
-        if basename_is_rel_to is None:
-            self.relative_path = self.basename
-        else:
-            self.relative_path = relpath(path, basename_is_rel_to)
         self.preload = preload
         self.display_data = {}
 
@@ -120,6 +115,10 @@ class FileSystemObject(  # pylint: disable=too-many-instance-attributes,too-many
             return self.basename[lastdot:].lower()
         except ValueError:
             return None
+    @property
+    def relative_path(self):
+        """Path relative to the current working directory."""
+        return relpath(self.path)
 
     @lazy_property
     def relative_path_lower(self):

--- a/ranger/container/fsobject.py
+++ b/ranger/container/fsobject.py
@@ -115,10 +115,18 @@ class FileSystemObject(  # pylint: disable=too-many-instance-attributes,too-many
             return self.basename[lastdot:].lower()
         except ValueError:
             return None
+
     @property
     def relative_path(self):
         """Path relative to the current working directory."""
         return relpath(self.path)
+
+    def relative_to(self, base=None):
+        """Path relative to 'to' or the current working directory."""
+        if base is None:
+            return self.relative_path
+        else:
+            return relpath(self.path, base)
 
     @lazy_property
     def relative_path_lower(self):

--- a/ranger/core/linemode.py
+++ b/ranger/core/linemode.py
@@ -14,6 +14,13 @@ from ranger.ext import spawn
 DEFAULT_LINEMODE = "filename"
 
 
+def relative_or_basename(fobj, relative_base=None):
+    if relative_base is None:
+        return fobj.basename
+    else:
+        return fobj.relative_to(relative_base)
+
+
 class LinemodeBase(object):
     """Supplies the file line contents for BrowserColumn.
 
@@ -34,7 +41,7 @@ class LinemodeBase(object):
     name = abstractproperty()
 
     @abstractmethod
-    def filetitle(self, fobj, metadata):
+    def filetitle(self, fobj, metadata, relative_base=None):
         """The left-aligned part of the line."""
         raise NotImplementedError
 
@@ -56,8 +63,8 @@ class LinemodeBase(object):
 class DefaultLinemode(LinemodeBase):  # pylint: disable=abstract-method
     name = "filename"
 
-    def filetitle(self, fobj, metadata):
-        return fobj.relative_path
+    def filetitle(self, fobj, metadata, relative_base=None):
+        return relative_or_basename(fobj, relative_base)
 
 
 class TitleLinemode(LinemodeBase):
@@ -65,7 +72,7 @@ class TitleLinemode(LinemodeBase):
     uses_metadata = True
     required_metadata = ["title"]
 
-    def filetitle(self, fobj, metadata):
+    def filetitle(self, fobj, metadata, relative_base=None):
         name = metadata.title
         if metadata.year:
             return "%s - %s" % (metadata.year, name)
@@ -81,21 +88,23 @@ class TitleLinemode(LinemodeBase):
 
 
 class PermissionsLinemode(LinemodeBase):
+    # pylint: disable=abstract-method
     name = "permissions"
 
-    def filetitle(self, fobj, metadata):
+    def filetitle(self, fobj, metadata, relative_base=None):
         return "%s %s %s %s" % (
-            fobj.get_permission_string(), fobj.user, fobj.group, fobj.relative_path)
-
-    def infostring(self, fobj, metadata):
-        return ""
+            fobj.get_permission_string(),
+            fobj.user,
+            fobj.group,
+            relative_or_basename(fobj, relative_base),
+        )
 
 
 class FileInfoLinemode(LinemodeBase):
     name = "fileinfo"
 
-    def filetitle(self, fobj, metadata):
-        return fobj.relative_path
+    def filetitle(self, fobj, metadata, relative_base=None):
+        return relative_or_basename(fobj, relative_base)
 
     def infostring(self, fobj, metadata):
         if not fobj.is_directory:
@@ -112,8 +121,8 @@ class FileInfoLinemode(LinemodeBase):
 class MtimeLinemode(LinemodeBase):
     name = "mtime"
 
-    def filetitle(self, fobj, metadata):
-        return fobj.relative_path
+    def filetitle(self, fobj, metadata, relative_base=None):
+        return relative_or_basename(fobj, relative_base)
 
     def infostring(self, fobj, metadata):
         if fobj.stat is None:
@@ -124,8 +133,8 @@ class MtimeLinemode(LinemodeBase):
 class SizeMtimeLinemode(LinemodeBase):
     name = "sizemtime"
 
-    def filetitle(self, fobj, metadata):
-        return fobj.relative_path
+    def filetitle(self, fobj, metadata, relative_base=None):
+        return relative_or_basename(fobj, relative_base)
 
     def infostring(self, fobj, metadata):
         if fobj.stat is None:
@@ -137,8 +146,8 @@ class SizeMtimeLinemode(LinemodeBase):
 class HumanReadableMtimeLinemode(LinemodeBase):
     name = "humanreadablemtime"
 
-    def filetitle(self, fobj, metadata):
-        return fobj.relative_path
+    def filetitle(self, fobj, metadata, relative_base=None):
+        return relative_or_basename(fobj, relative_base)
 
     def infostring(self, fobj, metadata):
         if fobj.stat is None:
@@ -149,8 +158,8 @@ class HumanReadableMtimeLinemode(LinemodeBase):
 class SizeHumanReadableMtimeLinemode(LinemodeBase):
     name = "sizehumanreadablemtime"
 
-    def filetitle(self, fobj, metadata):
-        return fobj.relative_path
+    def filetitle(self, fobj, metadata, relative_base=None):
+        return relative_or_basename(fobj, relative_base)
 
     def infostring(self, fobj, metadata):
         if fobj.stat is None:

--- a/ranger/core/tab.py
+++ b/ranger/core/tab.py
@@ -173,6 +173,9 @@ class Tab(FileManagerAware, SettingsAware):  # pylint: disable=too-many-instance
                 currentpath = join(currentpath, comp)
                 pathway.append(self.fm.get_directory(currentpath))
             self.pathway = tuple(pathway)
+            for comp in self.pathway:
+                comp.refilter()
+                comp.correct_pointer()
 
         self.assign_cursor_positions_for_subdirs()
 

--- a/ranger/gui/widgets/browsercolumn.py
+++ b/ranger/gui/widgets/browsercolumn.py
@@ -320,11 +320,27 @@ class BrowserColumn(Pager):  # pylint: disable=too-many-instance-attributes
                     current_linemode = drawn.linemode_dict[linemode.DEFAULT_LINEMODE]
 
             metakey = hash(repr(sorted(metadata.items()))) if metadata else 0
-            key = (self.wid, selected_i == i, drawn.marked, self.main_column,
-                   drawn.path in copied, tagged_marker, drawn.infostring,
-                   drawn.vcsstatus, drawn.vcsremotestatus, self.target.has_vcschild,
-                   self.fm.do_cut, current_linemode.name, metakey, active_pane,
-                   self.settings.line_numbers.lower(), linum_text_len)
+
+            flatness = getattr(self.target, "flat", None)
+            key = (
+                self.wid,
+                selected_i == i,
+                drawn.marked,
+                self.main_column,
+                drawn.path in copied,
+                tagged_marker,
+                drawn.infostring,
+                drawn.vcsstatus,
+                drawn.vcsremotestatus,
+                self.target.has_vcschild,
+                self.fm.do_cut,
+                current_linemode.name,
+                metakey,
+                active_pane,
+                self.settings.line_numbers.lower(),
+                linum_text_len,
+                flatness,
+            )
 
             # Check if current line has not already computed and cached
             if key in drawn.display_data:
@@ -342,7 +358,13 @@ class BrowserColumn(Pager):  # pylint: disable=too-many-instance-attributes
                 self.color_reset()
                 continue
 
-            text = current_linemode.filetitle(drawn, metadata)
+            text = current_linemode.filetitle(
+                drawn,
+                metadata,
+                relative_base=self.target.path
+                if flatness is not None and flatness != 0
+                else None,
+            )
 
             if drawn.marked and (self.main_column
                                  or self.settings.display_tags_in_all_columns):


### PR DESCRIPTION
I believe I've managed to figure out what was wrong with flattening.

Apologies for the low-effort PR description but I've run out of time and will be away until the 16th.

Any and all reviews and testing are more than welcome as this is a rather finicky problem domain :heart: 

I'm hoping, though not hopeful that this could also fix #2625.

Highlighting the important parts of the commit messages:

We can't set a `Directory` with multiple `basename_is_rel_to` values and it can appear simultaneously in both flattened and non-flattened directories, or differently flattened directories, so it can in fact be simultaneously rendered relative to multiple directories.

The `relative_path` property of an `FSObject` is now always semantically meaningful, relative to the current working directory. This does mean `relative_path` is no longer usable as a way to get an `FSObject`'s "display name."

The flat level of a directory changes the display names and therefore we cannot reuse cached `display_data` when the flat level changes.

To get a proper `infostring` we provide the column's target as a base to calculate relative paths to.

Changes to `Directory` mean the `relative_path` attribute is no longer a (bad) proxy for the way the object is displayed in the browser columns.

This means line modes can no longer use it as such. Using the path relative to the target of the current column, or the basename otherwise seems like an appropriate alternative.

While working on issues related to flattening I noticed unfortunate interplay between being in a hidden directory and the hidden filter. If we are in a hidden directory there's no point in hiding that directory from the parent directory. It causes confusion because the directory we are in does not appear in the parent and instead a different child of the parent is highlighted, leading us to potentially believe we are in a different directory.

I've also stopped filtering away hidden files and directories if they are highlighted, which makes moving left (to the parent) and then right (into the highlighted child) again a more idempotent operation.

~~EDIT: Need to fix up the various linting errors still.~~
EDIT: I changed `examples/plugin_linemode.py` because PyLint complains about the abstract base class and not reimplementing `filetitle` with the proper arguments. Ideally we wouldn't force any plugin filemodes to adopt the default parameter value and maybe not even the parameter at all.