### PR TITLE
img_display: Restore cleanup of Kitty tempfiles

### DIFF
--- a/ranger/ext/img_display.py
+++ b/ranger/ext/img_display.py
@@ -27,7 +27,7 @@ from collections import defaultdict
 import termios
 from contextlib import contextmanager
 import codecs
-from tempfile import NamedTemporaryFile
+from tempfile import gettempdir, NamedTemporaryFile
 
 from ranger import PY3
 from ranger.core.shared import FileManagerAware, SettingsAware
@@ -607,6 +607,17 @@ class KittyImageDisplayer(ImageDisplayer, FileManagerAware):
         # if resp.find(b'OK') != -1:
         if b'OK' in resp:
             self.stream = False
+            self.tempFileDir = os.path.join(
+                gettempdir(), "tty-graphics-protocol"
+            )
+            try:
+                os.mkdir(self.tempFileDir)
+            except OSError:
+                raise ImgDisplayUnsupportedException(
+                    "Could not create temporary directory for previews : {d}".format(
+                        d=tempFileDir
+                    )
+                )
         elif b'EBADF' in resp:
             self.stream = True
         else:
@@ -681,7 +692,12 @@ class KittyImageDisplayer(ImageDisplayer, FileManagerAware):
             #       the only format except raw RGB(A) bitmap that kitty understand)
             # c, r: size in cells of the viewbox
             cmds.update({'t': 't', 'f': 100, })
-            with NamedTemporaryFile(prefix='ranger_thumb_', suffix='.png', delete=False) as tmpf:
+            with NamedTemporaryFile(
+                prefix='ranger_thumb_',
+                suffix='.png',
+                dir=self.tempFileDir,
+                delete=False,
+            ) as tmpf:
                 image.save(tmpf, format='png', compress_level=0)
                 payload = base64.standard_b64encode(tmpf.name.encode(self.fsenc))
 

--- a/ranger/ext/img_display.py
+++ b/ranger/ext/img_display.py
@@ -612,12 +612,19 @@ class KittyImageDisplayer(ImageDisplayer, FileManagerAware):
             )
             try:
                 os.mkdir(self.tempFileDir)
+            except FileExistsError:
+                # We only need to ensure the directory exists
+                pass
             except OSError:
-                raise ImgDisplayUnsupportedException(
-                    "Could not create temporary directory for previews : {d}".format(
-                        d=self.tempFileDir
+                # Python 2.7 does not raise FileExistsError so we have to check
+                # whether the problem is the directory already being present.
+                # This is prone to race conditions, TOCTOU.
+                if not os.path.isdir(self.tempFileDir):
+                    raise ImgDisplayUnsupportedException(
+                        "Could not create temporary directory for previews : {d}".format(
+                            d=self.tempFileDir
+                        )
                     )
-                )
         elif b'EBADF' in resp:
             self.stream = True
         else:

--- a/ranger/ext/img_display.py
+++ b/ranger/ext/img_display.py
@@ -615,7 +615,7 @@ class KittyImageDisplayer(ImageDisplayer, FileManagerAware):
             except OSError:
                 raise ImgDisplayUnsupportedException(
                     "Could not create temporary directory for previews : {d}".format(
-                        d=tempFileDir
+                        d=self.tempFileDir
                     )
                 )
         elif b'EBADF' in resp:

--- a/ranger/ext/img_display.py
+++ b/ranger/ext/img_display.py
@@ -613,13 +613,10 @@ class KittyImageDisplayer(ImageDisplayer, FileManagerAware):
             )
             try:
                 os.mkdir(self.temp_file_dir)
-            except FileExistsError:
-                # We only need to ensure the directory exists
-                pass
             except OSError:
-                # Python 2.7 does not raise FileExistsError so we have to check
-                # whether the problem is the directory already being present.
-                # This is prone to race conditions, TOCTOU.
+                # COMPAT: Python 2.7 does not define FileExistsError so we have
+                # to check whether the problem is the directory already being
+                # present. This is prone to race conditions, TOCTOU.
                 if not os.path.isdir(self.temp_file_dir):
                     raise ImgDisplayUnsupportedException(
                         "Could not create temporary directory for previews : {d}".format(


### PR DESCRIPTION
Kitty version 0.26.0 stopped removing temporary files used in the Kitty Image Protocol unless their full path contains the string "tty-graphics-protocol," so we need to adapt to the new behavior.

By using a subdirectory of the directory used for temporary files with the appropriate name, Kitty should again delete the temporary PNGs we generate. An added benefit of using a subdirectory is avoiding cluttering up the directory for temporary files. This subdirectory is not cleaned up by Ranger and will remain as an empty directory (if previews work correctly) until removed by other means.

Fixes #2699