### PR TITLE
ci (workflows): bump actions version, fix Node deprecation warning

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -20,9 +20,9 @@ jobs:
       matrix:
         python-version: [3.x]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.github/workflows/pypy.yml
+++ b/.github/workflows/pypy.yml
@@ -16,9 +16,9 @@ jobs:
     env:
       TERM: dumb
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -20,9 +20,9 @@ jobs:
     env:
       TERM: dumb
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -14,7 +14,7 @@ jobs:
   test_shellcheck:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Install latest stable shellcheck
       run: |
         curl -LO "https://github.com/koalaman/shellcheck/releases/download/stable/shellcheck-stable.linux.x86_64.tar.xz"


### PR DESCRIPTION
<!-- Provide a descriptive summary of the changes in the title above -->

#### ISSUE TYPE
<!-- Pick relevant types and delete the rest -->
- Bug fix


#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [x] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [x] All changes follow the code style **[REQUIRED]**
- [x] All new and existing tests pass **[REQUIRED]**
- [ ] Changes require config files to be updated
    - [ ] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [x] Changes require tests to be updated
    - [x] Tests have been updated

#### DESCRIPTION

- Bump the `actions/checkout` version from `v2` (Node 12) to `v3` (Node 16).
- Bump the `actions/setup-python` version from `v2` (Node 12) to `v4` (Node 16).

#### MOTIVATION AND CONTEXT
<!-- Why are these changes required? -->
<!-- What problems do these changes solve? -->
<!-- Link to relevant issues -->

This PR fixes the Node 12 deprecation warning shown under the Annotations in Action runs by bumping the actions to use Node 16 instead.  More info here: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.

#### TESTING
<!-- What tests have been run? -->
<!-- How does the changes affect other areas of the codebase? -->

No tests have been run locally, we can refer to this PRs action runs for the test results. Since these aren't breaking changes, the tests should run fine.

#### IMAGES / VIDEOS<!-- Only if relevant -->
<!-- Link or embed images and videos of screenshots, sketches etc. -->

![image](https://user-images.githubusercontent.com/26346867/230734001-b0f894f3-2621-4a03-ad08-73eae9c90030.png)

Example of the issue (before this fix): https://github.com/ranger/ranger/actions/runs/4607666301