### PR TITLE
rifle.conf: include xdg-open fallback for pdf's

### DIFF
--- a/ranger/config/rifle.conf
+++ b/ranger/config/rifle.conf
@@ -154,6 +154,7 @@ ext pdf, has atril,    X, flag f = atril -- "$@"
 ext pdf, has okular,   X, flag f = okular -- "$@"
 ext pdf, has epdfview, X, flag f = epdfview -- "$@"
 ext pdf, has qpdfview, X, flag f = qpdfview "$@"
+ext pdf, has xdg-open, X, flag f = xdg-open "$@"
 ext pdf, has open,     X, flag f = open "$@"
 
 ext sc,    has sc,                    = sc -- "$@"


### PR DESCRIPTION
<!-- Provide a descriptive summary of the changes in the title above -->

#### ISSUE TYPE
<!-- Pick relevant types and delete the rest -->
- Improvement/feature implementation

#### RUNTIME ENVIRONMENT
<!-- Details of your runtime environment -->
<!-- Retrieve Python/ranger version and locale with `ranger -\-version` -->
- Operating system and version: `archlinux 6.0.6`
- Terminal emulator and version: `alacritty 0.11.0`
- Python version: `3.10.8`
- Ranger version/commit: `1.9.3`
- Locale: `en_US.UTF-8`

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [x] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [x] All changes follow the code style **[REQUIRED]**
- [x] All new and existing tests pass **[REQUIRED]**
- [x] Changes require config files to be updated
- [ ] Config files have been updated
- [ ] Changes require documentation to be updated
- [x] Documentation has been updated
- [ ] Changes require tests to be updated
- [x] Tests have been updated

#### DESCRIPTION
<!-- Describe the changes in detail -->
When not having any pdf viewer, instead of not opening pdf at all, fallback to xdg-opener (which opens in an existing browser according to it's MimeType).