### PR TITLE
scope.sh: Enable DjVu previews by default

### DIFF
--- a/ranger/data/scope.sh
+++ b/ranger/data/scope.sh
@@ -147,10 +147,10 @@ handle_image() {
             exit 1;;
 
         ## DjVu
-        # image/vnd.djvu)
-        #     ddjvu -format=tiff -quality=90 -page=1 -size="${DEFAULT_SIZE}" \
-        #           - "${IMAGE_CACHE_PATH}" < "${FILE_PATH}" \
-        #           && exit 6 || exit 1;;
+        image/vnd.djvu)
+            ddjvu -format=tiff -quality=90 -page=1 -size="${DEFAULT_SIZE}" \
+                  - "${IMAGE_CACHE_PATH}" < "${FILE_PATH}" \
+                  && exit 6 || exit 1;;
 
         ## Image
         image/*)


### PR DESCRIPTION
ImageMagick requires a large amount of memory to process DjVu files and is run on anything with a MIME type matching `image/*`. By enabling the special case for DjVu files by default, we either use `ddjvu` or we exit instead of trying to run them through ImageMagick. Preventing this from happening.

Fixes #2366