### PR TITLE
fix ranger#2859 Image Preview With Sixel Method Makes Ranger Freeze

### DIFF
--- a/ranger/ext/img_display.py
+++ b/ranger/ext/img_display.py
@@ -475,7 +475,12 @@ class SixelImageDisplayer(ImageDisplayer, FileManagerAware):
             cached = TemporaryFile("w+", prefix="ranger", suffix=path.replace(os.sep, "-"))
 
             environ = dict(os.environ)
-            environ.setdefault("MAGICK_OCL_DEVICE", "true")
+
+            if os.path.exists('/proc/driver/nvidia'):
+                environ.setdefault("MAGICK_OCL_DEVICE", "false")
+            else:
+                environ.setdefault("MAGICK_OCL_DEVICE", "true")
+
             try:
                 check_call(
                     [


### PR DESCRIPTION
<!-- Provide a descriptive summary of the changes in the title above -->

#### ISSUE TYPE
<!-- Pick relevant types and delete the rest -->
- Bug fix

#### RUNTIME ENVIRONMENT
- Python version: 3.11.5 
- ranger version: ranger-master
- Arch Linux: 
- foot and xterm: 
- Locale: en_US.UTF-8

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [X] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [X] All changes follow the code style **[REQUIRED]**
- [X] All new and existing tests pass **[REQUIRED]**

#### DESCRIPTION
Set MAGICK_OCL_DEVICE to false when NVIDIA card is detected.

#### MOTIVATION AND CONTEXT
The [imagemagick opencl documents](https://imagemagick.org/script/opencl.php) states that NVIDIA support is not enabled at the moment.
When the magick command is called with MAGICK_OCL_DEVICE set to true on a NVIDIA GPU the command will freeze

This commit fixes the following issue https://github.com/ranger/ranger/issues/2859

#### TESTING
These changes has no affect on other areas of the codebase



