### PR TITLE
Move the ABC compat wrapper to a separate file

### DIFF
--- a/ranger/core/linemode.py
+++ b/ranger/core/linemode.py
@@ -5,17 +5,12 @@
 
 from __future__ import (absolute_import, division, print_function)
 
-from abc import ABCMeta, abstractproperty, abstractmethod
+from abc import abstractproperty, abstractmethod
 from datetime import datetime
 
+from ranger.ext.abc import ABC
 from ranger.ext.human_readable import human_readable, human_readable_time
 from ranger.ext import spawn
-
-try:
-    from abc import ABC       # pylint: disable=ungrouped-imports
-except ImportError:
-    class ABC(object):        # pylint: disable=too-few-public-methods
-        __metaclass__ = ABCMeta
 
 
 DEFAULT_LINEMODE = "filename"

--- a/ranger/ext/abc.py
+++ b/ranger/ext/abc.py
@@ -1,0 +1,14 @@
+# This file is part of ranger, the console file manager.
+# License: GNU GPL version 3, see the file "AUTHORS" for details.
+
+from __future__ import absolute_import
+
+from abc import ABCMeta
+
+
+# A compat wrapper for the older Python versions.
+try:
+    from abc import ABC       # pylint: disable=ungrouped-imports,unused-import
+except ImportError:
+    class ABC(object):        # pylint: disable=too-few-public-methods
+        __metaclass__ = ABCMeta


### PR DESCRIPTION
It shouldn't be tied to the linemode module. Now it can be reused anywhere just as easily.

@toonn, please verify if this is the correct place. I don't have a strong opinion about it being inside `ranger.ext`, I just happened to put it in there.