### PR TITLE
mime.types: Add common requests

### DIFF
--- a/ranger/data/mime.types
+++ b/ranger/data/mime.types
@@ -31,7 +31,9 @@ image/webp              webp
 
 message/rfc822          eml
 
+text/plain              hs lhs rs ts tsx
 text/x-ruby             rb
+text/x-shellscript      sh
 
 video/ogg               ogv ogm
 video/webm              webm


### PR DESCRIPTION
Type `text/x-shellscript` to align with `file(1)` behavior.

No type added for JSON files because they officially have the `application/json` type.

Added several programming language extensions with type `text/plain` this agrees with `file(1)` for most. Two exceptions are `.rs`, which `file(1)` assigns `text/x-c` and is less than ideal, and `.tsx` which `file(1)` assigns `text/x-c++` and is even further removed.

Fixes #1804

This addresses most of the requests. `.gro` doesn't seem very common so I left it out.