### PR TITLE
[Feature] Add navigation scope

### DIFF
--- a/ranger/core/fm.py
+++ b/ranger/core/fm.py
@@ -44,12 +44,13 @@ class FM(Actions,  # pylint: disable=too-many-instance-attributes
     _visual_pos_start = None
     _visual_move_cycles = None
 
-    def __init__(self, ui=None, bookmarks=None, tags=None, paths=None):
+    def __init__(self, ui=None, bookmarks=None, tags=None, paths=None, root=None):
         """Initialize FM."""
         Actions.__init__(self)
         SignalDispatcher.__init__(self)
         self.ui = ui if ui is not None else UI()
         self.start_paths = paths if paths is not None else ['.']
+        self.root_dir = root if root is not None else '/'
         self.directories = {}
         self.bookmarks = bookmarks
         self.current_tab = 1

--- a/ranger/core/main.py
+++ b/ranger/core/main.py
@@ -6,6 +6,7 @@
 from __future__ import (absolute_import, division, print_function)
 
 import atexit
+from email.policy import default
 import locale
 import os.path
 import shutil
@@ -107,6 +108,8 @@ def main(
             continue
         if not os.access(path_abs, os.F_OK):
             paths_inaccessible += [path]
+        elif args.scope and not os.path.commonprefix([path_abs, args.scope]) == args.scope:
+            paths_inaccessible += ['{0} (not in scope)'.format(path)]
     if paths_inaccessible:
         print('Inaccessible paths: {0}'.format(', '.join(paths_inaccessible)),
               file=sys.stderr)
@@ -117,7 +120,7 @@ def main(
     exit_code = 0
     try:  # pylint: disable=too-many-nested-blocks
         # Initialize objects
-        fm = FM(paths=paths)
+        fm = FM(paths=paths, root=args.scope)
         FileManagerAware.fm_set(fm)
         load_settings(fm, args.clean)
 
@@ -306,6 +309,8 @@ def parse_arguments():
                       ", it will write the name of the last visited directory to OUTFILE")
     parser.add_option('--selectfile', type='string', metavar='filepath',
                       help="Open ranger with supplied file selected.")
+    parser.add_option('-s', '--scope', type='string', metavar='dir',
+                      help="Open ranger with scope, so that ranger navigation is limited to supplied directory")
     parser.add_option('--show-only-dirs', action='store_true',
                       help="Show only directories, no files or links")
     parser.add_option('--list-unused-keys', action='store_true',
@@ -361,6 +366,19 @@ def parse_arguments():
         args.choosefiles = path_init('choosefiles')
     if args.choosedir:
         args.choosedir = path_init('choosedir')
+
+    if args.scope:
+        try:
+            scope_abs = os.path.abspath(os.path.expanduser(args.scope))
+        except OSError as ex:
+            sys.stderr.write(
+                '--scope is not accessible: {0}\n{1}\n'.format(args.scope, str(ex)))
+            sys.exit(1)
+        if not os.path.isdir(scope_abs):
+            sys.stderr.write(
+                '--scope is not a directory: {0}\n'.format(args.scope))
+            sys.exit(1)
+        args.scope = scope_abs
 
     return args
 

--- a/ranger/core/main.py
+++ b/ranger/core/main.py
@@ -6,7 +6,6 @@
 from __future__ import (absolute_import, division, print_function)
 
 import atexit
-from email.policy import default
 import locale
 import os.path
 import shutil
@@ -271,7 +270,7 @@ def xdg_path(env_var):
     return None
 
 
-def parse_arguments():
+def parse_arguments():  # pylint: disable=too-many-statements
     """Parse the program arguments"""
     from optparse import OptionParser  # pylint: disable=deprecated-module
     from ranger import CONFDIR, CACHEDIR, DATADIR, USAGE
@@ -310,7 +309,7 @@ def parse_arguments():
     parser.add_option('--selectfile', type='string', metavar='filepath',
                       help="Open ranger with supplied file selected.")
     parser.add_option('-s', '--scope', type='string', metavar='dir',
-                      help="Open ranger with scope, so that ranger navigation is limited to supplied directory")
+                      help="Limit ranger browsing inside provided scope directory")
     parser.add_option('--show-only-dirs', action='store_true',
                       help="Show only directories, no files or links")
     parser.add_option('--list-unused-keys', action='store_true',

--- a/ranger/core/tab.py
+++ b/ranger/core/tab.py
@@ -4,7 +4,7 @@
 from __future__ import (absolute_import, division, print_function)
 
 import os
-from os.path import abspath, normpath, join, expanduser, isdir, dirname
+from os.path import abspath, normpath, join, expanduser, isdir, dirname, commonprefix
 
 from ranger import PY3
 from ranger.container import settings
@@ -135,7 +135,11 @@ class Tab(FileManagerAware, SettingsAware):  # pylint: disable=too-many-instance
         # TODO: Ensure that there is always a self.thisdir
         if path is None:
             return None
-        path = str(path)
+        # get the absolute path
+        path = normpath(join(self.path, expanduser(str(path))))
+
+        if commonprefix([path, self.fm.root_dir]) != self.fm.root_dir:
+            return False
 
         # clear filter in the folder we're leaving
         if self.fm.settings.clear_filters_on_dir_change and self.thisdir:
@@ -144,8 +148,6 @@ class Tab(FileManagerAware, SettingsAware):  # pylint: disable=too-many-instance
 
         previous = self.thisdir
 
-        # get the absolute path
-        path = normpath(join(self.path, expanduser(path)))
         selectfile = None
 
         if not isdir(path):

--- a/ranger/core/tab.py
+++ b/ranger/core/tab.py
@@ -138,7 +138,9 @@ class Tab(FileManagerAware, SettingsAware):  # pylint: disable=too-many-instance
         # get the absolute path
         path = normpath(join(self.path, expanduser(str(path))))
 
-        if commonprefix([path, self.fm.root_dir]) != self.fm.root_dir:
+        root_dir = self.fm.root_dir
+
+        if commonprefix([path, root_dir]) != root_dir:
             return False
 
         # clear filter in the folder we're leaving
@@ -170,8 +172,8 @@ class Tab(FileManagerAware, SettingsAware):  # pylint: disable=too-many-instance
             self.pathway = (self.fm.get_directory('/'), )
         else:
             pathway = []
-            currentpath = '/'
-            for comp in path.split('/'):
+            currentpath = root_dir
+            for comp in path[len(root_dir):].split('/'):
                 currentpath = join(currentpath, comp)
                 pathway.append(self.fm.get_directory(currentpath))
             self.pathway = tuple(pathway)


### PR DESCRIPTION
<!-- Provide a descriptive summary of the changes in the title above -->

#### ISSUE TYPE
- Improvement/feature implementation

#### RUNTIME ENVIRONMENT
<!-- Details of your runtime environment -->
<!-- Retrieve Python/ranger version and locale with `ranger -\-version` -->
- Operating system and version:  macOS 12.6
- Terminal emulator and version: iTerm2 3.4.16
- Python version: 3.10.6 (main, Aug 30 2022, 05:12:36)
- Ranger version/commit: fcf44f6f12506fa0096cb6468de6a2706bbfaf51
- Locale: en_US.UTF-8

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [x] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [x] All changes follow the code style **[REQUIRED]**
- [x] All new and existing tests pass **[REQUIRED]**
- [ ] Changes require config files to be updated
    - [ ] Config files have been updated
- [x] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
Added `--scope` arguments to limit ranger browsing only inside the provided scope directory


#### MOTIVATION AND CONTEXT
Ranger can browse the entire filesystem. If used to navigate inside a project (e.g. as vim file explorer) is useful to limit ranger to browse only in a specific directory.

Fix #2693 


#### TESTING
<!-- What tests have been run? -->
<!-- How does the changes affect other areas of the codebase? -->
