### PR TITLE
Fix image display with tmux + kitty

### DIFF
--- a/ranger/config/rc.conf
+++ b/ranger/config/rc.conf
@@ -110,7 +110,7 @@ set preview_images false
 #   the transfer method is changed to encode the whole image;
 #   while slower, this allows remote previews,
 #   for example during an ssh session.
-#   Tmux is unsupported.
+#   Tmux with passthrough enabled is supported.
 #
 # * ueberzug:
 #   Preview images in full color with the external command "ueberzug".


### PR DESCRIPTION
Fix image display with tmux + kitty

#### ISSUE TYPE
- Improvement/feature implementation

#### RUNTIME ENVIRONMENT
<!-- Details of your runtime environment -->
<!-- Retrieve Python/ranger version and locale with `ranger -\-version` -->
- Operating system and version: Arch Linux 6.3.3
- Terminal emulator and version: kitty 0.28.1
- ranger version: ranger-master v1.9.3-678-g1a007158
- Python version: 3.11.3 (main, Apr  5 2023, 15:52:25) [GCC 12.2.1 20230201]
- Locale: fr_FR.UTF-8

#### CHECKLIST
- [x] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [x] All changes follow the code style **[REQUIRED]**
- [x] All new and existing tests pass **[REQUIRED]**
- [x] Changes require config files to be updated
    - [x] Config files have been updated

#### DESCRIPTION
Fix escape sequence for tmux passthrough
Add the possibility to render images wiith placehoder ( necessary with tmux )

#### MOTIVATION AND CONTEXT
Could not view image with tmux+kitty but work in icat https://github.com/ranger/ranger/issues/2846

#### TESTING
Tested with 
- kitty without tmux
- kitty with tmux and allow-passthrough not set
- kitty with tmux and allow-passthrough set

i ran ```make test```