### PR TITLE
Fix opening tabs on files (regression from fe7c3b2 remove-duplicate-tabs-on-startup)

### DIFF
--- a/ranger/core/actions.py
+++ b/ranger/core/actions.py
@@ -1248,7 +1248,7 @@ class Actions(  # pylint: disable=too-many-instance-attributes,too-many-public-m
             if path:
                 tab.enter_dir(path, history=True)
             else:
-                if os.path.isdir(tab.path):
+                if os.path.exists(tab.path):
                     tab.enter_dir(tab.path, history=False)
                 else:
                     tab.thisdir = None


### PR DESCRIPTION
When starting ranger with files as command line arguments, it started to behave strangely after merge of #2724.. Fortunately an easy fix it seems 😀

Test case shown is starting `ranger ranger/core/main.py ranger/container/settings.py ranger/core/actions.py ranger/gui/widgets/titlebar.py` within the source directory, then switching to the 2nd tab (1st is correct).

Without this patch:
![ranger-file-in-tab-borked](https://github.com/ranger/ranger/assets/1227833/b33adaf9-2d03-4210-926c-147c783094e0)
With patch applied:
![ranger-file-in-tab-fixed](https://github.com/ranger/ranger/assets/1227833/77694128-409b-438a-b79e-af166666493c)
