### PR TITLE
Don't strip commands of trailing spaces

### DIFF
--- a/ranger/core/actions.py
+++ b/ranger/core/actions.py
@@ -375,7 +375,7 @@ class Actions(  # pylint: disable=too-many-instance-attributes,too-many-public-m
         # pylint: disable=unspecified-encoding
         with open(filename, 'r', encoding="utf-8") as fobj:
             for line in fobj:
-                line = line.strip(" \r\n")
+                line = line.strip("\r\n")
                 if line.startswith("#") or not line.strip():
                     continue
                 try:


### PR DESCRIPTION
It is nice be able to have trailing spaces in commands because it reduces the amount of keystrokes the user needs to use. For example if a user wants to create a shortcut for `touch` they'd like to have a trailing space which allows them to immediatly start typing the name of the file they are creating.

<!-- Provide a descriptive summary of the changes in the title above -->
No longer remove trailing whitespaces from commands in rc.conf

#### ISSUE TYPE
<!-- Pick relevant types and delete the rest -->
- Improvement/feature implementation 

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [x] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [x] All changes follow the code style **[REQUIRED]**
- [x] All new and existing tests pass **[REQUIRED]**
- [ ] Changes require config files to be updated
    - [ ] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
Removed a single whitespace character from the strip function when reading commands from `rc.conf`.


#### MOTIVATION AND CONTEXT
<!-- Why are these changes required? -->
Removing the trailing whitespaces from commands makes users have to press space after using a custom mapped command.
For example if you map "to" to "console touch " you will end up with "console touch" which will force you to press space.
<!-- Link to relevant issues -->
I don't know of any relevant issues, this fix is so small that I figured it would be easier to do it myself than open an issue.

#### TESTING
<!-- What tests have been run? -->
All of them
<!-- How does the changes affect other areas of the codebase? -->
It does not
