### PR TITLE
ext/img_display: support raw img preview in kitty

### DIFF
--- a/ranger/ext/img_display.py
+++ b/ranger/ext/img_display.py
@@ -791,6 +791,25 @@ class KittyImageDisplayer(ImageDisplayer, FileManagerAware):
         if self.needs_late_init:
             self._late_init()
 
+        dummy, ext = os.path.splitext(path)
+        if ext == ".ORF":
+            thumb_ext = ''
+            try:
+                import rawpy
+            except ImportError:
+                raise ImageDisplayError("Raw image previews in kitty require rawpy")
+
+            # convert raw file to tmp thumbnail
+            with rawpy.imread(path) as raw:
+                thumb = raw.extract_thumb()
+            if thumb.format == rawpy.ThumbFormat.JPEG:
+                thumb_ext = '.jpg'
+            elif thumb.format == rawpy.ThumbFormat.BITMAP:
+                thumb_ext = '.tiff'
+            with NamedTemporaryFile(mode='w+b', prefix='ranger_thumb_', suffix=thumb_ext, delete=False) as tmpf:
+                tmpf.write(thumb.data)
+                path = tmpf.name
+
         with warnings.catch_warnings(record=True):  # as warn:
             warnings.simplefilter('ignore', self.backend.DecompressionBombWarning)
             image = self.backend.open(path)


### PR DESCRIPTION
#### ISSUE TYPE
- Improvement/feature implementation

#### RUNTIME ENVIRONMENT
- Operating system and version: Ubuntu 22.04
- Terminal emulator and version: kitty 0.26.4
ranger version: ranger 1.9.3
Python version: 3.10.12 (main, Nov 20 2023, 15:14:05) [GCC 11.4.0]
Locale: fr_FR.UTF-8

#### CHECKLIST
- [ ] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [ ] All changes follow the code style **[REQUIRED]**
- [ ] All new and existing tests pass **[REQUIRED]**
- [ ] Changes require config files to be updated
    - [ ] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
Extract and save the thumbnail from raw using `rawpy` and replace `path`. 


#### MOTIVATION AND CONTEXT
Raw image can't be previewed since PIL doesn't support them.


#### TESTING
Provided example is tested with Olympus files (.ORF).

