### PR TITLE
Remove the legacy filename filters, replace them with a compatibility layer utilizing the filter stack

### DIFF
--- a/ranger/config/commands.py
+++ b/ranger/config/commands.py
@@ -1815,6 +1815,18 @@ class filter_stack(Command):
             )
             return
 
+        # Cleanup.
+        self.cancel()
+
+    def quick(self):
+        if self.rest(1).startswith("add name "):
+            self.fm.thisdir.temporary_filter = re.compile(self.rest(3))
+            self.fm.thisdir.refilter()
+
+        return False
+
+    def cancel(self):
+        self.fm.thisdir.temporary_filter = None
         self.fm.thisdir.refilter()
 
 

--- a/ranger/container/directory.py
+++ b/ranger/container/directory.py
@@ -11,8 +11,8 @@ import re
 from collections import deque
 from time import time
 
-import ranger.core.filter_stack as filter_stack
 from ranger.container.fsobject import BAD_INFO, FileSystemObject
+from ranger.core import filter_stack
 from ranger.core.filter_stack import InodeFilterConstants, accept_file
 from ranger.core.loader import Loadable
 from ranger.ext.mount_path import mount_path

--- a/ranger/container/directory.py
+++ b/ranger/container/directory.py
@@ -11,7 +11,9 @@ import re
 from collections import deque
 from time import time
 
+import ranger.core.filter_stack as filter_stack
 from ranger.container.fsobject import BAD_INFO, FileSystemObject
+from ranger.core.filter_stack import InodeFilterConstants, accept_file
 from ranger.core.loader import Loadable
 from ranger.ext.mount_path import mount_path
 from ranger.container.file import File
@@ -57,21 +59,6 @@ def sort_unicode_wrapper_list(old_sort_func):
     return sort_unicode
 
 
-def accept_file(fobj, filters):
-    """
-    Returns True if file shall be shown, otherwise False.
-    Parameters:
-        fobj - an instance of FileSystemObject
-        filters - an array of lambdas, each expects a fobj and
-                  returns True if fobj shall be shown,
-                  otherwise False.
-    """
-    for filt in filters:
-        if filt and not filt(fobj):
-            return False
-    return True
-
-
 def walklevel(some_dir, level):
     some_dir = some_dir.rstrip(os.path.sep)
     followlinks = level > 0
@@ -93,12 +80,6 @@ def mtimelevel(path, level):
     return mtime
 
 
-class InodeFilterConstants(object):  # pylint: disable=too-few-public-methods
-    DIRS = 'd'
-    FILES = 'f'
-    LINKS = 'l'
-
-
 class Directory(  # pylint: disable=too-many-instance-attributes,too-many-public-methods
         FileSystemObject, Accumulator, Loadable):
     is_directory = True
@@ -112,7 +93,6 @@ class Directory(  # pylint: disable=too-many-instance-attributes,too-many-public
     filenames = None
     files = None
     files_all = None
-    filter = None
     temporary_filter = None
     narrow_filter = None
     inode_type_filter = None
@@ -170,6 +150,46 @@ class Directory(  # pylint: disable=too-many-instance-attributes,too-many-public
         self.settings = LocalSettings(path, self.settings)
 
         self.use()
+
+    @property
+    def filter(self):
+        """A compatibility layer between the legacy filters and the filter stack."""
+
+        if not self.filter_stack:
+            return None
+
+        topmost_filter = self.filter_stack[-1]
+        if isinstance(topmost_filter, filter_stack.NameFilter):
+            return topmost_filter.regex
+
+        return None
+
+    @filter.setter
+    def filter(self, new_filter):
+        if not self.filter_stack:
+            # No filters applied at all, a trivial case.
+            if new_filter:
+                self.filter_stack.append(filter_stack.NameFilter(new_filter))
+            return
+
+        topmost_filter = self.filter_stack[-1]
+
+        if isinstance(topmost_filter, filter_stack.NameFilter):
+            # The topmost filter is a simple name filter.  Let's
+            # replace it, or possibly remove it if the new one
+            # is empty.
+            if new_filter:
+                # Consider the possibility of it being a filter
+                # derived from NameFilter.  Let's use the actual class
+                # it belonged to.
+                topmost_filter_class = type(topmost_filter)
+                self.filter_stack[-1] = topmost_filter_class(new_filter)
+            else:
+                self.filter_stack.pop()
+        else:
+            # Append a new filter as the existing ones are non-trivial.
+            if new_filter:
+                self.filter_stack.append(filter_stack.NameFilter(new_filter))
 
     @lazy_property
     def vcs(self):
@@ -293,9 +313,6 @@ class Directory(  # pylint: disable=too-many-instance-attributes,too-many-public
                     return True
                 return False
             filters.append(inode_filter_func)
-        if self.filter:
-            filter_search = self.filter.search
-            filters.append(lambda fobj: filter_search(fobj.basename))
         if self.temporary_filter:
             temporary_filter_search = self.temporary_filter.search
             filters.append(lambda fobj: temporary_filter_search(fobj.basename))

--- a/ranger/core/filter_stack.py
+++ b/ranger/core/filter_stack.py
@@ -67,20 +67,18 @@ def filter_combinator(combinator_name):
 @stack_filter("name")
 class NameFilter(BaseFilter):
     def __init__(self, pattern):
-        self.pattern = pattern
         self.regex = re.compile(pattern)
 
     def __call__(self, fobj):
         return self.regex.search(fobj.relative_path)
 
     def __str__(self):
-        return "<Filter: name =~ /{pat}/>".format(pat=self.pattern)
+        return "<Filter: name =~ /{pat}/>".format(pat=self.regex.pattern)
 
 
 @stack_filter("mime")
 class MimeFilter(BaseFilter, FileManagerAware):
     def __init__(self, pattern):
-        self.pattern = pattern
         self.regex = re.compile(pattern)
 
     def __call__(self, fobj):
@@ -90,7 +88,7 @@ class MimeFilter(BaseFilter, FileManagerAware):
         return self.regex.search(mimetype)
 
     def __str__(self):
-        return "<Filter: mimetype =~ /{pat}/>".format(pat=self.pattern)
+        return "<Filter: mimetype =~ /{pat}/>".format(pat=self.regex.pattern)
 
 
 @stack_filter("hash")

--- a/ranger/core/filter_stack.py
+++ b/ranger/core/filter_stack.py
@@ -14,11 +14,31 @@ except ImportError:
 # pylint: enable=invalid-name
 from os.path import abspath
 
-from ranger.container.directory import accept_file, InodeFilterConstants
 from ranger.core.shared import FileManagerAware
 from ranger.ext.hash import hash_chunks
 
 # pylint: disable=too-few-public-methods
+
+
+class InodeFilterConstants(object):
+    DIRS = "d"
+    FILES = "f"
+    LINKS = "l"
+
+
+def accept_file(fobj, filters):
+    """
+    Returns True if file shall be shown, otherwise False.
+    Parameters:
+        fobj - an instance of FileSystemObject
+        filters - an array of lambdas, each expects a fobj and
+                  returns True if fobj shall be shown,
+                  otherwise False.
+    """
+    for filt in filters:
+        if filt and not filt(fobj):
+            return False
+    return True
 
 
 class BaseFilter(object):


### PR DESCRIPTION
I've removed the original filtering mechanism ranger used to use, and replaced it with a thin compatibility layer that utilizes the newer filter stack mechanism. While I was at it, I also added live previews for the `:filter_stack add name` command just like the ones we have in `:filter`.

#### ISSUE TYPE
<!-- Pick relevant types and delete the rest -->
- Improvement/feature implementation

#### RUNTIME ENVIRONMENT
<!-- Details of your runtime environment -->
<!-- Retrieve Python/ranger version and locale with `ranger -\-version` -->
- Operating system and version: NixOS 22.11
- Terminal emulator and version: Alacritty 0.11.0
- Python version: 3.10.9
- Ranger version/commit: N/A
- Locale: en_US.UTF-8

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [X] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [ ] All changes follow the code style **[REQUIRED]**
- [ ] All new and existing tests pass **[REQUIRED]**
- [ ] Changes require config files to be updated
    - [ ] Config files have been updated
- [X] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
<!-- Describe the changes in detail -->

Assuming no explicit filter stack manipulation occurs, the semantics should be the same as before. If filter stack is being actively used, the compatibility layer either edits the topmost filter (if it's a name-based one), or adds a new element to the filter stack (all the other cases). Both such a new filter stack node and the legacy filtering mechanism are logically AND-ed with the rest of the filter stack, so the semantics are still mostly preserved.

The "inode type filters" are left intact for now. Considering they are both more complex (there are both global and local inode type filters) and less commonly used, it might be reasonable to just leave them be, at least for a time being.

It might be desirable to replace the internal "temporary filter" mechanism with a fully fledged "temporary filter stack node" that would be processed by the unified filter stack system. Possibly with a similar compatibility layer.

Some definitions got moved to `filter_stack.py` to prevent circular imports between it and `directory.py`. I believe these definitions should end up there anyway if we continue to unify the filtering system.

#### MOTIVATION AND CONTEXT
<!-- Why are these changes required? -->
<!-- What problems do these changes solve? -->
<!-- Link to relevant issues -->

Currently ranger has 3-5 (depending on who you ask and how you count) independent filtering systems. They work, but it's confusing both for the users and for the maintainers. This is a start.

#### TESTING
<!-- What tests have been run? -->
<!-- How does the changes affect other areas of the codebase? -->

I've manually tested `.n`, `zf` and the other filter stack keys to check if they still work correctly.