### PR TITLE
fix(actions.py): misplaced name and value in error message

### DIFF
--- a/ranger/core/actions.py
+++ b/ranger/core/actions.py
@@ -134,7 +134,7 @@ class Actions(  # pylint: disable=too-many-instance-attributes,too-many-public-m
             return value
         if list in types:
             return value.split(',')
-        raise ValueError("Invalid value `%s' for option `%s'!" % (name, value))
+        raise ValueError("Invalid value `%s' for option `%s'!" % (value, name))
 
     def toggle_visual_mode(self, reverse=False, narg=None):
         """:toggle_visual_mode


### PR DESCRIPTION
Problem: the error message
```
"Invalid value `%s' for option `%s'!" % (name, value)
```
displays option name after "value" and option value after "option", e.g.
```
:set use_preview_script xxx
Invalid value `use_preview_script' for option `xxx'!
```
Apparently, it's supposed to say
```
Invalid value `xxx' for option `use_preview_script'!
```

Solution: swap arguments (name, value) after % string interpolation operator

Note: I believe using python f-strings [rather than % operator] is a better approach. In particular, f-strings could reduce this type of mistakes:
```
f"Invalid value `{value}' for option `{name}'!"
```
Also, see "Note" at https://docs.python.org/3.12/library/stdtypes.html#printf-style-string-formatting
Unfortunately, f-strings are only added in python 3.6, but ranger seems to be supporting plenty of older python versions including python 2 (?) :/