### PR TITLE
handle middle mouse click and fix pylint tests

### DIFF
--- a/ranger/gui/mouse_event.py
+++ b/ranger/gui/mouse_event.py
@@ -13,6 +13,7 @@ class MouseEvent(object):
         curses.BUTTON2_PRESSED,
         curses.BUTTON3_PRESSED,
         curses.BUTTON4_PRESSED,
+        curses.BUTTON5_PRESSED,
     ]
     CTRL_SCROLLWHEEL_MULTIPLIER = 5
 
@@ -44,7 +45,7 @@ class MouseEvent(object):
         # the code for the "scroll down" button.
         if self.bstate & curses.BUTTON4_PRESSED:
             return -self.CTRL_SCROLLWHEEL_MULTIPLIER if self.ctrl() else -1
-        elif self.bstate & curses.BUTTON2_PRESSED \
+        elif self.bstate & curses.BUTTON5_PRESSED \
                 or self.bstate & 2**21 \
                 or self.bstate > curses.ALL_MOUSE_EVENTS:
             return self.CTRL_SCROLLWHEEL_MULTIPLIER if self.ctrl() else 1
@@ -58,6 +59,9 @@ class MouseEvent(object):
 
     def shift(self):
         return self.bstate & curses.BUTTON_SHIFT
+
+    def middle_click(self):
+        return self.bstate & curses.BUTTON2_PRESSED
 
     def key_invalid(self):
         return self.bstate > curses.ALL_MOUSE_EVENTS

--- a/ranger/gui/widgets/browsercolumn.py
+++ b/ranger/gui/widgets/browsercolumn.py
@@ -59,6 +59,9 @@ class BrowserColumn(Pager):  # pylint: disable=too-many-instance-attributes
 
     def click(self, event):     # pylint: disable=too-many-branches
         """Handle a MouseEvent"""
+        if (event.middle_click()):
+            raise SystemExit
+
         direction = event.mouse_wheel_direction()
         if not (event.pressed(1) or event.pressed(3) or direction):
             return False

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 flake8
 pylint
 pytest
+astroid>2.5,<3.0


### PR DESCRIPTION
<!-- Provide a descriptive summary of the changes in the title above -->

#### ISSUE TYPE
<!-- Pick relevant types and delete the rest -->
- Bug fix
- Improvement/feature implementation

#### RUNTIME ENVIRONMENT
<!-- Details of your runtime environment -->
<!-- Retrieve Python/ranger version and locale with `ranger -\-version` -->
- Operating system and version: Debian 12
- Terminal emulator and version: Kitty 0.26.5 & tmux 3.3a_3
- Python version: Python 3.9.18
- Ranger version/commit: 136416c
- Locale: en_GB.utf8

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [x] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [x] All changes follow the code style **[REQUIRED]**
- [x] All new and existing tests pass **[REQUIRED]**
- [ ] Changes require config files to be updated
    - [ ] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
Use middle mouse click to close and fix Pylint dependency problem

#### MOTIVATION AND CONTEXT
<!-- Why are these changes required? -->
Not able to customize the middle mouse button because ranger doesn't recognise it
<!-- What problems do these changes solve? -->
Allows seamless use of the mouse, preventing the need to touch the keyboard to close
<!-- Link to relevant issues -->
n/a

#### TESTING
<!-- What tests have been run? -->
make test
<!-- How does the changes affect other areas of the codebase? -->
n/a