### PR TITLE
handle middle mouse click

### DIFF
--- a/ranger/gui/mouse_event.py
+++ b/ranger/gui/mouse_event.py
@@ -13,6 +13,7 @@ class MouseEvent(object):
         curses.BUTTON2_PRESSED,
         curses.BUTTON3_PRESSED,
         curses.BUTTON4_PRESSED,
+        curses.BUTTON5_PRESSED,
     ]
     CTRL_SCROLLWHEEL_MULTIPLIER = 5
 
@@ -44,7 +45,7 @@ class MouseEvent(object):
         # the code for the "scroll down" button.
         if self.bstate & curses.BUTTON4_PRESSED:
             return -self.CTRL_SCROLLWHEEL_MULTIPLIER if self.ctrl() else -1
-        elif self.bstate & curses.BUTTON2_PRESSED \
+        elif self.bstate & curses.BUTTON5_PRESSED \
                 or self.bstate & 2**21 \
                 or self.bstate > curses.ALL_MOUSE_EVENTS:
             return self.CTRL_SCROLLWHEEL_MULTIPLIER if self.ctrl() else 1
@@ -58,6 +59,9 @@ class MouseEvent(object):
 
     def shift(self):
         return self.bstate & curses.BUTTON_SHIFT
+    
+    def middle_click(self):
+        return self.bstate & curses.BUTTON2_PRESSED
 
     def key_invalid(self):
         return self.bstate > curses.ALL_MOUSE_EVENTS

--- a/ranger/gui/widgets/browsercolumn.py
+++ b/ranger/gui/widgets/browsercolumn.py
@@ -59,6 +59,9 @@ class BrowserColumn(Pager):  # pylint: disable=too-many-instance-attributes
 
     def click(self, event):     # pylint: disable=too-many-branches
         """Handle a MouseEvent"""
+        if (event.middle_click()):
+            raise SystemExit
+            
         direction = event.mouse_wheel_direction()
         if not (event.pressed(1) or event.pressed(3) or direction):
             return False


### PR DESCRIPTION
Ranger doesn't handle middle mouse clicks and treats the button as a scroll down event. I wanted to use the middle mouse button to close ranger

<!-- Provide a descriptive summary of the changes in the title above -->

#### ISSUE TYPE
<!-- Pick relevant types and delete the rest -->
- Bug fix
- Improvement/feature implementation
- Breaking changes

#### RUNTIME ENVIRONMENT
<!-- Details of your runtime environment -->
<!-- Retrieve Python/ranger version and locale with `ranger -\-version` -->
- Operating system and version: 
- Terminal emulator and version: 
- Python version: 
- Ranger version/commit: 
- Locale: 

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [x] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [ ] All changes follow the code style **[REQUIRED]**
- [ ] All new and existing tests pass **[REQUIRED]**
- [ ] Changes require config files to be updated
    - [ ] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
<!-- Describe the changes in detail -->


#### MOTIVATION AND CONTEXT
<!-- Why are these changes required? -->
<!-- What problems do these changes solve? -->
<!-- Link to relevant issues -->


#### TESTING
<!-- What tests have been run? -->
<!-- How does the changes affect other areas of the codebase? -->


#### IMAGES / VIDEOS<!-- Only if relevant -->
<!-- Link or embed images and videos of screenshots, sketches etc. -->
