### PR TITLE
Fix image display for palette images with transparency

### DIFF
--- a/ranger/ext/img_display.py
+++ b/ranger/ext/img_display.py
@@ -644,7 +644,7 @@ class KittyImageDisplayer(ImageDisplayer, FileManagerAware):
                                  self.backend.LANCZOS)
 
         if image.mode not in ('RGB', 'RGBA'):
-            image = image.convert('RGB')
+            image = image.convert('RGBA' if image.info.get("transparency", False) else 'RGB')
         # start_x += ((box[0] - image.width) // 2) // self.pix_row
         # start_y += ((box[1] - image.height) // 2) // self.pix_col
         if self.stream:

--- a/ranger/ext/img_display.py
+++ b/ranger/ext/img_display.py
@@ -644,7 +644,9 @@ class KittyImageDisplayer(ImageDisplayer, FileManagerAware):
                                  self.backend.LANCZOS)
 
         if image.mode not in ('RGB', 'RGBA'):
-            image = image.convert('RGBA' if image.info.get("transparency", False) else 'RGB')
+            image = image.convert('RGBA'
+                                  if image.info.get("transparency", None) is not None
+                                  else 'RGB')
         # start_x += ((box[0] - image.width) // 2) // self.pix_row
         # start_y += ((box[1] - image.height) // 2) // self.pix_col
         if self.stream:

--- a/ranger/ext/img_display.py
+++ b/ranger/ext/img_display.py
@@ -643,10 +643,10 @@ class KittyImageDisplayer(ImageDisplayer, FileManagerAware):
             image = image.resize((int(scale * image.width), int(scale * image.height)),
                                  self.backend.LANCZOS)
 
-        if image.mode not in ('RGB', 'RGBA'):
-            image = image.convert('RGBA'
-                                  if image.info.get("transparency", None) is not None
-                                  else 'RGB')
+        if image.mode not in ("RGB", "RGBA"):
+            image = image.convert(
+                "RGBA" if "transparency" in image.info else "RGB"
+            )
         # start_x += ((box[0] - image.width) // 2) // self.pix_row
         # start_y += ((box[1] - image.height) // 2) // self.pix_col
         if self.stream:


### PR DESCRIPTION
Even if image is not in RGB or RGBA format, it could still contain
transparency information.

I used the "transparency" key in the image info dict, see documentation here: https://pillow.readthedocs.io/en/stable/handbook/image-file-formats.html
Basically this key only exists for some formats in some modes, when the image contains transparency. I didn't test any formats besides a rudimentary test of palette mode .png; this change may also affect .eps, .gif, .gd, .xpm.

<!-- Provide a descriptive summary of the changes in the title above -->

#### ISSUE TYPE
- Bug fix

#### RUNTIME ENVIRONMENT
<!-- Details of your runtime environment -->
<!-- Retrieve Python/ranger version and locale with `ranger -\-version` -->
- Operating system and version:  Arch
- Terminal emulator and version: kitty 0.25.2
- Python version: 3.10.5
- Ranger version/commit: fcf44f6f12506fa0096cb6468de6a2706bbfaf51
- Locale: en_US.UTF-8

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [x] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [ ] All changes follow the code style **[REQUIRED]**
- [ ] All new and existing tests pass **[REQUIRED]**
- [ ] Changes require config files to be updated
    - [ ] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
<!-- Describe the changes in detail -->


#### MOTIVATION AND CONTEXT
<!-- Why are these changes required? -->
<!-- What problems do these changes solve? -->
<!-- Link to relevant issues -->
Fixes: https://github.com/ranger/ranger/issues/2690

#### TESTING
<!-- What tests have been run? -->
<!-- How does the changes affect other areas of the codebase? -->
I ran the tests and got a 9.99/10 reported failure rate; but AFAICT there aren't any tests which cover this change.

#### IMAGES / VIDEOS<!-- Only if relevant -->
<!-- Link or embed images and videos of screenshots, sketches etc. -->
