### PR TITLE
[Feature] Display count of files to be deleted

### DIFF
--- a/ranger/config/commands.py
+++ b/ranger/config/commands.py
@@ -765,7 +765,7 @@ class delete(Command):
         confirm = self.fm.settings.confirm_on_delete
         if confirm != 'never' and (confirm != 'multiple' or many_files):
             self.fm.ui.console.ask(
-                "Confirm deletion of: %s (y/N)" % ', '.join(files),
+                "Confirm deletion of (total %s): %s (y/N)" % (len(files), ', '.join(files)),
                 partial(self._question_callback, files),
                 ('n', 'N', 'y', 'Y'),
             )
@@ -831,7 +831,7 @@ class trash(Command):
 
         if confirm != 'never' and (confirm != 'multiple' or many_files):
             self.fm.ui.console.ask(
-                "Confirm deletion of: %s (y/N)" % ', '.join(file_names),
+                "Confirm deletion of (total %s): %s (y/N)" % (len(files), ', '.join(files)),
                 partial(self._question_callback, files),
                 ('n', 'N', 'y', 'Y'),
             )

--- a/ranger/config/commands.py
+++ b/ranger/config/commands.py
@@ -757,7 +757,7 @@ class delete(Command):
         confirm = self.fm.settings.confirm_on_delete
         if confirm != 'never' and (confirm != 'multiple' or many_files):
             self.fm.ui.console.ask(
-                "Confirm deletion of: %s (y/N)" % ', '.join(files),
+                "Confirm deletion of (total %s): %s (y/N)" % (len(files), ', '.join(files)),
                 partial(self._question_callback, files),
                 ('n', 'N', 'y', 'Y'),
             )
@@ -819,7 +819,7 @@ class trash(Command):
         confirm = self.fm.settings.confirm_on_delete
         if confirm != 'never' and (confirm != 'multiple' or many_files):
             self.fm.ui.console.ask(
-                "Confirm deletion of: %s (y/N)" % ', '.join(file_names),
+                "Confirm deletion of (total %s): %s (y/N)" % (len(files), ', '.join(files)),
                 partial(self._question_callback, files),
                 ('n', 'N', 'y', 'Y'),
             )

--- a/ranger/config/commands.py
+++ b/ranger/config/commands.py
@@ -765,7 +765,7 @@ class delete(Command):
         confirm = self.fm.settings.confirm_on_delete
         if confirm != 'never' and (confirm != 'multiple' or many_files):
             self.fm.ui.console.ask(
-                "Confirm deletion of (total %s): %s (y/N)" % (len(files), ', '.join(files)),
+                "Confirm deletion of %s items: %s (y/N)" % (len(files), ', '.join(files)),
                 partial(self._question_callback, files),
                 ('n', 'N', 'y', 'Y'),
             )
@@ -831,7 +831,7 @@ class trash(Command):
 
         if confirm != 'never' and (confirm != 'multiple' or many_files):
             self.fm.ui.console.ask(
-                "Confirm deletion of (total %s): %s (y/N)" % (len(files), ', '.join(files)),
+                "Confirm deletion of %s items: %s (y/N)" % (len(files), ', '.join(file_names)),
                 partial(self._question_callback, files),
                 ('n', 'N', 'y', 'Y'),
             )


### PR DESCRIPTION
<!-- Provide a descriptive summary of the changes in the title above -->

#### ISSUE TYPE
<!-- Pick relevant types and delete the rest -->
Improvement/feature implementation

#### RUNTIME ENVIRONMENT
<!-- Details of your runtime environment -->
<!-- Retrieve Python/ranger version and locale with `ranger -\-version` -->
- Operating system and version: 
- Terminal emulator and version: 
- Python version: 
- Ranger version/commit: 
- Locale: 

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [x] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [x] All changes follow the code style **[REQUIRED]**
- [x] All new and existing tests pass **[REQUIRED]**
- [ ] Changes require config files to be updated
    - [ ] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
<!-- Describe the changes in detail -->
while deletion, additionally display the total count of files/directories getting deleted in the prompt
![image](https://user-images.githubusercontent.com/10793628/192503174-8062bab3-20f2-4442-8605-b02d95ff4513.png)

#### MOTIVATION AND CONTEXT
Currently if there are large number of files, it helps the user to know how many files may get deleted

#### TESTING
<!-- What tests have been run? -->
<!-- How does the changes affect other areas of the codebase? -->


#### IMAGES / VIDEOS<!-- Only if relevant -->
<!-- Link or embed images and videos of screenshots, sketches etc. -->
