### PR TITLE
Add IINA to rifle.conf

### DIFF
--- a/ranger/config/rifle.conf
+++ b/ranger/config/rifle.conf
@@ -121,6 +121,8 @@ ext midi?,        terminal, has wildmidi = wildmidi -- "$@"
 #-------------------------------------------
 mime ^video|^audio, has gmplayer, X, flag f = gmplayer -- "$@"
 mime ^video|^audio, has smplayer, X, flag f = smplayer "$@"
+mime ^video,        has iina,     X, flag f = iina -- "$@"
+mime ^video|^audio, has iina,     X, flag f = iina --music-mode -- "$@"
 mime ^video,        has mpv,      X, flag f = mpv -- "$@"
 mime ^video,        has mpv,      X, flag f = mpv --fs -- "$@"
 mime ^video,        has mplayer2, X, flag f = mplayer2 -- "$@"


### PR DESCRIPTION
We prefer IINA over mpv as it's a native macOS app that uses libmpv as its backend. The `iina` command is provided by Homebrew Cask and the Nix package rather than upstream.

#### ISSUE TYPE

- Improvement/feature implementation

#### RUNTIME ENVIRONMENT

- Operating system and version: macOS 15

#### CHECKLIST

- [x] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [x] All changes follow the code style **[REQUIRED]**
- [ ] All new and existing tests pass **[REQUIRED]**
- [x] Changes require config files to be updated
    - [x] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated