### PR TITLE
Tolerate missing paths

### DIFF
--- a/ranger/container/bookmarks.py
+++ b/ranger/container/bookmarks.py
@@ -242,6 +242,7 @@ class Bookmarks(FileManagerAware):
                             try:
                                 dct[key] = self.bookmarktype(value)
                             except ValueError:
+                                dct[key] = str(value)
                                 self.fm.notify(
                                     "Bookmark {0} points to file '{1}', instead of a directory".format(
                                         key, value

--- a/ranger/container/bookmarks.py
+++ b/ranger/container/bookmarks.py
@@ -239,7 +239,14 @@ class Bookmarks(FileManagerAware):
                     if self.load_pattern.match(line):
                         key, value = line[0], line[2:-1]
                         if key in ALLOWED_KEYS:
-                            dct[key] = self.bookmarktype(value)
+                            try:
+                                dct[key] = self.bookmarktype(value)
+                            except ValueError:
+                                self.fm.notify(
+                                    "Bookmark {0} points to file '{1}', instead of a directory".format(
+                                        key, value
+                                    )
+                                )
         except OSError as ex:
             self.fm.notify('Bookmarks error: {0}'.format(str(ex)), bad=True)
             return None

--- a/ranger/container/bookmarks.py
+++ b/ranger/container/bookmarks.py
@@ -244,9 +244,10 @@ class Bookmarks(FileManagerAware):
                             except ValueError:
                                 dct[key] = str(value)
                                 self.fm.notify(
-                                    "Bookmark {0} points to file '{1}', instead of a directory".format(
-                                        key, value
-                                    )
+                                    (
+                                        "Bookmark {0} points to path '{1}', "
+                                        + "which is not  a directory"
+                                    ).format(key, value)
                                 )
         except OSError as ex:
             self.fm.notify('Bookmarks error: {0}'.format(str(ex)), bad=True)

--- a/ranger/container/directory.py
+++ b/ranger/container/directory.py
@@ -127,7 +127,12 @@ class Directory(  # pylint: disable=too-many-instance-attributes,too-many-public
     }
 
     def __init__(self, path, **kw):
-        assert not os.path.isfile(path), "No directory given!"
+        if os.path.isfile(path):
+            raise ValueError(
+                "Expecting a path to a directory but '{0}' is a file".format(
+                    path
+                )
+            )
 
         Loadable.__init__(self, None, None)
         Accumulator.__init__(self)

--- a/ranger/container/directory.py
+++ b/ranger/container/directory.py
@@ -127,12 +127,8 @@ class Directory(  # pylint: disable=too-many-instance-attributes,too-many-public
     }
 
     def __init__(self, path, **kw):
-        if os.path.isfile(path):
-            raise ValueError(
-                "Expecting a path to a directory but '{0}' is a file".format(
-                    path
-                )
-            )
+        if not os.path.isdir(path):
+            raise ValueError("Not a directory: '{0}'".format(path))
 
         Loadable.__init__(self, None, None)
         Accumulator.__init__(self)

--- a/ranger/gui/widgets/view_base.py
+++ b/ranger/gui/widgets/view_base.py
@@ -88,7 +88,7 @@ class ViewBase(Widget, DisplayableContainer):  # pylint: disable=too-many-instan
         whitespace = " " * maxlen
         for line, items in zip(range(self.hei - 1), sorted_bookmarks):
             key, mark = items
-            string = " " + key + "   " + mark.path
+            string = " " + key + "   " + str(mark)
             self.addstr(ystart + line, 0, whitespace)
             self.addnstr(ystart + line, 0, string, self.wid)
 


### PR DESCRIPTION
Bookmarks can sometimes point to invalid paths, be they on removable media or since replaced by files rather than directories. Ranger rather inelegantly crashes when this happens without notifying users about the reason at all. (Unless Python's run with the optimize flag in which case Ranger happily creates a `Directory` object that actually represents a file until such time when shenanigans happen.)

This PR makes instantiating a `Directory` object with a file path an exception, preventing shenanigans. It reports bookmarked paths that are invalid. And it tries to retain invalid bookmarks across Ranger invocations so the user can deal with them at their leisure.