### PR TITLE
README: Mention pillow dependency for Kitty image previews

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ For general usage:
 For enhanced file previews (with `scope.sh`):
 
 * `img2txt` (from `caca-utils`) for ASCII-art image previews
-* `w3mimgdisplay`, `ueberzug`, `mpv`, `iTerm2`, `kitty`, `terminology` or `urxvt` for image previews
+* `w3mimgdisplay`, `ueberzugpp`, `mpv`, `iTerm2`, `kitty` (Requires `pillow` to be installed for the Python interpreter running Ranger), `terminology` or `urxvt` for image previews
 * `convert` (from `imagemagick`) to auto-rotate images and for image previews
 * `rsvg-convert` (from [`librsvg`](https://wiki.gnome.org/Projects/LibRsvg))
   for SVG previews


### PR DESCRIPTION
Addresses a [comment from #1499][1] pointing out the lack of mention of the Pillow dependency in the README.

[1]: https://github.com/ranger/ranger/issues/1499#issuecomment-1690718069