### PR TITLE
Disable terminal focus reporting

### DIFF
--- a/ranger/gui/ui.py
+++ b/ranger/gui/ui.py
@@ -130,6 +130,7 @@ class UI(  # pylint: disable=too-many-instance-attributes,too-many-public-method
             self.win.addstr("loading...")
             self.win.refresh()
             self._draw_title = curses.tigetflag('hs')  # has_status_line
+        print("\x1b[?1004l")
 
         self.update_size()
         self.is_on = True


### PR DESCRIPTION
Terminals can be asked to report focus events with

        print("\x1b[?1004h")

For some reason, our use of curses sends a sequence like that (not
exactly that one, but it contains "1004", you can observe it by
running ranger inside "script").

Then the terminal will send ^[[I and ^[[O for "focus in" and "focus
out" events respectively.  This is quite annoying. The proper way
to deal with these is to map them ourselves in all modes (to a nop,
or optionally add some UI feedback).

I do not know how to do that, so turn it off altogether with the
corresponding "l" sequence.

Fixes #2864
