### PR TITLE
Unconfuse CI

### DIFF
--- a/.github/workflows/other.yml
+++ b/.github/workflows/other.yml
@@ -1,14 +1,6 @@
-name: PEP8 and tests
+name: Other tests
 
-on:
-  push:
-    paths:
-      - '.github/workflows/python.yml'
-      - '**.py'
-  pull_request:
-    paths:
-      - '.github/workflows/python.yml'
-      - '**.py'
+on: [push, pull_request]
 
 jobs:
   test_py:
@@ -31,6 +23,14 @@ jobs:
         # We need to ignore PyLint because we can't install the one we need for
         # Python 2.7 and 3.5
         pip install -r <(grep -v pylint requirements.txt)
-    - name: Flake8 and test
+    - name: Get changed Python files
+      uses: dorny/paths-filter@v2
+      id: paths-filter
+      with:
+        filters: |
+          code:
+            - added|modified: '!(ranger/config)**.py'
+    - name: Other tests
+      if: ${{ steps.path-filter.outputs.code == 'true' }}
       run: |
-        make test_flake8 test_doctest test_other
+        make test_doctest test_other

--- a/.github/workflows/other.yml
+++ b/.github/workflows/other.yml
@@ -12,9 +12,9 @@ jobs:
     env:
       TERM: dumb
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,46 @@
+name: PR Pylint, PEP8 and Pytest
+
+on: pull_request
+
+jobs:
+  test_pylint:
+    runs-on: ubuntu-latest
+    strategy:
+      max-parallel: 4
+      matrix:
+        python-version: [3.x]
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+    - name: Get changed Python files
+      uses: dorny/paths-filter@v2
+      id: paths-filter
+      with:
+        list-files: 'shell'
+        filters: |
+          code:
+            - added|modified: '!(ranger/config)**.py'
+          config:
+            - added|modified: 'ranger/config/**.py'
+    - name: Lint code with Flake8 and Pylint
+      if: ${{ steps.path-filter.outputs.code == 'true' }}
+      run: |
+        flake8 ${{ steps.paths-filter.outputs.code_files }}
+        pylint ${{ steps.paths-filter.outputs.code_files }}
+    - name: Lint config with Flake8 and Pylint
+      if: ${{ steps.path-filter.outputs.config == 'true' }}
+      run: |
+        flake8 ${{ steps.paths-filter.outputs.config }}
+        pylint --rcfile=ranger/config/.pylintrc \
+          ${{ steps.paths-filter.outputs.config_files }}
+    - name: Test code with Pytest
+      if: ${{ steps.path-filter.outputs.code == 'true' }}
+      run: |
+        make test_pytest

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -10,9 +10,9 @@ jobs:
       matrix:
         python-version: [3.x]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -1,12 +1,7 @@
-name: Pylint
+name: Pylint, PEP8 and Pytest
 
 on:
   push:
-    paths:
-      - '.github/workflows/pylint.yml'
-      - '**.py'
-      - 'requirements.txt'
-  pull_request:
     paths:
       - '.github/workflows/pylint.yml'
       - '**.py'
@@ -29,6 +24,6 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
-    - name: Lint with pylint, test with pytest
+    - name: Lint with Flake8 and Pylint, test with Pytest
       run: |
-        make test_pylint test_pytest
+        make test_flake8 test_pylint test_pytest

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -15,9 +15,9 @@ jobs:
       matrix:
         python-version: [3.x]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.github/workflows/pypy.yml
+++ b/.github/workflows/pypy.yml
@@ -13,13 +13,13 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [pypy2, pypy3]
+        python-version: [pypy2.7, pypy3.9]
     env:
       TERM: dumb
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.github/workflows/pypy.yml
+++ b/.github/workflows/pypy.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - '.github/workflows/pypy.yml'
       - '**.py'
+      - 'requirements.txt'
 
 jobs:
   test_pypy:
@@ -27,4 +28,4 @@ jobs:
         pip install -r requirements.txt
     - name: Pypy lints and tests
       run: |
-        make test_pylint test_flake8 test_pytest test_doctest test_other
+        make test_flake8 test_pylint test_pytest test_doctest test_other

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -6,7 +6,7 @@ jobs:
   test_shellcheck:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Install latest stable shellcheck
       run: |
         curl -LO "https://github.com/koalaman/shellcheck/releases/download/stable/shellcheck-stable.linux.x86_64.tar.xz"

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,14 +1,6 @@
 name: Shellcheck scope.sh
 
-on:
-  push:
-    paths:
-      - '.github/workflows/shellcheck.yml'
-      - 'ranger/data/scope.sh'
-  pull_request:
-    paths:
-      - '.github/workflows/shellcheck.yml'
-      - 'ranger/data/scope.sh'
+on: [push, pull_request]
 
 jobs:
   test_shellcheck:
@@ -19,6 +11,14 @@ jobs:
       run: |
         curl -LO "https://github.com/koalaman/shellcheck/releases/download/stable/shellcheck-stable.linux.x86_64.tar.xz"
         tar xf shellcheck-stable.linux.x86_64.tar.xz
+    - name: Check if scope.sh was changed
+      uses: dorny/paths-filter@v2
+      id: paths-filter
+      with:
+        filters: |
+          scope:
+            - added|modified: 'ranger/data/scope.sh'
     - name: Shellcheck scope.sh
+      if: ${{ steps.path-filter.outputs.scope == 'true' }}
       run: |
         env PATH=shellcheck-stable:$PATH make test_shellcheck


### PR DESCRIPTION
Change CI to run conditionally without remaining pending
    
Using the built-in paths filter means Actions will not be run at all.
When they are set as "required checks" on PRs that means they will be
marked as pending forever. This is confusing for contributors and means
maintainers need to keep in mind when checks should actually complete or
not.

Using the paths-filter Action means we can use conditional execution of
steps, which results in things being marked as skipped, rather than
pending. This should make everything a bit less confusing.

Some tests that are only run on push events, mostly for the master
branch, still use the built-in path filtering. These aren't used as
required checks so they aren't as front and center.

One unfortunate consequence of the change is that more Action runs will
be spun up unnecessarily. Such senseless waste of resources is pretty
sad and GitHub should fix this.