### PR TITLE
Fix the ABC checks on Python 3

### DIFF
--- a/ranger/core/linemode.py
+++ b/ranger/core/linemode.py
@@ -11,10 +11,17 @@ from datetime import datetime
 from ranger.ext.human_readable import human_readable, human_readable_time
 from ranger.ext import spawn
 
+try:
+    from abc import ABC
+except ImportError:
+    class ABC(object):
+        __metaclass__ = ABCMeta
+
+
 DEFAULT_LINEMODE = "filename"
 
 
-class LinemodeBase(object):
+class LinemodeBase(ABC):
     """Supplies the file line contents for BrowserColumn.
 
     Attributes:
@@ -26,7 +33,6 @@ class LinemodeBase(object):
             If any of these metadata fields are absent, fall back to
             the default linemode
     """
-    __metaclass__ = ABCMeta
 
     uses_metadata = False
     required_metadata = []

--- a/ranger/core/linemode.py
+++ b/ranger/core/linemode.py
@@ -12,9 +12,9 @@ from ranger.ext.human_readable import human_readable, human_readable_time
 from ranger.ext import spawn
 
 try:
-    from abc import ABC
+    from abc import ABC       # pylint: disable=ungrouped-imports
 except ImportError:
-    class ABC(object):
+    class ABC(object):        # pylint: disable=too-few-public-methods
         __metaclass__ = ABCMeta
 
 


### PR DESCRIPTION
#### ISSUE TYPE
<!-- Pick relevant types and delete the rest -->
- Bug fix


#### RUNTIME ENVIRONMENT
<!-- Details of your runtime environment -->
<!-- Retrieve Python/ranger version and locale with `ranger -\-version` -->
- Operating system and version: N/A
- Terminal emulator and version: N/A
- Python version: Python 3.10.9 and Python 2.7.18.6
- Ranger version/commit: N/A
- Locale: N/A

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [X] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [x] All changes follow the code style **[REQUIRED]**
- [x] All new and existing tests pass **[REQUIRED]**
- [ ] Changes require config files to be updated
    - [ ] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION, MOTIVATION AND CONTEXT

The previous solution used the ABCMeta metaclass directly as the ABC non-meta class didn't exist in Python 2.

Python 2 and 3 have different syntax for metaclasses.  The one used by Python 2 doesn't work on Python 3 but is not an error either.  The one used by Python 3 is an error in Python 2.  We used to use the Python 2 syntax while acknowledging it merely doesn't do anything on Python 3.

The regular class ABC allows to avoid using the metaclass syntax at all, but it's only available in Python 3.  This solution implements it on our side (using the Python 2 metaclass syntax) if it's not available, but otherwise uses the standard ABC class with regular inheritance.

#### TESTING
<!-- What tests have been run? -->
<!-- How does the changes affect other areas of the codebase? -->

Manual ranger startup on both Python 2 and Python 3. Then I've removed once mandatory method that `abc` should catch check to see if ranger will refuse to start. The checks are now working on both Python 2 and Python 3.
