### PR TITLE
fix #2873 WM_NAME now shows "not accessible" in non-existent directories

### DIFF
--- a/ranger/gui/ui.py
+++ b/ranger/gui/ui.py
@@ -369,15 +369,18 @@ class UI(  # pylint: disable=too-many-instance-attributes,too-many-public-method
         self.win.touchwin()
         DisplayableContainer.draw(self)
         if self._draw_title and self.settings.update_title:
-            cwd = self.fm.thisdir.path
-            if self.settings.tilde_in_titlebar \
-               and (cwd == self.fm.home_path
-                    or cwd.startswith(self.fm.home_path + "/")):
-                cwd = '~' + cwd[len(self.fm.home_path):]
-            if self.settings.shorten_title:
-                split = cwd.rsplit(os.sep, self.settings.shorten_title)
-                if os.sep in split[0]:
-                    cwd = os.sep.join(split[1:])
+            if self.fm.thisdir:
+                cwd = self.fm.thisdir.path
+                if self.settings.tilde_in_titlebar \
+                   and (cwd == self.fm.home_path
+                        or cwd.startswith(self.fm.home_path + "/")):
+                    cwd = '~' + cwd[len(self.fm.home_path):]
+                if self.settings.shorten_title:
+                    split = cwd.rsplit(os.sep, self.settings.shorten_title)
+                    if os.sep in split[0]:
+                        cwd = os.sep.join(split[1:])
+            else:
+                cwd = "not accessible"
             try:
                 fixed_cwd = cwd.encode('utf-8', 'surrogateescape'). \
                     decode('utf-8', 'replace')


### PR DESCRIPTION
<!-- Provide a descriptive summary of the changes in the title above -->
#### ISSUE TYPE 
<!-- Pick relevant types and delete the rest -->
- Bug fix

#### RUNTIME ENVIRONMENT
<!-- Details of your runtime environment -->
<!-- Retrieve Python/ranger version and locale with `ranger -\-version` -->
- Operating system and version: Arch Linux
- Terminal emulator and version: Alacritty 0.12.2
- Python version: 3.11.5
- Ranger version/commit: 136416c
- Locale: en_US.UTF-8

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [x] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [x] All changes follow the code style **[REQUIRED]**
- [x] All new and existing tests pass **[REQUIRED]**
    - I did not run spellcheck `HACKING` was not clear which tool to use specifically
- [ ] Changes require config files to be updated
    - [ ] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
<!-- Describe the changes in detail -->
fixes #2873
Before ranger used to crash with `update_title=true` setting when trying to display a non-existent directory.
The reason was a call to `UI.fm.thisdir.path` while `UI.fm.thisdir == None` when ranger is pointing to a non-existent directory, invalidating the path attribute.
This PR checks if `UI.fm.thisdir` is None and makes sure `WM_NAME` shows `ranger:not accessible` (same as the ranger UI).

#### MOTIVATION AND CONTEXT
<!-- Why are these changes required? -->
fix crashing issue detailed in #2873 
<!-- What problems do these changes solve? -->
<!-- Link to relevant issues -->


#### TESTING
<!-- What tests have been run? -->
`make test_py` has been run successfully. I was not sure which spellchecker to get, `HACKING` wasn't super clear on this, sorry.
<!-- How does the changes affect other areas of the codebase? -->
Changes should not have any effects on the rest of the codebase.