### PR TITLE
Implement timeout and memory limits for pandoc in scope.sh

### DIFF
--- a/ranger/data/scope.sh
+++ b/ranger/data/scope.sh
@@ -87,7 +87,15 @@ handle_extension() {
             ## Preview as text conversion
             odt2txt "${FILE_PATH}" && exit 5
             ## Preview as markdown conversion
-            pandoc -s -t markdown -- "${FILE_PATH}" && exit 5
+            ulimit -v 500000  # Limit to 500MB
+            timeout 10s pandoc -s -t markdown -- "${FILE_PATH}" && exit 5
+            if [ $? -eq 124 ]; then
+                echo "Pandoc timed out or was terminated due to excessive memory usage" >&2
+                exit 1
+            elif [ $? -ne 0 ]; then
+                echo "Pandoc failed" >&2
+                exit 1
+            fi
             exit 1;;
         ods|odp)
             ## Preview as text conversion (unsupported by pandoc for markdown)
@@ -107,7 +115,15 @@ handle_extension() {
             w3m -dump "${FILE_PATH}" && exit 5
             lynx -dump -- "${FILE_PATH}" && exit 5
             elinks -dump "${FILE_PATH}" && exit 5
-            pandoc -s -t markdown -- "${FILE_PATH}" && exit 5
+            ulimit -v 500000  # Limit to 500MB
+            timeout 10s pandoc -s -t markdown -- "${FILE_PATH}" && exit 5
+            if [ $? -eq 124 ]; then
+                echo "Pandoc timed out or was terminated due to excessive memory usage" >&2
+                exit 1
+            elif [ $? -ne 0 ]; then
+                echo "Pandoc failed" >&2
+                exit 1
+            fi
             ;;
 
         ## JSON
@@ -308,7 +324,15 @@ handle_mime() {
         ## uncommented other methods to preview those formats
         *wordprocessingml.document|*/epub+zip|*/x-fictionbook+xml)
             ## Preview as markdown conversion
-            pandoc -s -t markdown -- "${FILE_PATH}" && exit 5
+            ulimit -v 500000  # Limit to 500MB
+            timeout 10s pandoc -s -t markdown -- "${FILE_PATH}" && exit 5
+            if [ $? -eq 124 ]; then
+                echo "Pandoc timed out or was terminated due to excessive memory usage" >&2
+                exit 1
+            elif [ $? -ne 0 ]; then
+                echo "Pandoc failed" >&2
+                exit 1
+            fi
             exit 1;;
 
         ## E-mails


### PR DESCRIPTION
- Add a timeout of 10 seconds to pandoc commands to prevent indefinite execution.
- Introduce a memory limit of 500MB using ulimit to restrict pandoc's memory usage.
- Update relevant sections in scope.sh where pandoc is invoked, including handling OpenDocument, HTML, DOCX, ePub, and FB2 files.
- Implement error handling for cases where pandoc exceeds the timeout or memory limit, ensuring the script exits gracefully with an appropriate message.
- Improve the robustness of file previews in ranger by preventing pandoc from causing system instability due to excessive resource consumption.

#### ISSUE TYPE
- Improvement/feature implementation

#### RUNTIME ENVIRONMENT
ranger version: ranger 1.9.3

- Operating system and version: 
macOS 15.0.0

- Terminal emulator and version:
Apple Terminal (Version 453)

- Python version:
Python version: 3.11.9 (main, Apr  2 2024, 08:25:04) [Clang 15.0.0 (clang-1500.3.9.4)]

- Ranger version/commit: 
bd9b37faee9748798f3970468bd0d1dedbf0e99f

- Locale: 
Locale: en_US.UTF-8

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [x] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [x] All changes follow the code style **[REQUIRED]**
- [x] All new and existing tests pass **[REQUIRED]**
- [x] Changes require config files to be updated
    - [x] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
This pull request introduces a timeout and memory limit for the `pandoc` commands used in `scope.sh` to prevent indefinite execution and excessive memory consumption.

Specifically:

A timeout of 10 seconds is added to the `pandoc` commands.
Memory usage is limited to 500MB using ulimit.
These changes are applied to sections handling OpenDocument, HTML, DOCX, ePub, and FB2 files.
Error handling is included for cases where pandoc exceeds the timeout or memory limit, ensuring the script exits gracefully with an appropriate message.


#### MOTIVATION AND CONTEXT
These changes are required to improve the stability and robustness of file previews in `ranger` when handling files that require `pandoc` for conversion. Without these limits, `pandoc` can cause system instability by running indefinitely or consuming excessive resources, especially with large or complex files.


#### TESTING
<!-- What tests have been run? -->
Manual tests were conducted with various document types and sizes to ensure that `pandoc` is correctly terminated when exceeding the specified timeout or memory limits. The changes were verified to work without impacting other areas of the codebase. (more testing may be advised)
