### PR TITLE
Add option confirm_on_trash (minor edit)

### DIFF
--- a/doc/ranger.pod
+++ b/doc/ranger.pod
@@ -1031,6 +1031,12 @@ Ask for a confirmation when running the "delete" command?  Valid values are
 "always", "never", "multiple" (default). With "multiple", ranger will ask only
 if you delete multiple files at once.
 
+=item confirm_on_trash [string]
+
+Ask for a confirmation when running the "trash" command?  Valid values are
+"always", "never", "multiple", "like_delete" (default). With "like_delete",
+ranger will honor the parameter "confirm_on_delete" instead.
+
 =item dirname_in_tabs [bool]
 
 Display the directory name in tabs?

--- a/ranger/config/commands.py
+++ b/ranger/config/commands.py
@@ -822,7 +822,11 @@ class trash(Command):
             file_names = [f.relative_path for f in files]
             many_files = (cwd.marked_items or is_directory_with_files(tfile.path))
 
-        confirm = self.fm.settings.confirm_on_delete
+        confirm = self.fm.settings.confirm_on_trash
+
+        if confirm == 'like_delete':
+            confirm = self.fm.settings.confirm_on_delete
+
         if confirm != 'never' and (confirm != 'multiple' or many_files):
             self.fm.ui.console.ask(
                 "Confirm deletion of: %s (y/N)" % ', '.join(file_names),

--- a/ranger/config/rc.conf
+++ b/ranger/config/rc.conf
@@ -40,6 +40,12 @@ set show_hidden false
 # With "multiple", ranger will ask only if you delete multiple files at once.
 set confirm_on_delete multiple
 
+# Ask for a confirmation when running the "trash" command?
+# Valid values are "always", "never", "multiple", "like_delete" (default)
+# With "like_delete", ranger will honor the parameter "confirm_on_delete" instead.
+set confirm_on_trash like_delete
+
+
 # Use non-default path for file preview script?
 # ranger ships with scope.sh, a script that calls external programs (see
 # README.md for dependencies) to preview images, archives, etc.

--- a/ranger/container/settings.py
+++ b/ranger/container/settings.py
@@ -35,6 +35,7 @@ ALLOWED_SETTINGS = {
     'colorscheme': str,
     'column_ratios': (tuple, list),
     'confirm_on_delete': str,
+    'confirm_on_trash': str,
     'dirname_in_tabs': bool,
     'display_size_in_main_column': bool,
     'display_size_in_status_bar': bool,
@@ -108,6 +109,7 @@ ALLOWED_SETTINGS = {
 ALLOWED_VALUES = {
     'cd_tab_case': ['sensitive', 'insensitive', 'smart'],
     'confirm_on_delete': ['multiple', 'always', 'never'],
+    'confirm_on_trash': ['like_delete', 'multiple', 'always', 'never'],
     'draw_borders': ['none', 'both', 'outline', 'separators'],
     'draw_borders_multipane': [None, 'none', 'both', 'outline',
                                'separators', 'active-pane'],


### PR DESCRIPTION
Novel option "confirm_on_trash" is similar to option "confirm_on_delete", but for the "trash" action.

Default value for this option is "like_delete" for backwards compatibility.

#### ISSUE TYPE
- Improvement/feature implementation

#### RUNTIME ENVIRONMENT
<!-- Details of your runtime environment -->
<!-- Retrieve Python/ranger version and locale with `ranger -\-version` -->
- Operating system and version: Debian Trixie
- Terminal emulator and version: Xterm(395)
- Python version: 3.12.7 (main, Nov  8 2024, 17:55:36) [GCC 14.2.0]
- Ranger version/commit: ranger-master v1.9.3-731-gd97b6fc1
- Locale: en_US.UTF-8

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [X] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [X] All changes follow the code style **[REQUIRED]**
- [ ] All new and existing tests pass **[REQUIRED]**
- [X] Changes require config files to be updated
    - [X] Config files have been updated
- [X] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION

Didn't run "make man", as pod2man seems not to work well on my installation.


#### MOTIVATION AND CONTEXT
<!-- Why are these changes required? -->
<!-- What problems do these changes solve? -->
<!-- Link to relevant issues -->
Trashing and deleting a file are completely different actions in terms of safety: one wants ranger to ask for confirmation when deleting whereas ranger should not ask for confirmation when trashing.  This option allows the user to enable this.

#### TESTING
<!-- What tests have been run? -->
<!-- How does the changes affect other areas of the codebase? -->


