### PR TITLE
Fixed mistooks of nim scripts as a video aNIMations in rifle.conf

### DIFF
--- a/ranger/config/rifle.conf
+++ b/ranger/config/rifle.conf
@@ -87,14 +87,15 @@ ext x?html?, has w3m,               terminal = w3m "$@"
 # Define the "editor" for text files as first action
 mime ^text,  label editor = ${VISUAL:-$EDITOR} -- "$@"
 mime ^text,  label pager  = $PAGER -- "$@"
-!mime ^text, label editor, ext xml|json|csv|tex|py|pl|rb|rs|js|sh|php|dart = ${VISUAL:-$EDITOR} -- "$@"
-!mime ^text, label pager,  ext xml|json|csv|tex|py|pl|rb|rs|js|sh|php|dart = $PAGER -- "$@"
+!mime ^text, label editor, ext xml|json|csv|tex|py|pl|rb|rs|js|sh|php|dart|nim = ${VISUAL:-$EDITOR} -- "$@"
+!mime ^text, label pager,  ext xml|json|csv|tex|py|pl|rb|rs|js|sh|php|dart|nim = $PAGER -- "$@"
 
 ext 1                         = man "$1"
 ext s[wmf]c, has zsnes, X     = zsnes "$1"
 ext s[wmf]c, has snes9x-gtk,X = snes9x-gtk "$1"
 ext nes, has fceux, X         = fceux "$1"
 ext exe, has wine             = wine "$1"
+ext nim, has nim 	      = nim r -- "$1"
 name ^[mM]akefile$            = make
 
 #--------------------------------------------
@@ -283,9 +284,9 @@ label open, has xdg-open = xdg-open "$@"
 label open, has open     = open -- "$@"
 
 # Define the editor for non-text files + pager as last action
-              !mime ^text, !ext xml|json|csv|tex|py|pl|rb|rs|js|sh|php|dart  = ask
-label editor, !mime ^text, !ext xml|json|csv|tex|py|pl|rb|rs|js|sh|php|dart  = ${VISUAL:-$EDITOR} -- "$@"
-label pager,  !mime ^text, !ext xml|json|csv|tex|py|pl|rb|rs|js|sh|php|dart  = $PAGER -- "$@"
+              !mime ^text, !ext xml|json|csv|tex|py|pl|rb|rs|js|sh|php|dart|nim  = ask
+label editor, !mime ^text, !ext xml|json|csv|tex|py|pl|rb|rs|js|sh|php|dart|nim  = ${VISUAL:-$EDITOR} -- "$@"
+label pager,  !mime ^text, !ext xml|json|csv|tex|py|pl|rb|rs|js|sh|php|dart|nim  = $PAGER -- "$@"
 
 
 ######################################################################

--- a/ranger/data/mime.types
+++ b/ranger/data/mime.types
@@ -31,7 +31,7 @@ image/webp              webp
 
 message/rfc822          eml
 
-text/plain              hs lhs rs ts tsx
+text/plain              hs lhs nim rs ts tsx
 text/x-ruby             rb
 text/x-shellscript      sh
 


### PR DESCRIPTION
I've opened an issue for it: https://github.com/ranger/ranger/issues/3010

<!-- Provide a descriptive summary of the changes in the title above -->

#### ISSUE TYPE
<!-- Pick relevant types and delete the rest -->
- Bug fix
- Improvement/feature implementation

#### Runtime Environment
- OS: Linux tfed-laptop 6.6.47-1-MANJARO `#1` SMP PREEMPT_DYNAMIC Mon Aug 19 09:51:26 UTC 2024 x86_64 GNU/Linux
- terminal: xfce4-terminal 1.1.3 (Xfce 4.18)
- Python version: 3.12.5 (main, Aug  9 2024, 08:20:41) [GCC 14.2.1 20240805]
- `I've got a local ranger git package` 
- ranger version: ranger-master v1.9.3-730-gbd9b37fa
- Ranger version/commit: bd9b37faee9748798f3970468bd0d1dedbf0e99f (the latest one)
- Locale: en_US.UTF-8

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [X] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [X] All changes follow the code style **[REQUIRED]**
- [ ] All new and existing tests pass **[REQUIRED]**
- [X] Changes require config files to be updated
    - [X] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [X] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
<!-- Describe the changes in detail -->
I add `.nim` file-type in support due to #3010 issue

#### MOTIVATION AND CONTEXT
<!-- Why are these changes required? -->
<!-- What problems do these changes solve? -->
<!-- Link to relevant issues -->
ranger (meaning rifle) doesn't want to open `.nim` from `l` and `Right` keys
because he thinks that `nim` stands for aNIMation, and not for Nim Programming Language

#### TESTING
<!-- What tests have been run? -->
<!-- How does the changes affect other areas of the codebase? -->
I haven't made much testes.
But it seems to work to me.
Because I've added minimal changes.

#### IMAGES / VIDEOS<!-- Only if relevant -->
<!-- Link or embed images and videos of screenshots, sketches etc. -->
