### PR TITLE
Linemode option documentation fix

### DIFF
--- a/doc/ranger.1
+++ b/doc/ranger.1
@@ -1586,7 +1586,7 @@ Sets the linemode of all files in the current directory.  The linemode may be:
 \&   format, more precise the more recent.
 \& "sizemtime":
 \&   display each line as "<basename>...<size> <mtime>" in ISO format
-\& "humanreadablesizemtime":
+\& "sizehumanreadablemtime":
 \&   display each line as "<basename>...<size> <mtime>" in a human
 \&   readable format, more precise the more recent.
 \& "permissions":

--- a/doc/ranger.pod
+++ b/doc/ranger.pod
@@ -1724,7 +1724,7 @@ Sets the linemode of all files in the current directory.  The linemode may be:
    format, more precise the more recent.
  "sizemtime":
    display each line as "<basename>...<size> <mtime>" in ISO format
- "humanreadablesizemtime":
+ "sizehumanreadablemtime":
    display each line as "<basename>...<size> <mtime>" in a human
    readable format, more precise the more recent.
  "permissions":


### PR DESCRIPTION
<!-- Provide a descriptive summary of the changes in the title above -->

#### ISSUE TYPE
- Improvement/feature implementation

#### RUNTIME ENVIRONMENT
- Operating system and version: Ubuntu 22.04 LTS
- Terminal emulator and version: Gnome Shell 42.9
- Python version: 3.10.12
- Ranger version/commit: 38bb8901004b75a407ffee4b9e176bc0a436cb15
- Locale: en_US

#### CHECKLIST
- [X] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [X] All changes follow the code style **[REQUIRED]**
- [ ] All new and existing tests pass **[REQUIRED]**
- [X] Changes require config files to be updated
    - [ ] Config files have been updated
- [X] Changes require documentation to be updated
    - [X] Documentation has been updated
- [ ] Changes require tests to be updated
    - [X] Tests have been updated

#### DESCRIPTION
Fixed inconsistency in ranger documentation where it was stated that commanding 'linemode humanreadablesizemtime' changed the linemode to display human readable modification time and file size, but the correct command for this is 'linemode sizehumanreadablemtime'


#### MOTIVATION AND CONTEXT
Found the issue when I tried to follow documentation to set the default line mode. Realized the issue and figured I should make this change since it makes the documentation accurate to what the software actually does and will likely help future documentation readers in the future save some time.


#### TESTING
Testing broke for the same reason disclosed [here](https://github.com/ranger/ranger/pull/2978)

#### IMAGES / VIDEOS
