### PR TITLE
Restore previous behaviour of move_parent to ignore files (fixes #2325)

### DIFF
--- a/ranger/core/actions.py
+++ b/ranger/core/actions.py
@@ -569,7 +569,9 @@ class Actions(  # pylint: disable=too-many-instance-attributes,too-many-public-m
             if parent.pointer + n < 0:
                 n = 0 - parent.pointer
             try:
-                self.thistab.enter_dir(parent.files[parent.pointer + n])
+                fobj = parent.files[parent.pointer + n]
+                if fobj.is_directory:
+                    self.thistab.enter_dir(fobj)
             except IndexError:
                 pass
 


### PR DESCRIPTION
Well, from git history it is clear that `enter_dir()` was expanded to handle files gracefully by selecting them, which is a nice feature. Even with that, the old behaviour of `move_parent()` (ignoring files) can easily be regained by adding the check for fs object type therein, as in this patch.