### PR TITLE
Introduce setting to hide infostring in parent directories column.

### DIFF
--- a/doc/ranger.pod
+++ b/doc/ranger.pod
@@ -1081,6 +1081,10 @@ this pattern will hide all files that start with a dot or end with a tilde.
 
  set hidden_filter ^\.|~$
 
+=item hide_infostring_in_parent_directories [bool]
+
+Hide infostring in the parent directories column?
+
 =item hint_collapse_threshold [int]
 
 The key hint lists up to this size have their sublists expanded.

--- a/ranger/config/rc.conf
+++ b/ranger/config/rc.conf
@@ -29,6 +29,9 @@ set viewmode miller
 # How many columns are there, and what are their relative widths?
 set column_ratios 1,3,4
 
+# Hide infostring in the parent directories column?
+set hide_infostring_in_parent_directories false
+
 # Which files should be hidden? (regular expression)
 set hidden_filter ^\.|\.(?:pyc|pyo|bak|swp)$|^lost\+found$|^__(py)?cache__$
 

--- a/ranger/container/settings.py
+++ b/ranger/container/settings.py
@@ -46,6 +46,7 @@ ALLOWED_SETTINGS = {
     'freeze_files': bool,
     'global_inode_type_filter': str,
     'hidden_filter': str,
+    'hide_infostring_in_parent_directories': bool,
     'hint_collapse_threshold': int,
     'hostname_in_titlebar': bool,
     'size_in_bytes': bool,

--- a/ranger/gui/widgets/browsercolumn.py
+++ b/ranger/gui/widgets/browsercolumn.py
@@ -388,19 +388,20 @@ class BrowserColumn(Pager):  # pylint: disable=too-many-instance-attributes
             # info string
             infostring = []
             infostringlen = 0
-            try:
-                infostringdata = current_linemode.infostring(drawn, metadata)
-                if infostringdata:
-                    infostring.append([" " + infostringdata,
-                                       ["infostring"]])
-            except NotImplementedError:
-                infostring = self._draw_infostring_display(drawn, space)
-            if infostring:
-                infostringlen = self._total_len(infostring)
-                if space - infostringlen > 2:
-                    sep = [[" ", []]] if predisplay_right else []
-                    predisplay_right = infostring + sep + predisplay_right
-                    space -= infostringlen + len(sep)
+            if self.level >= 0 or not self.settings.hide_infostring_in_parent_directories:
+                try:
+                    infostringdata = current_linemode.infostring(drawn, metadata)
+                    if infostringdata:
+                        infostring.append([" " + infostringdata,
+                                           ["infostring"]])
+                except NotImplementedError:
+                    infostring = self._draw_infostring_display(drawn, space)
+                if infostring:
+                    infostringlen = self._total_len(infostring)
+                    if space - infostringlen > 2:
+                        sep = [[" ", []]] if predisplay_right else []
+                        predisplay_right = infostring + sep + predisplay_right
+                        space -= infostringlen + len(sep)
 
             textstring = self._draw_text_display(text, space)
             textstringlen = self._total_len(textstring)


### PR DESCRIPTION
Added a setting to hide the infostring in the left column showing parent directories.

I am using https://github.com/alexanderjeurissen/ranger_devicons and _default_linemode devicons-sizemtime_. But I wanted to omit _sizemtime_ only in the left column.

#### ISSUE TYPE
- Improvement

#### RUNTIME ENVIRONMENT
- Operating system and version: Manjaro Linux 22.0.0
- Terminal emulator and version: st 0.8.2, tmux 3.3_a-2, zsh 5.9-1
- Python version: 3.10.7
- Ranger version/commit: ranger-master v1.9.3-526-g7171fe43
- Locale: de_DE.UTF-8

#### CHECKLIST
- [X] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [X] All changes follow the code style **[REQUIRED]**
- [X] All new and existing tests pass **[REQUIRED]**
- [X] Changes require config files to be updated
    - [X] Config files have been updated
- [X] Changes require documentation to be updated
    - [X] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
Just added a flag to hide the infostring in parent directories column (level < 0).


#### MOTIVATION AND CONTEXT
When the width of the left column is too small to show names and sizemtime I wanted to hide sizemtime (infostring).


#### TESTING
make test runs fine

#### ADDITIONAL INFORMATION
When I executed _make man_ there have been a lot of changes in _doc/ranger.1_ which would revert most changes of commit 7171fe43b7f3568fc8fcfc085077ae615010dc1a. So I left these changes out of this pull request.