### PR TITLE
basename_natural: Improve performance

### DIFF
--- a/ranger/container/fsobject.py
+++ b/ranger/container/fsobject.py
@@ -43,7 +43,7 @@ BAD_INFO = '?'
 
 _UNSAFE_CHARS = '\n' + ''.join(map(chr, range(32))) + ''.join(map(chr, range(128, 256)))
 _SAFE_STRING_TABLE = maketrans(_UNSAFE_CHARS, '?' * len(_UNSAFE_CHARS))
-_EXTRACT_NUMBER_RE = re.compile(r'(\d+|\D)')
+_EXTRACT_NUMBER_RE = re.compile(r'\d+|\D+')
 
 
 def safe_path(path):
@@ -157,21 +157,21 @@ class FileSystemObject(  # pylint: disable=too-many-instance-attributes,too-many
     @lazy_property
     def basename_natural(self):
         basename_list = []
-        for string in _EXTRACT_NUMBER_RE.split(self.relative_path):
-            try:
-                basename_list += [('0', int(string))]
-            except ValueError:
-                basename_list += [(string, 0)]
+        for string in _EXTRACT_NUMBER_RE.findall(self.relative_path):
+            if string[0].isdigit():
+                basename_list.append(('0', int(string)))
+            else:
+                basename_list.append((string,))
         return basename_list
 
     @lazy_property
     def basename_natural_lower(self):
         basename_list = []
-        for string in _EXTRACT_NUMBER_RE.split(self.relative_path_lower):
-            try:
-                basename_list += [('0', int(string))]
-            except ValueError:
-                basename_list += [(string, 0)]
+        for string in _EXTRACT_NUMBER_RE.findall(self.relative_path_lower):
+            if string[0].isdigit():
+                basename_list.append(('0', int(string)))
+            else:
+                basename_list.append((string,))
         return basename_list
 
     @lazy_property

--- a/tests/ranger/container/test_fsobject.py
+++ b/tests/ranger/container/test_fsobject.py
@@ -30,7 +30,7 @@ def test_basename_natural1():
             "hello",
             "hello1", "hello2",
             "hello11", "hello12",
-            "hello100", "hello101", "hello111", "hello112",
+            "hello100", "hello101", "hello111", "hello112"
         )
     ]
     assert fsos == sorted(fsos[::-1], key=operator.attrgetter("basename_natural"))
@@ -42,11 +42,12 @@ def test_basename_natural2():
     fsos = [
         create_filesystem_object(path)
         for path in (
-            "hello", "hello.txt",
-            "hello0.txt", "hello1.txt", "hello2.txt", "hello3.txt"
-            "hello10.txt", "hello11.txt", "hello12.txt", "hello13.txt"
-            "hello100.txt", "hello101.txt", "hello102.txt", "hello103.txt"
-            "hello110.txt", "hello111.txt", "hello112.txt", "hello113.txt"
+            "hello",
+            "hello0.txt", "hello1.txt", "hello2.txt", "hello3.txt",
+            "hello10.txt", "hello11.txt", "hello12.txt", "hello13.txt",
+            "hello100.txt", "hello101.txt", "hello102.txt", "hello103.txt",
+            "hello110.txt", "hello111.txt", "hello112.txt", "hello113.txt",
+            "hello.txt"
         )
     ]
     assert fsos == sorted(fsos[::-1], key=operator.attrgetter("basename_natural"))


### PR DESCRIPTION
<!-- Provide a descriptive summary of the changes in the title above -->

#### ISSUE TYPE
<!-- Pick relevant types and delete the rest -->
- Improvement/feature implementation
- Breaking changes

#### RUNTIME ENVIRONMENT
<!-- Details of your runtime environment -->
<!-- Retrieve Python/ranger version and locale with `ranger -\-version` -->
- Operating system and version: NixOS 24.05
- Terminal emulator and version: WezTerm 20230712-072601-f4abf8fd
- Python version: 2.6.9 2.7.10 3.11.6
- Ranger version/commit: 136416c7e2ecc27315fe2354ecadfe09202df7dd
- Locale: en_US.UTF-8

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [x] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [x] All changes follow the code style **[REQUIRED]**
- [x] All new and existing tests pass **[REQUIRED]**
- [ ] Changes require config files to be updated
    - [ ] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [x] Changes require tests to be updated
    - [x] Tests have been updated

#### DESCRIPTION
<!-- Describe the changes in detail -->

Various optimizations to `basename_natural` functions.

**Breaking change:** The regex was from `\D` to `\D+` so that all non-digits are grouped together and less elements are generated in `basename_list`, this results in the sorting order being changed so that numbers come before non-numbers after non-number prefixes. For example:

```
Original:
"a" < "a b" < "a#" < "a1" < "ab"
After changes:
"a" < "a1" < "a b" < "a#" < "ab"
```

Tests have been updated to reflect this. If this change is undesirable then I do have a version that keeps the original behavior, however it's slightly slower and much more complex.

#### MOTIVATION AND CONTEXT
<!-- Why are these changes required? -->
<!-- What problems do these changes solve? -->
<!-- Link to relevant issues -->

Helps with #1173, but doesn't completely address it.

In certain scenarios with file sorting method left as the default natural sort, a large chunk of time used in viewing large directories is spent on sorting. Running `ranger --profile` on a directory with 76k files on an NVMe drive shows 16 seconds out of the 24 seconds startup time is spent generating the natural sort keys.

#### TESTING
<!-- What tests have been run? -->
<!-- How does the changes affect other areas of the codebase? -->

Ran tests with `make test_py` on Python 3.11.

Results of profiling with `ranger --profile` on my `/nix/store` directory, which has 76k files:

```
Original:
       1    0.002   24.282  fm.py:388(loop)
   76079   14.642   16.219  fsobject.py:167(basename_natural_lower)
After changes:
       1    0.002   10.809  fm.py:388(loop)
   76079    1.826    2.966  fsobject.py:167(basename_natural_lower)
```

Testing only `basename_natural` with `timeit` shows an improvement from 15.0s to 1.3s on the same directory. (Alternate version that keeps the sorting behavior runs in 2.2s).

#### IMAGES / VIDEOS<!-- Only if relevant -->
<!-- Link or embed images and videos of screenshots, sketches etc. -->
