### PR TITLE
Fix Python 2 support related to Subprocess

### DIFF
--- a/ranger/ext/img_display.py
+++ b/ranger/ext/img_display.py
@@ -21,7 +21,7 @@ import sys
 import warnings
 import json
 import threading
-from subprocess import Popen, PIPE, DEVNULL
+from subprocess import Popen, PIPE
 from collections import defaultdict
 
 import termios
@@ -761,13 +761,14 @@ class UeberzugImageDisplayer(ImageDisplayer):
 
         # We cannot close the process because that stops the preview.
         # pylint: disable=consider-using-with
-        self.process = Popen(
-            ["ueberzug", "layer", "--silent"],
-            cwd=self.working_dir,
-            stderr=DEVNULL,
-            stdin=PIPE,
-            universal_newlines=True,
-        )
+        with open(os.devnull, "wb") as devnull:
+            self.process = Popen(
+                ["ueberzug", "layer", "--silent"],
+                cwd=self.working_dir,
+                stderr=devnull,
+                stdin=PIPE,
+                universal_newlines=True,
+            )
         self.is_initialized = True
 
     def _execute(self, **kwargs):

--- a/ranger/ext/rifle.py
+++ b/ranger/ext/rifle.py
@@ -82,7 +82,7 @@ except ImportError:
     #         support.
     from contextlib import contextmanager
     # pylint: disable=ungrouped-imports
-    from subprocess import Popen, TimeoutExpired
+    from subprocess import Popen
 
     try:
         from ranger import PY3
@@ -121,7 +121,9 @@ except ImportError:
                     try:
                         # pylint: disable=no-member
                         popen2._wait(timeout=popen2._sigint_wait_secs)
-                    except TimeoutExpired:
+                    except Exception:  # pylint: disable=broad-except
+                        # COMPAT: This is very broad but Python 2.7 does not
+                        # have TimeoutExpired, nor SubprocessError
                         pass
                 popen2._sigint_wait_secs = 0  # Note that this's been done.
                 # pylint: disable=lost-exception


### PR DESCRIPTION
Accidentally introduced names that were introduced in Python 3. TimeoutExpired inherits from SubprocessError, which isn't in Python2 either, which inherits from Exception. Way too broad but not really another option.

DEVNULL was also introduced to the subprocess module later. Passing in `os.devnull` should be more or less equivalent in behavior.