### PR TITLE
import other configs from rifle.conf

### DIFF
--- a/ranger/ext/rifle.py
+++ b/ranger/ext/rifle.py
@@ -228,7 +228,7 @@ class Rifle(object):  # pylint: disable=too-many-instance-attributes
         if config_file is None:
             config_file = self.config_file
         self.rules = []
-        def processFile(name):
+        def process_file(name):
             with open(name, "r") as fobj:
                 for line in fobj:
                     line = line.strip()
@@ -236,7 +236,7 @@ class Rifle(object):  # pylint: disable=too-many-instance-attributes
                         continue
                     if line.startswith('!import'):
                         file = line[7:].strip()
-                        processFile(file)
+                        process_file(file)
                         continue
                     if self.delimiter1 not in line:
                         raise ValueError("Line without delimiter: '" + line + "'")
@@ -245,12 +245,11 @@ class Rifle(object):  # pylint: disable=too-many-instance-attributes
                     tests = tuple(tuple(f.strip().split(None, 1)) for f in tests)
                     command = command.strip()
                     self.rules.append((command, tests))
-        processFile(config_file)
+        process_file(config_file)
 
     def _eval_condition(self, condition, files, label):
         # Handle the negation of conditions starting with an exclamation mark,
         # then pass on the arguments to _eval_condition2().
-
         if not condition:
             return True
         if condition[0].startswith('!'):


### PR DESCRIPTION
<!-- Provide a descriptive summary of the changes in the title above -->

#### ISSUE TYPE
<!-- Pick relevant types and delete the rest -->
- Improvement/feature implementation

#### RUNTIME ENVIRONMENT
<!-- Details of your runtime environment -->
<!-- Retrieve Python/ranger version and locale with `ranger -\-version` -->
- Operating system and version: Arch linux rolling 
- Terminal emulator and version: kitty 0.31.0 
- Python version: 3.11.8$
- Ranger version/commit: 
- Locale: 

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [X] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [X] All changes follow the code style **[REQUIRED]**
- [ ] All new and existing tests pass **[REQUIRED]** (i got permission trough irc to ignore this)
- [ ] Changes require config files to be updated
    - [ ] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
<!-- Describe the changes in detail -->

you can add `!import /path/to/file` to rifle.conf to import another configuration file
works the same as if you copied the contents of the file and paated them into the config


#### MOTIVATION AND CONTEXT
<!-- Why are these changes required? -->
<!-- What problems do these changes solve? -->
you can break up your config for readability n stuff

currently, keeping configs up to date was your responsibility
now you can just import the original config at the bottom of yours to be up to date

#### TESTING
<!-- What tests have been run? -->
<!-- How does the changes affect other areas of the codebase? -->

didnt run any tests, `make test` crashes
from irc:
> __monty__ 22:02:43
> Feel free to ignore the pylint stuff until I've been able to deal with that.

<!-- Only if relevant -->
<!-- Link or embed images and videos of screenshots, sketches etc. -->
