### PR TITLE
Disable multiplexer title renaming in Microsoft WSL

### DIFF
--- a/ranger/gui/ui.py
+++ b/ranger/gui/ui.py
@@ -50,14 +50,19 @@ def _setup_mouse(signal):
         curses.mousemask(0)
 
 
+def _in_wsl():
+    # Check if the current environment is Microsoft WSL instead of native Linux
+    with open('/proc/sys/kernel/osrelease', encoding="utf-8") as file:
+        return 'microsoft' in file.read().lower()
+
+
 def _in_tmux():
-    return (os.environ.get("TMUX", "")
-            and 'tmux' in get_executables())
+    return False if _in_wsl() else (os.environ.get("TMUX", "") and 'tmux' in get_executables())
 
 
 def _in_screen():
-    return ('screen' in os.environ.get("TERM", "")
-            and 'screen' in get_executables())
+    return False if _in_wsl() else \
+        ('screen' in os.environ.get("TERM", "") and 'screen' in get_executables())
 
 
 class UI(  # pylint: disable=too-many-instance-attributes,too-many-public-methods


### PR DESCRIPTION
#### ISSUE TYPE
- Improvement/feature implementation

#### RUNTIME ENVIRONMENT
- Operating system and version: Ubuntu 22.04 on 5.15.79.1-microsoft-standard-WSL2
- Terminal emulator and version: Windows Terminal 1.15.3465.0, tmux next-3.4, zsh 5.8.1
- Python version: 3.10.6
- Ranger version/commit: ranger-master
- Locale: en_US.UTF-8

#### CHECKLIST
- [X] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [X] All changes follow the code style **[REQUIRED]**
- [X] All new and existing tests pass **[REQUIRED]**
- [ ] Changes require config files to be updated
    - [ ] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
Modify the behavior of the _in_tmux and _in_screen functions added in https://github.com/ranger/ranger/commit/1cdcce0a44d031be13009a70e25cc4cf75789eac to detect if the current environment is not native Linux but Microsoft WSL and return False in this case to prevent calling the get_executables function.

#### MOTIVATION AND CONTEXT
get_executables function, extremely slows Ranger startup due to parsing `/mnt/ c/*` directories from $PATH (for example, directories such as `/mnt/c/Users/`, `/mnt/c/WINDOWS/System32/`, '/mnt/c/Program Files/`, etc. located on an NTFS Windows drive.)

#### TESTING
This is a minor local change that does not affect other areas of the codebase in any way.
I did `make test` and all tests passed!