### PR TITLE
fix bulkrename: handle libcurses behavior change in patch level 20231111

### DIFF
--- a/ranger/gui/ui.py
+++ b/ranger/gui/ui.py
@@ -157,7 +157,10 @@ class UI(  # pylint: disable=too-many-instance-attributes,too-many-public-method
             pass
         if self.settings.mouse_enabled:
             _setup_mouse({"value": False})
-        curses.endwin()
+        try:
+            curses.endwin()
+        except curses.error:
+            pass
         self.is_on = False
 
     def set_load_mode(self, boolean):


### PR DESCRIPTION
#### ISSUE TYPE
- Bug fix

#### RUNTIME ENVIRONMENT
- Operating system and version: Alpine Linux 3.19
- Terminal emulator and version: foot, 1.16.2
- Python version: 3.11.6
- Ranger version/commit: 1.9.3, also tested on master [136416c7e2ecc27315fe2354ecadfe09202df7dd]
- Locale: en_US.UTF-8

#### CHECKLIST
- [X] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [X] All changes follow the code style **[REQUIRED]**
- [X] All new and existing tests pass **[REQUIRED]** [1]
- [ ] Changes require config files to be updated
    - [ ] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
Handle an error which breaks the bulk rename command due to changed curses behavior.

#### MOTIVATION AND CONTEXT
The libcurses patch level 20231111 introduces a change (described in [this thread](https://www.mail-archive.com/debian-bugs-dist@lists.debian.org/msg1944374.html)) which results in an unhandled error which aborts a `:bulkchange` operation.

The following output is observed in the message log:
```
21:51:15 INFO Locale: en_US.UTF-8
21:51:15 INFO Process ID: 28100
21:51:32 ERRO Notification: endwin() returned ERR
21:51:32 ERRO endwin() returned ERR
Traceback (most recent call last):
  File "/tmp/ranger/ranger-master/ranger/core/actions.py", line 272, in execute_console
    cmd.execute()
  File "/tmp/ranger/ranger-master/ranger/config/commands.py", line 1295, in execute
    self.fm.execute_file([File(cmdfile.name)], app='editor')
  File "/tmp/ranger/ranger-master/ranger/core/actions.py", line 446, in execute_file
    return execute()
           ^^^^^^^^^
  File "/tmp/ranger/ranger-master/ranger/core/actions.py", line 444, in execute
    return self.rifle.execute(filenames, mode, label, flags, None)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/ranger/ranger-master/ranger/ext/rifle.py", line 440, in execute
    self.hook_before_executing(command, self._mimetype, self._app_flags)
  File "/tmp/ranger/ranger-master/ranger/core/fm.py", line 136, in <lambda>
    self.ui.suspend() if 'f' not in flags else None
    ^^^^^^^^^^^^^^^^^
  File "/tmp/ranger/ranger-master/ranger/gui/ui.py", line 160, in suspend
    curses.endwin()
_curses.error: endwin() returned ERR
```

The above thread reports a similar issue, although in the case of ranger, removing curses.echo() and/or curses.endwin() results in incorrect ouput following file rename.

This PR addresses https://github.com/ranger/ranger/issues/2934

#### TESTING
* make tests pass [1]
* Potential solutions such as removing the `curses.echo()` and `curses.endwin()` did not completely fix the behavior
* attempted to call the patched `ui.suspend()` by `:open_with` and `:shell` commands which should utilize the terminal with no misbehavior

---
1- needed to specify pylint <= 2.17.7
