### PR TITLE
Reordered conditions to fix %F macro substituting active object from previous tab

### DIFF
--- a/ranger/core/actions.py
+++ b/ranger/core/actions.py
@@ -346,11 +346,11 @@ class Actions(  # pylint: disable=too-many-instance-attributes,too-many-public-m
         for tabname in self.fm.tabs:
             if not first_tab:
                 first_tab = tabname
+            if self.fm.current_tab == tabname:
+                found_current_tab = True
             if found_current_tab:
                 next_tab = self.fm.tabs[tabname]
                 break
-            if self.fm.current_tab == tabname:
-                found_current_tab = True
         if found_current_tab and next_tab is None:
             next_tab = self.fm.tabs[first_tab]
         try:


### PR DESCRIPTION
<!-- Provide a descriptive summary of the changes in the title above -->

#### ISSUE TYPE
<!-- Pick relevant types and delete the rest -->
- Bug fix

#### RUNTIME ENVIRONMENT
<!-- Details of your runtime environment -->
<!-- Retrieve Python/ranger version and locale with `ranger -\-version` -->
- Operating system and version: Manjaro 21.0.1
- Terminal emulator and version: URxvt v9.22
- Python version:  3.8.10
- Ranger version/commit: 136416c
- Locale: en_US.UTF-8

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [x] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [x] All changes follow the code style **[REQUIRED]**
- [x] All new and existing tests pass **[REQUIRED]**
- [ ] Changes require config files to be updated
    - [ ] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
<!-- Describe the changes in detail -->
On the first run of the `for` loop on line 346 in `actions.py` the value `found_current_tab` is checked before any reassignment is possible.  Flipping the order of the final two conditions in the loop remedies this issue.

#### MOTIVATION AND CONTEXT
<!-- Why are these changes required? -->
<!-- What problems do these changes solve? -->
<!-- Link to relevant issues -->
#2866 

#### TESTING
<!-- What tests have been run? -->
<!-- How does the changes affect other areas of the codebase? -->

make test passes all tests
reproducing steps in bug gives desired effect