### PR TITLE
Recommend use of pipx over pip installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,10 @@ For enhanced file previews (with `scope.sh`):
 Installing
 ----------
 Use the package manager of your operating system to install ranger.
-You can also install ranger through PyPI: ```pip install ranger-fm```.
+You can also install ranger through PyPI: `pip install ranger-fm`.
+However, it is recommended to use [`pipx`](https://pypa.github.io/pipx/) instead
+(to benefit from isolated environments). Use
+`pipx run --spec ranger-fm ranger` to install and run ranger in one step.
 
 <details>
   <summary>


### PR DESCRIPTION
#### ISSUE TYPE

Documentation

#### RUNTIME ENVIRONMENT
<!-- Details of your runtime environment -->
<!-- Retrieve Python/ranger version and locale with `ranger -\-version` -->
- Operating system and version: 
- Terminal emulator and version: 
- Python version: 
- Ranger version/commit: 
- Locale: 

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [x] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [x] All changes follow the code style **[REQUIRED]**
- [x] All new and existing tests pass **[REQUIRED]**
- [ ] Changes require config files to be updated
    - [ ] Config files have been updated
- [x] Changes require documentation to be updated
    - [x] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION

Recommend the use of [`pipx`](https://pypa.github.io/pipx/) over pip installations.

#### MOTIVATION AND CONTEXT

pipx installs ranger in an isolated environment and `pipx run` commands will also not be "distracted" by conda or virtual environments (avoiding having to install ranger for every such environment separately)

#### TESTING

No code changed.