### PR TITLE
Load plugins from system confdir (/etc/ranger/plugins)

### DIFF
--- a/ranger/core/main.py
+++ b/ranger/core/main.py
@@ -438,49 +438,53 @@ def load_settings(  # pylint: disable=too-many-locals,too-many-branches,too-many
         load_custom_commands(system_comm_path, custom_comm_path)
 
         # XXX Load plugins (experimental)
-        plugindir = fm.confpath('plugins')
-        try:
-            plugin_files = os.listdir(plugindir)
-        except OSError:
-            LOG.debug('Unable to access plugin directory: %s', plugindir)
-        else:
-            plugins = []
-            for path in plugin_files:
-                if not path.startswith('_'):
-                    if path.endswith('.py'):
-                        # remove trailing '.py'
-                        plugins.append(path[:-3])
-                    elif os.path.isdir(os.path.join(plugindir, path)):
-                        plugins.append(path)
+        def try_load_plugins_from(plugindir):
+            try:
+                plugin_files = os.listdir(plugindir)
+            except OSError:
+                LOG.debug('Unable to access plugin directory: %s', plugindir)
+            else:
+                plugins = []
+                for path in plugin_files:
+                    if not path.startswith('_'):
+                        if path.endswith('.py'):
+                            # remove trailing '.py'
+                            plugins.append(path[:-3])
+                        elif os.path.isdir(os.path.join(plugindir, path)):
+                            plugins.append(path)
 
+                ranger.fm = fm
+                for plugin in sorted(plugins):
+                    try:
+                        try:
+                            # importlib does not exist before python2.7.  It's
+                            # required for loading commands from plugins, so you
+                            # can't use that feature in python2.6.
+                            import importlib
+                        except ImportError:
+                            module = __import__('plugins', fromlist=[plugin])
+                        else:
+                            module = importlib.import_module('plugins.' + plugin)
+                            fm.commands.load_commands_from_module(module)
+                        LOG.debug("Loaded plugin '%s'", plugin)
+                    except Exception as ex:  # pylint: disable=broad-except
+                        ex_msg = "Error while loading plugin '{0}'".format(plugin)
+                        LOG.error(ex_msg)
+                        LOG.exception(ex)
+                        fm.notify(ex_msg, bad=True)
+                ranger.fm = None
+
+        if os.path.exists(fm.confpath('plugins')):
             if not os.path.exists(fm.confpath('plugins', '__init__.py')):
-                LOG.debug("Creating missing '__init__.py' file in plugin folder")
+                LOG.debug("Creating missing '__init__.py' file in user plugin folder")
                 with open(
                     fm.confpath('plugins', '__init__.py'), 'w', encoding="utf-8"
                 ):
                     # Create the file if it doesn't exist.
                     pass
 
-            ranger.fm = fm
-            for plugin in sorted(plugins):
-                try:
-                    try:
-                        # importlib does not exist before python2.7.  It's
-                        # required for loading commands from plugins, so you
-                        # can't use that feature in python2.6.
-                        import importlib
-                    except ImportError:
-                        module = __import__('plugins', fromlist=[plugin])
-                    else:
-                        module = importlib.import_module('plugins.' + plugin)
-                        fm.commands.load_commands_from_module(module)
-                    LOG.debug("Loaded plugin '%s'", plugin)
-                except Exception as ex:  # pylint: disable=broad-except
-                    ex_msg = "Error while loading plugin '{0}'".format(plugin)
-                    LOG.error(ex_msg)
-                    LOG.exception(ex)
-                    fm.notify(ex_msg, bad=True)
-            ranger.fm = None
+        try_load_plugins_from(fm.confpath('plugins'))
+        try_load_plugins_from(os.path.join(system_confdir, 'plugins'))
 
         allow_access_to_confdir(ranger.args.confdir, False)
         # Load rc.conf


### PR DESCRIPTION
#### ISSUE TYPE
- Bug fix

#### RUNTIME ENVIRONMENT
- Operating system and version:  NixOS 23.11
- Terminal emulator and version: kitty 0.31.0
- Python version: 3.11.6 (main, Oct  2 2023, 13:45:54) [GCC 12.3.0]
- Ranger version/commit: ranger-master v1.9.3-720-gcb9ab8df
Locale: en_US.UTF-8

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [X] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [X] All changes follow the code style **[REQUIRED]**
- [X] All new and existing tests pass **[REQUIRED]**
- [ ] Changes require config files to be updated
    - [ ] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
This patch makes ranger load plugins from /etc/ranger/plugins

#### MOTIVATION AND CONTEXT
I wanted to setup ranger plugin system-wide using nixos system configuration, however I noticed that ranger does not load plugins placed in /etc/ranger/plugins
Since ranger already loads configuration from /etc/ranger/rc.conf, I excpected it would load plugins from the same system confdir too. This change fixes that.

#### TESTING
All test have ran successfully,
I believe this change doesn't affect other areas of the codebase
