### PR TITLE
Add image preview via FreeCAD

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ For enhanced file previews (with `scope.sh`):
 * `jupyter nbconvert` for Jupyter Notebooks
 * `fontimage` for font previews
 * `openscad` for 3D model previews (`stl`, `off`, `dxf`, `scad`, `csg`)
+* `freecad` for 3D model previews (`step`, `obj`)
 * `draw.io` for [draw.io](https://app.diagrams.net/) diagram previews
   (`drawio` extension)
 

--- a/ranger/core/fm.py
+++ b/ranger/core/fm.py
@@ -286,7 +286,10 @@ class FM(Actions,  # pylint: disable=too-many-instance-attributes
             copy('data/scope.sh', 'scope.sh')
             os.chmod(self.confpath('scope.sh'),
                      os.stat(self.confpath('scope.sh')).st_mode | stat.S_IXUSR)
-        if which in ('all', 'rifle', 'scope', 'commands', 'commands_full', 'rc'):
+        if which in ('freecad_image', 'all'):
+            copy('data/freecad_image.py', 'freecad_image.py')
+        if which in ('all', 'rifle', 'scope', 'commands', 'commands_full', 'rc',
+                     'freecad_image'):
             sys.stderr.write("\n> Please note that configuration files may "
                              "change as ranger evolves.\n  It's completely up to you to "
                              "keep them up to date.\n")

--- a/ranger/data/freecad_image.py
+++ b/ranger/data/freecad_image.py
@@ -1,0 +1,32 @@
+#!/usr/bin/python
+
+import sys
+sys.path.append('/usr/lib/freecad/lib/')
+from pathlib import Path
+
+import FreeCAD
+import FreeCADGui as Gui
+import Part, Mesh
+
+_, dimensions, path_out, path_in = sys.argv
+path_in = Path(path_in)
+
+Gui.showMainWindow()
+window = Gui.getMainWindow()
+window.showMinimized()
+
+if path_in.suffix.lower() == '.obj':
+    Mesh.open(str(path_in))
+else:
+    Part.open(str(path_in))
+
+x, y = (int(n) for n in dimensions.split(','))
+
+Gui.SendMsgToActiveView('OrthographicCamera')
+Gui.SendMsgToActiveView('ViewAxo')
+
+# for f in [,'ViewFront','ViewTop']:
+
+Gui.ActiveDocument.ActiveView.saveImage(path_out, x, y, 'Transparent')
+
+FreeCAD.closeDocument(FreeCAD.ActiveDocument.Name)

--- a/ranger/data/scope.sh
+++ b/ranger/data/scope.sh
@@ -272,6 +272,16 @@ handle_image() {
     #         -o "${TMPPNG}" "${1}"
     #     mv "${TMPPNG}" "${IMAGE_CACHE_PATH}"
     # }
+    #
+    # freecad_image() {
+    #     TMPPNG="$(mktemp -t XXXXXX.png)"
+    #     python3 $(dirname $0)/freecad_image.py \
+    #         "${OPENSCAD_IMGSIZE/x/,}" \
+    #         "${TMPPNG}" \
+    #         "${1}" 2>&1 >> /tmp/test
+    #     mv "${TMPPNG}" "${IMAGE_CACHE_PATH}"
+    # }
+
 
     case "${FILE_EXTENSION_LOWER}" in
        ## 3D models
@@ -285,6 +295,9 @@ handle_image() {
        # 3mf|amf|dxf|off|stl)
        #     openscad_image <(echo "import(\"${FILE_PATH}\");") && exit 6
        #     ;;
+       # step|stp|obj)
+       #      freecad_image "${FILE_PATH}" && exit 6
+       #      ;;
        drawio)
            draw.io -x "${FILE_PATH}" -o "${IMAGE_CACHE_PATH}" \
                --width "${DEFAULT_SIZE%x*}" && exit 6

--- a/ranger/data/scope.sh
+++ b/ranger/data/scope.sh
@@ -275,10 +275,10 @@ handle_image() {
     #
     # freecad_image() {
     #     TMPPNG="$(mktemp -t XXXXXX.png)"
-    #     python3 $(dirname $0)/freecad_image.py \
+    #     python3 "$(dirname "$0")/freecad_image.py" \
     #         "${OPENSCAD_IMGSIZE/x/,}" \
     #         "${TMPPNG}" \
-    #         "${1}" 2>&1 >> /tmp/test
+    #         "${1}"
     #     mv "${TMPPNG}" "${IMAGE_CACHE_PATH}"
     # }
 


### PR DESCRIPTION
Add image previews for .step and .obj files via FreeCAD


#### ISSUE TYPE
- Improvement/feature implementation

#### RUNTIME ENVIRONMENT
<!-- Details of your runtime environment -->
<!-- Retrieve Python/ranger version and locale with `ranger -\-version` -->
- Operating system and version: Ubuntu 22.04
- Terminal emulator and version: alacritty 0.11.0
- Python version: 3.10.5
- Ranger version/commit: 1.9.3
- Locale: en_US.UTF-8

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [x] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [ x All changes follow the code style **[REQUIRED]**
- [x] All new and existing tests pass **[REQUIRED]**
- [ ] Changes require config files to be updated
    - [ ] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
Openscad image previews are fantastic, but they only support certain 3D file formats. The big missing ones are step and obj. This pull request adds support for image previews for step and obj via FreeCAD. It should be possible to add more formats down the road.

Unfortunately, it's not possible to take screenshots with FreeCAD running headlessly. The script works by minimizing FreeCAD to make it as unobtrusive as possible. I'm still looking for a better solution. 


#### MOTIVATION AND CONTEXT
Just like existing openscad image previews, but for step and obj.


#### TESTING
It's only something in `scope.sh` that's commented out by default. No breaking changes. Tested on a few step and obj files on my computer.

I ran `make test`
