### PR TITLE
Add liberapay donation badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ ranger 1.9.3
 <a href="https://repology.org/metapackage/ranger/versions">
   <img src="https://repology.org/badge/latest-versions/ranger.svg" alt="latest packaged version(s)">
 </a>
+[![Donate via Liberapay](https://img.shields.io/liberapay/patrons/ranger)](https://liberapay.com/ranger)
 
 ranger is a console file manager with VI key bindings.  It provides a
 minimalistic and nice curses interface with a view on the directory hierarchy.

--- a/README.md
+++ b/README.md
@@ -4,9 +4,7 @@ ranger 1.9.3
 <img src="https://ranger.github.io/ranger_logo.png" width="150">
 
 [![Build Status](https://travis-ci.org/ranger/ranger.svg?branch=master)](https://travis-ci.org/ranger/ranger)
-<a href="https://repology.org/metapackage/ranger/versions">
-  <img src="https://repology.org/badge/latest-versions/ranger.svg" alt="latest packaged version(s)">
-</a>
+<a href="https://repology.org/metapackage/ranger/versions"><img src="https://repology.org/badge/latest-versions/ranger.svg" alt="latest packaged version(s)"></a>
 [![Donate via Liberapay](https://img.shields.io/liberapay/patrons/ranger)](https://liberapay.com/ranger)
 
 ranger is a console file manager with VI key bindings.  It provides a


### PR DESCRIPTION
This adds the liberapay donation badge to the README.

I had to put the "latest package version" badge from 3 lines into 1, otherwise the github markdown renderer would add a linked whitespace with a blue underline between the two badges, which looked terrible.