### PR TITLE
Remove outdated information on security-relevant bugs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,6 @@
 * You can obtain much better error messages with `ranger --debug`, please post
   those in bug reports rather than the usual, single-line error message. Also
   check the log by using the default map `W` or by running the command `display_log`.
-* Send security-relevant bugs PGP-encrypted to hut@hut.pm, see `HACKING.md`.
 
 ## Tips on patching
 


### PR DESCRIPTION
#### ISSUE TYPE
- Bug fix

#### DESCRIPTION
info on security-relevant bugs has been removed from HACKING.md, yet CONTRIBUTING.md refers to it. This change removes the "dead link" in CONTRIBUTING.md.