### PR TITLE
get_executables: Use platform instead of reading /proc

### DIFF
--- a/ranger/ext/get_executables.py
+++ b/ranger/ext/get_executables.py
@@ -3,9 +3,10 @@
 
 from __future__ import (absolute_import, division, print_function)
 
-from stat import S_IXOTH, S_IFREG
 from os import listdir, environ, stat
+import platform
 import shlex
+from stat import S_IXOTH, S_IFREG
 
 from ranger.ext.iter_tools import unique
 
@@ -23,8 +24,9 @@ def get_executables():
 
 def _in_wsl():
     # Check if the current environment is Microsoft WSL instead of native Linux
-    with open('/proc/sys/kernel/osrelease', encoding="utf-8") as file:
-        return 'microsoft' in file.read().lower()
+    # WSL 2 has `WSL2` in the release string but WSL 1 does not, both contain
+    # `microsoft`, lower case.
+    return 'microsoft' in platform.release()
 
 
 def get_executables_uncached(*paths):


### PR DESCRIPTION
Not every system has a `/proc` file system. We could catch the error but it is simpler to check `platform.release()`. This string contains `WSL2` for WSL version 2 but the only common substring for version 1 is lower case `microsoft`. On Windows this string should simply contain a major version number and not include that substring.

Fixes #2815