### PR TITLE
ranger.py: Allow passing -flags and --options when sourcing

### DIFF
--- a/ranger.py
+++ b/ranger.py
@@ -14,7 +14,7 @@ ranger="${1:-ranger}"
 if [ -n "$1" ]; then
     shift
 fi
-"$ranger" --choosedir="$temp_file" -- "${@:-$PWD}"
+"$ranger" --choosedir="$temp_file" "$@"
 return_value="$?"
 if chosen_dir="$(cat -- "$temp_file")" && [ -n "$chosen_dir" ] && [ "$chosen_dir" != "$PWD" ]; then
     cd -- "$chosen_dir"


### PR DESCRIPTION
A previous refactor prefixed any arguments passed when sourcing the `ranger.py` polyglot with ` -- ` in an attempt to prevent accidentally interpreting a path as flags or options. Because of the quoting involved this is not actually necessary and only serves to prevent passing flags and options when sourcing the script.

Another thing that came up in discussion for PR #1743 is whether or not to explicitly replace an empty argument list with the PWD. In particular because of concerns around relying on Ranger's implicit behavior of opening the PWD when no arguments are passed. Since this behavior is already relied upon when any arguments that are not paths are passed, it should be reasonable to rely on this behavior when no arguments are passed. Furthermore, if the implicit behavior does ever change it will prevent a possibly unexpected difference in behavior.

Fixes #2187