### PR TITLE
Add method of opening text files with sudo -e

### DIFF
--- a/ranger/config/rifle.conf
+++ b/ranger/config/rifle.conf
@@ -87,8 +87,10 @@ ext x?html?, has w3m,               terminal = w3m "$@"
 # Define the "editor" for text files as first action
 mime ^text,  label editor = ${VISUAL:-$EDITOR} -- "$@"
 mime ^text,  label pager  = $PAGER -- "$@"
+mime ^text,  label sudoedit, has sudo = sudo -e -- "$@"
 !mime ^text, label editor, ext xml|json|csv|tex|py|pl|rb|rs|js|sh|php|dart = ${VISUAL:-$EDITOR} -- "$@"
 !mime ^text, label pager,  ext xml|json|csv|tex|py|pl|rb|rs|js|sh|php|dart = $PAGER -- "$@"
+!mime ^text, label sudoedit, has sudo, ext xml|json|csv|tex|py|pl|rb|rs|js|sh|php|dart = sudo -e -- "$@"
 
 ext 1                         = man "$1"
 ext s[wmf]c, has zsnes, X     = zsnes "$1"


### PR DESCRIPTION
[`sudo -e`](https://www.sudo.ws/docs/man/sudo.man/#e) allows the user to edit files of a different user as themselves by making a temporary copy. This can be used to edit privileged files in a familiar environment.

It is superior to the existing method of the `r` flag, which uses [`sudo -E`](https://www.sudo.ws/docs/man/sudo.man/#e) and invokes another program, `su`, with the `m` option, which doesn't keep the user's path, preventing the user from using a locally installed editor/program.

Additionally, the user might not be authorized to use `sudo -E` when they otherwise would be able to use `sudo -e`. The reverse is true as well, so both should be options.