### PR TITLE
directory: Fix max call in mtimelevel

### DIFF
--- a/ranger/container/directory.py
+++ b/ranger/container/directory.py
@@ -76,7 +76,7 @@ def mtimelevel(path, level):
     for dirpath, dirnames, _ in walklevel(path, level):
         dirlist = [os.path.join("/", dirpath, d) for d in dirnames
                    if level == -1 or dirpath.count(os.path.sep) - path.count(os.path.sep) <= level]
-        mtime = max(mtime, [-1] + [os.stat(d).st_mtime for d in dirlist])
+        mtime = max([mtime] + [os.stat(d).st_mtime for d in dirlist])
     return mtime
 
 


### PR DESCRIPTION
Pylint flagged a nested max call as redundant but it was a false positive. However, the nested max call materialized a generator as a list and prepended `-1` because the function errors on an empty argument. Instead of nesting a max call we can drop the nesting and prepend the current value instead of passing it as a separate argument.

Fixes #2812