### PR TITLE
new application context for files

### DIFF
--- a/ranger/container/fsobject.py
+++ b/ranger/container/fsobject.py
@@ -82,6 +82,7 @@ class FileSystemObject(  # pylint: disable=too-many-instance-attributes,too-many
     document = False
     image = False
     media = False
+    application = False
     video = False
 
     size = 0
@@ -196,7 +197,7 @@ class FileSystemObject(  # pylint: disable=too-many-instance-attributes,too-many
         except KeyError:
             return str(self.stat.st_gid)
 
-    for attr in ('video', 'audio', 'image', 'media', 'document', 'container'):
+    for attr in ('video', 'audio', 'image', 'media', 'document', 'container', 'application'):
         exec(  # pylint: disable=exec-used
             "%s = lazy_property(lambda self: self.set_mimetype() or self.%s)" % (attr, attr))
 
@@ -221,17 +222,18 @@ class FileSystemObject(  # pylint: disable=too-many-instance-attributes,too-many
             self._mimetype = ''
         # pylint: enable=attribute-defined-outside-init
 
-        self.video = self._mimetype.startswith('video')
-        self.image = self._mimetype.startswith('image')
-        self.audio = self._mimetype.startswith('audio')
+        self.video = self._mimetype.startswith('video/')
+        self.image = self._mimetype.startswith('image/')
+        self.audio = self._mimetype.startswith('audio/')
         self.media = self.video or self.image or self.audio
-        self.document = self._mimetype.startswith('text') \
+        self.document = self._mimetype.startswith('text/') \
             or self.extension in DOCUMENT_EXTENSIONS \
             or self.basename.lower() in DOCUMENT_BASENAMES
         self.container = self.extension in CONTAINER_EXTENSIONS
+        self.application = self._mimetype.startswith('application/')
 
         # pylint: disable=attribute-defined-outside-init
-        keys = ('video', 'audio', 'image', 'media', 'document', 'container')
+        keys = ('video', 'audio', 'image', 'media', 'document', 'container', 'application')
         self._mimetype_tuple = tuple(key for key in keys if getattr(self, key))
 
         if self._mimetype == '':

--- a/ranger/gui/context.py
+++ b/ranger/gui/context.py
@@ -11,7 +11,7 @@ CONTEXT_KEYS = [
     'active_pane', 'inactive_pane',
     'directory', 'file', 'hostname',
     'executable', 'media', 'link', 'fifo', 'socket', 'device',
-    'video', 'audio', 'image', 'media', 'document', 'container',
+    'video', 'audio', 'image', 'media', 'document', 'container', 'application',
     'selected', 'empty', 'main_column', 'message', 'background',
     'good', 'bad',
     'space', 'permissions', 'owner', 'group', 'mtime', 'nlink',


### PR DESCRIPTION
<!-- Provide a descriptive summary of the changes in the title above -->

#### ISSUE TYPE
<!-- Pick relevant types and delete the rest -->
- Improvement/feature implementation

#### RUNTIME ENVIRONMENT
<!-- Details of your runtime environment -->
<!-- Retrieve Python/ranger version and locale with `ranger -\-version` -->
- Operating system and version: Linux 6.6.8-100.fc38.x86_64 #1 SMP PREEMPT_DYNAMIC Thu Dec 21 04:01:45 UTC 2023 x86_64 GNU/Linux
- Terminal emulator and version: XTerm(388)
- Python version: Python 3.11.6
- Ranger version/commit: 136416c7e2ecc27315fe2354ecadfe09202df7dd ← Is this not a redundant question to ask?
- Locale: ja_JP.utf8

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [X] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [X] All changes follow the code style **[REQUIRED]**
- [X] All new and existing tests pass **[REQUIRED]**
- [ ] Changes require config files to be updated
    - [ ] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
<!-- Describe the changes in detail -->
This adds an “application” context for file MIME types, joining the likes of “audio”, “video”, etc--because I found it useful and hope that others might, too.  Example MIME types this covers:

⋅ application/json
⋅ application/x-bytecode.python
⋅ application/x-object

This also changes MIME checks to be more watertight/pedantic, because “textiles” are not the same thing as “text”.

#### MOTIVATION AND CONTEXT
Differentiation of files based on type helps aid in navigation.

#### TESTING
```
⬛ add-new-application-context make test_py
Running pylint...
pylint ./ranger/api ./ranger/colorschemes ./ranger/container ./ranger/core ./ranger/ext ./ranger/gui ./ranger/__init__.py ./doc/tools/performance_test.py ./doc/tools/print_colors.py ./doc/tools/print_keys.py ./doc/tools/convert_papermode_to_metadata.py ./examples/plugin_avfs.py ./examples/plugin_chmod_keybindings.py ./examples/plugin_fasd_add.py ./examples/plugin_file_filter.py ./examples/plugin_hello_world.py ./examples/plugin_linemode.py ./examples/plugin_new_macro.py ./examples/plugin_new_sorting_method.py ./examples/plugin_pmount.py ./examples/plugin_pmount_dynamic.py ./examples/plugin_ipc.py ./ranger.py ./setup.py ./tests

--------------------------------------------------------------------
Your code has been rated at 10.00/10 (previous run: 10.00/10, +0.00)

pylint --rcfile=./ranger/config/.pylintrc ./ranger/config

--------------------------------------------------------------------
Your code has been rated at 10.00/10 (previous run: 10.00/10, +0.00)

Running flake8...
flake8 ./ranger/api ./ranger/colorschemes ./ranger/container ./ranger/core ./ranger/ext ./ranger/gui ./ranger/__init__.py ./doc/tools/performance_test.py ./doc/tools/print_colors.py ./doc/tools/print_keys.py ./doc/tools/convert_papermode_to_metadata.py ./examples/plugin_avfs.py ./examples/plugin_chmod_keybindings.py ./examples/plugin_fasd_add.py ./examples/plugin_file_filter.py ./examples/plugin_hello_world.py ./examples/plugin_linemode.py ./examples/plugin_new_macro.py ./examples/plugin_new_sorting_method.py ./examples/plugin_pmount.py ./examples/plugin_pmount_dynamic.py ./examples/plugin_ipc.py ./ranger.py ./setup.py ./tests ./ranger/config

Running doctests...
Testing ranger/api/commands.py...
Testing ranger/ext/direction.py...
Testing ranger/ext/iter_tools.py...
Testing ranger/ext/lazy_property.py...
Testing ranger/ext/macrodict.py...
Testing ranger/ext/human_readable.py...
Testing ranger/ext/keybinding_parser.py...
Testing ranger/ext/rifle.py...
Testing ranger/ext/signals.py...
Testing ranger/ext/widestring.py...
Testing ranger/gui/ansi.py...
Testing ranger/gui/widgets/console.py...

Running py.test tests...
py.test tests
=============================================== test session starts ================================================
platform linux -- Python 3.11.6, pytest-7.2.2, pluggy-1.0.0
rootdir: /home/user/.local/git/ranger
plugins: anyio-3.5.0
collected 15 items

tests/pylint/test_py2_compat.py ........                                                                     [ 53%]
tests/ranger/container/test_bookmarks.py ..                                                                  [ 66%]
tests/ranger/container/test_container.py ..                                                                  [ 80%]
tests/ranger/container/test_fsobject.py ..                                                                   [ 93%]
tests/ranger/core/test_main.py .                                                                             [100%]

================================================ 15 passed in 0.36s ================================================

Checking completeness of man page...

Finished python and documentation tests!

```