### PR TITLE
Fix compatibility issues with Python 2.6

### DIFF
--- a/ranger/ext/img_display.py
+++ b/ranger/ext/img_display.py
@@ -456,11 +456,13 @@ class SixelImageDisplayer(ImageDisplayer, FileManagerAware):
 
     def _clear_cache(self, path):
         if os.path.exists(path):
-            self.cache = {
-                ce: cd
+            # pylint: disable=consider-using-dict-comprehension
+            # COMPAT Dictionary comprehensions didn't exist before 2.7
+            self.cache = dict([
+                (ce, cd)
                 for ce, cd in self.cache.items()
                 if ce.inode != os.stat(path).st_ino
-            }
+            ])
 
     def _sixel_cache(self, path, width, height):
         stat = os.stat(path)
@@ -478,8 +480,7 @@ class SixelImageDisplayer(ImageDisplayer, FileManagerAware):
             environ.setdefault("MAGICK_OCL_DEVICE", "true")
             try:
                 check_call(
-                    [
-                        *MAGICK_CONVERT_CMD_BASE,
+                    list(MAGICK_CONVERT_CMD_BASE) + [
                         path + "[0]",
                         "-geometry",
                         "{0}x{1}>".format(fit_width, fit_height),

--- a/ranger/ext/img_display.py
+++ b/ranger/ext/img_display.py
@@ -461,11 +461,13 @@ class SixelImageDisplayer(ImageDisplayer, FileManagerAware):
 
     def _clear_cache(self, path):
         if os.path.exists(path):
-            self.cache = {
-                ce: cd
+            # pylint: disable=consider-using-dict-comprehension
+            # COMPAT Dictionary comprehensions didn't exist before 2.7
+            self.cache = dict([
+                (ce, cd)
                 for ce, cd in self.cache.items()
                 if ce.inode != os.stat(path).st_ino
-            }
+            ])
 
     def _sixel_cache(self, path, width, height):
         stat = os.stat(path)
@@ -483,8 +485,7 @@ class SixelImageDisplayer(ImageDisplayer, FileManagerAware):
             environ.setdefault("MAGICK_OCL_DEVICE", "true")
             try:
                 check_call(
-                    [
-                        *MAGICK_CONVERT_CMD_BASE,
+                    list(MAGICK_CONVERT_CMD_BASE) + [
                         path + "[0]",
                         "-geometry",
                         "{0}x{1}>".format(fit_width, fit_height),

--- a/ranger/ext/popen_forked.py
+++ b/ranger/ext/popen_forked.py
@@ -19,12 +19,11 @@ def Popen_forked(*args, **kwargs):  # pylint: disable=invalid-name
         return False
     if pid == 0:
         os.setsid()
-        with open(os.devnull, 'r', encoding="utf-8") as null_r, open(
-            os.devnull, 'w', encoding="utf-8"
-        ) as null_w:
-            kwargs['stdin'] = null_r
-            kwargs['stdout'] = kwargs['stderr'] = null_w
-            Popen(*args, **kwargs)  # pylint: disable=consider-using-with
+        with open(os.devnull, 'r', encoding="utf-8") as null_r:
+            with open(os.devnull, 'w', encoding="utf-8") as null_w:
+                kwargs['stdin'] = null_r
+                kwargs['stdout'] = kwargs['stderr'] = null_w
+                Popen(*args, **kwargs)  # pylint: disable=consider-using-with
         os._exit(0)  # pylint: disable=protected-access
     else:
         os.wait()

--- a/ranger/ext/popen_forked.py
+++ b/ranger/ext/popen_forked.py
@@ -19,12 +19,11 @@ def Popen_forked(*args, **kwargs):  # pylint: disable=invalid-name
         return False
     if pid == 0:
         os.setsid()
-        with open(os.devnull, 'r', encoding="utf-8") as null_r, open(
-            os.devnull, 'w', encoding="utf-8"
-        ) as null_w:
-            kwargs['stdin'] = null_r
-            kwargs['stdout'] = kwargs['stderr'] = null_w
-            Popen(*args, **kwargs)  # pylint: disable=consider-using-with
+        with open(os.devnull, 'r', encoding="utf-8") as null_r:
+            with open(os.devnull, 'w', encoding="utf-8") as null_w:
+                kwargs['stdin'] = null_r
+                kwargs['stdout'] = kwargs['stderr'] = null_w
+                Popen(*args, **kwargs)  # pylint: disable=consider-using-with
         os._exit(0)  # pylint: disable=protected-access
     else:
         os.waitpid(pid, 0)

--- a/ranger/ext/rifle.py
+++ b/ranger/ext/rifle.py
@@ -142,12 +142,11 @@ except ImportError:
         if pid == 0:
             os.setsid()
             # pylint: disable=unspecified-encoding
-            with open(os.devnull, "r") as null_r, open(
-                os.devnull, "w"
-            ) as null_w:
-                kwargs["stdin"] = null_r
-                kwargs["stdout"] = kwargs["stderr"] = null_w
-                Popen(*args, **kwargs)  # pylint: disable=consider-using-with
+            with open(os.devnull, "r") as null_r:
+                with open(os.devnull, "w") as null_w:
+                    kwargs["stdin"] = null_r
+                    kwargs["stdout"] = kwargs["stderr"] = null_w
+                    Popen(*args, **kwargs)  # pylint: disable=consider-using-with
             os._exit(0)  # pylint: disable=protected-access
         return True
 

--- a/ranger/ext/rifle.py
+++ b/ranger/ext/rifle.py
@@ -145,12 +145,11 @@ except ImportError:
         if pid == 0:
             os.setsid()
             # pylint: disable=unspecified-encoding
-            with open(os.devnull, "r") as null_r, open(
-                os.devnull, "w"
-            ) as null_w:
-                kwargs["stdin"] = null_r
-                kwargs["stdout"] = kwargs["stderr"] = null_w
-                Popen(*args, **kwargs)  # pylint: disable=consider-using-with
+            with open(os.devnull, "r") as null_r:
+                with open(os.devnull, "w") as null_w:
+                    kwargs["stdin"] = null_r
+                    kwargs["stdout"] = kwargs["stderr"] = null_w
+                    Popen(*args, **kwargs)  # pylint: disable=consider-using-with
             os._exit(0)  # pylint: disable=protected-access
         return True
 

--- a/ranger/ext/which.py
+++ b/ranger/ext/which.py
@@ -4,7 +4,7 @@
 from __future__ import (absolute_import, division, print_function)
 
 import shutil
-from subprocess import check_output, CalledProcessError
+from ranger.ext.spawn import check_output, CalledProcessError
 from ranger import PY3
 
 


### PR DESCRIPTION
<!-- Provide a descriptive summary of the changes in the title above -->

#### ISSUE TYPE
<!-- Pick relevant types and delete the rest -->
- Bug fix

#### RUNTIME ENVIRONMENT
<!-- Details of your runtime environment -->
<!-- Retrieve Python/ranger version and locale with `ranger -\-version` -->
- Operating system and version: NixOS 24
- Terminal emulator and version: WezTerm 20230712-072601-f4abf8fd
- Python version: 2.6.9
- Ranger version/commit: 136416c7e2ecc27315fe2354ecadfe09202df7dd
- Locale: LC_ALL=C

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [x] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [x] All changes follow the code style **[REQUIRED]**
- [x] All new and existing tests pass **[REQUIRED]**
- [ ] Changes require config files to be updated
    - [ ] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION, MOTIVATION AND CONTEXT
<!-- Describe the changes in detail -->
<!-- Why are these changes required? -->
<!-- What problems do these changes solve? -->
<!-- Link to relevant issues -->

Various fixes for Python 2.6, namely:

- multi with/as: `with a as b, c as d: ...`
- list unpacking: `[*a, *b, ...]`
- `subprocess.check_output()`
- dictionary comprehension

#### TESTING
<!-- What tests have been run? -->
<!-- How does the changes affect other areas of the codebase? -->

Ran `make test_py` with 3.11 and ran ranger with `--clean` on 2.6

#### IMAGES / VIDEOS<!-- Only if relevant -->
<!-- Link or embed images and videos of screenshots, sketches etc. -->

N/A