### PR TITLE
Support Expansion Of Environment Variables in cd command

### DIFF
--- a/ranger/config/commands.py
+++ b/ranger/config/commands.py
@@ -143,6 +143,12 @@ class cd(Command):
             if os.path.isfile(destination):
                 self.fm.select_file(destination)
                 return
+        elif self.arg(1) == '-e':
+            self.shift()
+            destination = os.path.realpath(os.path.expandvars(self.rest(1)))
+            if os.path.isfile(destination):
+                self.fm.select_file(destination)
+                return
         else:
             destination = self.rest(1)
 


### PR DESCRIPTION

Added an option to the `:cd` command.
Using `:cd -e $HOME` will do the expected thing.

#### ISSUE TYPE
- Improvement/feature implementation

#### RUNTIME ENVIRONMENT
- Operating system and version: x86_64 GNU/Linux 6.2.8-arch1-1 (Arch Linux)
- Terminal emulator and version: kitty 0.27.1
- Python version: Python 3.10.10
- Ranger version/commit: ranger-master v1.9.3-604-g8875ad2f
- Locale: en_US.UTF-8

#### CHECKLIST
- [X] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [X] All changes follow the code style **[REQUIRED]**
- [X] All new and existing tests pass **[REQUIRED]**
- [ ] Changes require config files to be updated
    - [ ] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
<!-- Describe the changes in detail -->


#### MOTIVATION AND CONTEXT
I have many files and directories in my environment, like `$XRESOURCES`, `$XINITRC`, `$PYTHONPATH`,...
A simple `cd` into or select of that dir/file was previously not possible.
Now if I want to hop into my `$NVIMRC`, I can do just that with `cd -e $NVIMRC`

#### TESTING
`cd -e $HOME/.config` works; changes directory correctly
`cd -e $XINITRC` works; selects file
`cd -e $TEST_DIR` works, where `$TEST_DIR` contains spaces.

The `cd` command now cannot accept `-e` as a target directory, of course.
