### PR TITLE
report file byte size in IIP

### DIFF
--- a/ranger/ext/img_display.py
+++ b/ranger/ext/img_display.py
@@ -357,7 +357,7 @@ class ITerm2ImageDisplayer(ImageDisplayer, FileManagerAware):
             return ""
         image_width = self._fit_width(
             image_width, image_height, max_cols, max_rows)
-        content = self._encode_image_content(path)
+        content, byte_size = self._encode_image_content(path)
         display_protocol = "\033"
         close_protocol = "\a"
         if os.environ["TERM"].startswith(("screen", "tmux")):
@@ -366,7 +366,7 @@ class ITerm2ImageDisplayer(ImageDisplayer, FileManagerAware):
 
         text = "{0}]1337;File=inline=1;preserveAspectRatio=0;size={1};width={2}px:{3}{4}\n".format(
             display_protocol,
-            str(len(content)),
+            str(byte_size),
             str(int(image_width)),
             content,
             close_protocol)
@@ -384,7 +384,8 @@ class ITerm2ImageDisplayer(ImageDisplayer, FileManagerAware):
     def _encode_image_content(path):
         """Read and encode the contents of path"""
         with open(path, 'rb') as fobj:
-            return base64.b64encode(fobj.read()).decode('utf-8')
+            content = fobj.read()
+            return base64.b64encode(content).decode('utf-8'), len(content)
 
     @staticmethod
     def imghdr_what(path):


### PR DESCRIPTION
<!-- Provide a descriptive summary of the changes in the title above -->

#### ISSUE TYPE
<!-- Pick relevant types and delete the rest -->
- Bug fix: Fixes #2883.

#### RUNTIME ENVIRONMENT
<!-- Details of your runtime environment -->
<!-- Retrieve Python/ranger version and locale with `ranger -\-version` -->
- Terminal emulator and version: vscode 1.80+ integrated terminal
- Python version: 3.10

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [x] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [x] All changes follow the code style **[REQUIRED]**
- [x] All new and existing tests pass **[REQUIRED]**

#### DESCRIPTION
<!-- Describe the changes in detail -->
With `preview_images_method iterm2` being set, vscode terminal does not show images. This is due to ranger wrongly sending the size of the base64 encoded content, instead of the byte size of the original file/data.

#### TESTING
<!-- What tests have been run? -->
- `set preview_images_method iterm2` in conf file
- open integrated terminal in vscode
- run ranger
- navigate to folder with images
- images now show up

#### Additional note
 Vscode terminal will still refuse to show an image that creates a rather big sequence (>20MB, again a security/sanity check). Here it might make sense to do an interim resizing with PIL if available. (not part of this PR)