### PR TITLE
Enable sixel output support for ueberzug

### DIFF
--- a/ranger/ext/img_display.py
+++ b/ranger/ext/img_display.py
@@ -764,16 +764,15 @@ class UeberzugImageDisplayer(ImageDisplayer, FileManagerAware):
         else:
             self.win.mvwin(start_y, start_x)
             self.win.resize(height, width)
-        with temporarily_moved_cursor(start_y, start_x):
-            self._execute(
-                action='add',
-                identifier=self.IMAGE_ID,
-                x=start_x,
-                y=start_y,
-                max_width=width,
-                max_height=height,
-                path=path
-            )
+        self._execute(
+            action='add',
+            identifier=self.IMAGE_ID,
+            x=start_x,
+            y=start_y,
+            max_width=width,
+            max_height=height,
+            path=path
+        )
 
     def clear(self, start_x, start_y, width, height):
         if self.win is not None:


### PR DESCRIPTION
<!-- Provide a descriptive summary of the changes in the title above -->

#### ISSUE TYPE
- Improvement/feature implementation

#### RUNTIME ENVIRONMENT
<!-- Details of your runtime environment -->
<!-- Retrieve Python/ranger version and locale with `ranger -\-version` -->
- Operating system and version: 
- Terminal emulator and version:  Alacritty 0.11.0
- Python version:  CPython 3.10
- Ranger version/commit:  1.9.3
- Locale: 

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [X] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [X] All changes follow the code style **[REQUIRED]**
- [X] All new and existing tests pass **[REQUIRED]**
- [ ] Changes require config files to be updated
    - [ ] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
<!-- Describe the changes in detail -->
Connect stdout and properly clear preview area, fixes #723 

#### MOTIVATION AND CONTEXT
<!-- Why are these changes required? -->
<!-- What problems do these changes solve? -->
<!-- Link to relevant issues -->

I've been working on [ueberzugpp](https://github.com/jstkdng/ueberzugpp) after ueberzug was killed by its maintainer. It is written in C++, supports more image formats, is faster when resizing if required (due to using opencv) and supports both X11 (original ueberzug) and sixel image displaying.

Since it is a drop-in replacement, the X11 display works with current ranger without a problem. For the sixel display to work it is required to connect ranger's stdout to `ueberzugpp`'s stdout.

Almost all of this changes have been obtained from #2466.

#### TESTING
<!-- What tests have been run? -->
<!-- How does the changes affect other areas of the codebase? -->

This has been tested with current ranger.

#### IMAGES / VIDEOS<!-- Only if relevant -->
<!-- Link or embed images and videos of screenshots, sketches etc. -->

`ueberzugpp`'s sixel display working with konsole.

![image](https://user-images.githubusercontent.com/52050345/218314888-a3e0f0f2-1322-4bdc-9892-6c882c0e8644.png)
