### PR TITLE
Avoid crash when setting 'max_console_history-size=None' in rc.conf

### DIFF
--- a/ranger/container/history.py
+++ b/ranger/container/history.py
@@ -13,7 +13,6 @@ class HistoryEmptyException(Exception):
 class History(object):
 
     def __init__(self, maxlen=None, unique=True):
-        assert maxlen is not None, "maxlen cannot be None"
         if isinstance(maxlen, History):
             self.history = list(maxlen.history)
             self.index = maxlen.index
@@ -39,7 +38,7 @@ class History(object):
             if self.history and self.history[-1] == item:
                 del self.history[-1]
         # Remove first if list is too long
-        if len(self.history) > max(self.maxlen - 1, 0):
+        if self.maxlen is not None and (len(self.history) > max(self.maxlen - 1, 0)):
             del self.history[0]
         # Append the item and fast forward
         self.history.append(item)
@@ -79,7 +78,7 @@ class History(object):
 
         self.history[:self.index] = list(
             other_history.history[:other_history.index + 1])
-        if len(self.history) > self.maxlen:
+        if self.maxlen is not None and (len(self.history) > self.maxlen):
             self.history = self.history[
                 -self.maxlen:]  # pylint: disable=invalid-unary-operand-type
 

--- a/tests/ranger/container/test_container.py
+++ b/tests/ranger/container/test_container.py
@@ -2,7 +2,6 @@ from __future__ import (absolute_import, division, print_function)
 
 from ranger.container import history
 
-
 HISTORY_TEST_ENTRIES = [str(k) for k in range(20)]
 OTHER_TEST_ENTRIES = [str(k) for k in range(40, 45)]
 
@@ -90,6 +89,29 @@ def testhistorybasic():
     # modify, modifies the top of the stack
     hist.modify("23")
     assert hist.current() == "23"
+
+
+def test_history_without_max_length():
+    unlimited_history = history.History(maxlen=None)
+    for entry in OTHER_TEST_ENTRIES:
+        unlimited_history.add(entry)
+    assert len(unlimited_history) == len(OTHER_TEST_ENTRIES)
+    # we create a copy to test the rebase
+    limited_history = history.History(maxlen=10)
+    for entry in HISTORY_TEST_ENTRIES:
+        limited_history.add(entry)
+    assert len(limited_history) == 10
+    # add a new entry to the unlimited history to check the top
+    top_entry = "1000"
+    unlimited_history.add(top_entry)
+    assert len(unlimited_history) == len(OTHER_TEST_ENTRIES) + 1
+    # check that unlimited history can handle rebase
+    unlimited_history.rebase(limited_history)
+    assert len(unlimited_history) == 11
+    assert len(limited_history) == 10
+    # check the rebase performed successfully
+    assert unlimited_history.current() == top_entry
+    assert list(unlimited_history)[len(unlimited_history) - 2] == limited_history.current()
 
 
 def testhistoryunique():


### PR DESCRIPTION
<!-- Provide a descriptive summary of the changes in the title above -->

#### ISSUE TYPE
<!-- Pick relevant types and delete the rest -->
- Bug fix

#### RUNTIME ENVIRONMENT
<!-- Details of your runtime environment -->
<!-- Retrieve Python/ranger version and locale with `ranger -\-version` -->
- Operating system and version: Arch kernel 6.8.8-arch1-1
- Terminal emulator and version: konsole 24.02.2
- Python version: 3.12.3
- Ranger version/commit: https://github.com/ranger/ranger/commit/38bb8901004b75a407ffee4b9e176bc0a436cb15
- Locale: es_ES.UTF-8

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [X] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [X] All changes follow the code style **[REQUIRED]**
- [X] All new and existing tests pass **[REQUIRED]**
- [ ] Changes require config files to be updated
    - [ ] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [X] Changes require tests to be updated
    - [X] Tests have been updated

#### DESCRIPTION
<!-- Describe the changes in detail -->
Allow for maxlen to be None and avoid operating with it in numeric computations. The code of History.add and History.rebase has been adapted in order to take this change into account. History behaves as expected when maxlen=None
* on add operations, the history has no limit
* on rebase operations, the history is rebased successfully


#### MOTIVATION AND CONTEXT
<!-- Why are these changes required? -->
<!-- What problems do these changes solve? -->
<!-- Link to relevant issues -->
The changes solve this issue https://github.com/ranger/ranger/issues/1895

#### TESTING
<!-- What tests have been run? -->
<!-- How does the changes affect other areas of the codebase? -->
All of the tests of ranger/test were executed and passed
