### PR TITLE
use urllib for URIs

### DIFF
--- a/ranger/core/main.py
+++ b/ranger/core/main.py
@@ -255,9 +255,8 @@ https://github.com/ranger/ranger/issues
 
 def get_paths(args):
     if args.paths:
-        prefix = 'file://'
-        prefix_length = len(prefix)
-        paths = [path[prefix_length:] if path.startswith(prefix) else path for path in args.paths]
+        from urllib.parse import urlparse, unquote
+        paths = [unquote(urlparse(path).path) for path in args.paths]
     else:
         start_directory = os.environ.get('PWD')
         is_valid_start_directory = start_directory and os.path.exists(start_directory)


### PR DESCRIPTION
fixes percent encoding being broken (eg when steam opens ranger as default file manager)
may break paths that are actually named in percent encoding (that are not themselves percent encoded)
i imagine there's a better way to do this but this seems to work so far

#### ISSUE TYPE
- Bug fix
- Improvement/feature implementation
- Breaking changes
(i feel like depending on definition it could be any or all of these)

#### RUNTIME ENVIRONMENT
- Operating system and version: Linux Lite 5.4
- Terminal emulator and version: alacritty 0.12.2
- Python version: Python 3.8.10
- Ranger version/commit: 136416c7e2ecc27315fe2354ecadfe09202df7dd
- Locale: en_US.UTF-8

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [x] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [x] All changes follow the code style **[REQUIRED]**  (at least as far as i can tell after reading it, the import from within a function seems odd but matches the rest of the file afaik)
- [x] All new and existing tests pass **[REQUIRED]**
- [ ] Changes require config files to be updated
    - [ ] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
<!-- Describe the changes in detail -->
uses urllib.parse.urlparse and urllib.parse.unquote to, respectively, parse the path from a URI and decode URI percent encoding
potential better way would be to only unquote() the path if it is actually a file:// uri but i literally do not know python

#### MOTIVATION AND CONTEXT
<!-- Why are these changes required? -->
<!-- What problems do these changes solve? -->
<!-- Link to relevant issues -->
my previous fix was to make the exo preferred filemanager a shell script that removed the file:// and replaced %20's with spaces before passing any path to ranger (the current apt version of ranger has a bug where it removes the leading slash of file uris, but that was fixed by cloning the repo)

#### TESTING
"What tests have been run?"
make test_py; make test
"How does the changes affect other areas of the codebase?"
shouldn't, apart from changing the argument parsing

<!--#### IMAGES / VIDEOS<!- - Only if relevant -->
<!-- Link or embed images and videos of screenshots, sketches etc. -->
