### PR TITLE
Properly auto-detect support for Kitty image previews

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ For general usage:
 For enhanced file previews (with `scope.sh`):
 
 * `img2txt` (from `caca-utils`) for ASCII-art image previews
-* `w3mimgdisplay`, `ueberzug`, `mpv`, `iTerm2`, `kitty`, `terminology` or `urxvt` for image previews
+* `w3mimgdisplay`, `ueberzug`, `mpv`, `iTerm2`, `kitty` (or other supporting terminal), `terminology` or `urxvt` for image previews
 * `convert` (from `imagemagick`) to auto-rotate images and for image previews
 * `rsvg-convert` (from [`librsvg`](https://wiki.gnome.org/Projects/LibRsvg))
   for SVG previews

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ For general usage:
 For enhanced file previews (with `scope.sh`):
 
 * `img2txt` (from `caca-utils`) for ASCII-art image previews
-* `w3mimgdisplay`, `ueberzug`, `mpv`, `iTerm2`, `kitty` (or other supporting terminal), `terminology` or `urxvt` for image previews
+* `w3mimgdisplay`, `ueberzug`, `mpv`, `iTerm2`, `kitty` (or other terminal supporting the Kitty graphics protocol), `terminology` or `urxvt` for image previews
 * `convert` (from `imagemagick`) to auto-rotate images and for image previews
 * `rsvg-convert` (from [`librsvg`](https://wiki.gnome.org/Projects/LibRsvg))
   for SVG previews

--- a/doc/ranger.pod
+++ b/doc/ranger.pod
@@ -230,8 +230,8 @@ C<img2txt> (from C<caca-utils>) for ASCII-art image previews
 
 =item -
 
-C<w3mimgdisplay>, C<ueberzug>, C<mpv>, C<iTerm2>, C<kitty>, C<terminology> or
-C<urxvt> for image previews
+C<w3mimgdisplay>, C<ueberzug>, C<mpv>, C<iTerm2>, C<kitty> (or other supporting
+terminal), C<terminology> or C<urxvt> for image previews
 
 =item -
 
@@ -342,7 +342,7 @@ Preferred dithering method can be specified by setting C<sixel_dithering>.
 
 =head3 kitty
 
-This only works in Kitty. It requires PIL (or pillow) to work.
+This works in Kitty and a few other terminals. It requires PIL (or pillow) to work.
 Allows remote image previews, for example in an ssh session.
 
 To enable this feature, set the option C<preview_images_method> to kitty.

--- a/doc/ranger.pod
+++ b/doc/ranger.pod
@@ -230,8 +230,9 @@ C<img2txt> (from C<caca-utils>) for ASCII-art image previews
 
 =item -
 
-C<w3mimgdisplay>, C<ueberzug>, C<mpv>, C<iTerm2>, C<kitty> (or other supporting
-terminal), C<terminology> or C<urxvt> for image previews
+C<w3mimgdisplay>, C<ueberzug>, C<mpv>, C<iTerm2>, C<kitty> (or other terminal
+supporting the Kitty graphics protocol), C<terminology> or C<urxvt> for image
+previews
 
 =item -
 
@@ -342,7 +343,8 @@ Preferred dithering method can be specified by setting C<sixel_dithering>.
 
 =head3 kitty
 
-This works in Kitty and a few other terminals. It requires PIL (or pillow) to work.
+This works in terminals supporting the Kitty graphics protocol. It requires PIL
+(or pillow) to work.
 Allows remote image previews, for example in an ssh session.
 
 To enable this feature, set the option C<preview_images_method> to kitty.

--- a/ranger/config/rc.conf
+++ b/ranger/config/rc.conf
@@ -116,7 +116,8 @@ set preview_images false
 #   the transfer method is changed to encode the whole image;
 #   while slower, this allows remote previews,
 #   for example during an ssh session.
-#   Tmux is unsupported.
+#   Any terminal supporting the kitty image protocol should work automatically.
+#   Note that tmux breaks this, and is therefore unsupported.
 #
 # * ueberzug:
 #   Preview images in full color with the external command "ueberzug".

--- a/ranger/config/rc.conf
+++ b/ranger/config/rc.conf
@@ -116,8 +116,9 @@ set preview_images false
 #   the transfer method is changed to encode the whole image;
 #   while slower, this allows remote previews,
 #   for example during an ssh session.
-#   Any terminal supporting the kitty image protocol should work automatically.
-#   Note that tmux breaks this, and is therefore unsupported.
+#   Any terminal supporting the Kitty graphics protocol should work automatically.
+#   Note that the Kitty graphics protocol does not work from inside a tmux
+#   session, so tmux is unsupported.
 #
 # * ueberzug:
 #   Preview images in full color with the external command "ueberzug".

--- a/ranger/config/rifle.conf
+++ b/ranger/config/rifle.conf
@@ -253,6 +253,7 @@ mime ^font, has fontforge, X, flag f = fontforge "$@"
 # gnome-terminal/konsole/xterm on the other hand are often installed as part of
 # a desktop environment or as fallback terminal emulators.
 mime ^ranger/x-terminal-emulator, has terminology = terminology -e "$@"
+mime ^ranger/x-terminal-emulator, has ghostty = ghostty -e "$@"
 mime ^ranger/x-terminal-emulator, has kitty = kitty -- "$@"
 mime ^ranger/x-terminal-emulator, has alacritty = alacritty -e "$@"
 mime ^ranger/x-terminal-emulator, has sakura = sakura -e "$@"

--- a/ranger/ext/img_display.py
+++ b/ranger/ext/img_display.py
@@ -772,7 +772,7 @@ class KittyImageDisplayer(ImageDisplayer, FileManagerAware):
             self.stream = True
         else:
             raise ImgDisplayUnsupportedException(
-                'kitty replied an unexpected response: {r}'.format(r=resp))
+                'kitty protocol replied an unexpected response: {r}'.format(r=resp))
 
         # get the image manipulation backend
         try:
@@ -781,7 +781,7 @@ class KittyImageDisplayer(ImageDisplayer, FileManagerAware):
             import PIL.Image
             self.backend = PIL.Image
         except ImportError:
-            raise ImageDisplayError("Image previews in kitty require PIL (pillow)")
+            raise ImageDisplayError("kitty image previews require PIL (pillow)")
             # TODO: implement a wrapper class for Imagemagick process to
             # replicate the functionality we use from im
 
@@ -864,7 +864,7 @@ class KittyImageDisplayer(ImageDisplayer, FileManagerAware):
         if b'OK' in resp:
             return
         else:
-            raise ImageDisplayError('kitty replied "{r}"'.format(r=resp))
+            raise ImageDisplayError('kitty protocol replied "{r}"'.format(r=resp))
 
     def clear(self, start_x, start_y, width, height):
         # let's assume that every time ranger call this

--- a/ranger/ext/img_display.py
+++ b/ranger/ext/img_display.py
@@ -720,29 +720,35 @@ class KittyImageDisplayer(ImageDisplayer, FileManagerAware):
         self.temp_file_dir = None  # Only used when streaming is not an option
 
     def _late_init(self):
-        # tmux
-        if 'kitty' not in os.environ['TERM']:
-            # this doesn't seem to work, ranger freezes...
-            # commenting out the response check does nothing
-            # self.protocol_start = b'\033Ptmux;\033' + self.protocol_start
-            # self.protocol_end += b'\033\\'
-            raise ImgDisplayUnsupportedException(
-                'kitty previews only work in'
-                + ' kitty and outside tmux. '
-                + 'Make sure your TERM contains the string "kitty"')
-
-        # automatic check if we share the filesystem using a dummy file
+        # query terminal for kitty image support
+        # https://sw.kovidgoyal.net/kitty/graphics-protocol/#querying-support-and-available-transmission-mediums
+        # combined with automatic check if we share the filesystem using a dummy file
         with NamedTemporaryFile() as tmpf:
             tmpf.write(bytearray([0xFF] * 3))
             tmpf.flush()
+            # kitty image protocol query
             for cmd in self._format_cmd_str(
                     {'a': 'q', 'i': 1, 'f': 24, 't': 'f', 's': 1, 'v': 1, 'S': 3},
                     payload=base64.standard_b64encode(tmpf.name.encode(self.fsenc))):
                 self.stdbout.write(cmd)
             sys.stdout.flush()
+            # VT100 Primary Device Attributes (DA1) query
+            self.stdbout.write(b'\x1b[c')
+            sys.stdout.flush()
+            # read response(s); DA1 response should always be last
             resp = b''
-            while resp[-2:] != self.protocol_end:
+            #          (DA1 resp start   )     (DA1 resp end     )
+            while not ((b'\x1b[?' in resp) and (resp[-1:] == b'c')):
                 resp += self.stdbin.read(1)
+
+        # check whether kitty query was acknowledged
+        # NOTE: this catches tmux too, no special case needed!
+        if not resp.startswith(self.protocol_start):
+            raise ImgDisplayUnsupportedException(
+                'terminal did not respond to kitty image-support query; disabling')
+        # strip resp down to just the kitty response
+        resp = resp[:resp.find(self.protocol_end) + 1]
+
         # set the transfer method based on the response
         # if resp.find(b'OK') != -1:
         if b'OK' in resp:


### PR DESCRIPTION
#### ISSUE TYPE
- Improvement/feature implementation

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [X] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [X] All changes follow the code style **[REQUIRED]**
- [X] All new and existing tests pass **[REQUIRED]**
- [ ] Changes require config files to be updated
    - [ ] Config files have been updated
- [X] Changes require documentation to be updated
    - [x] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
Rather than checking `$TERM` to determine Kitty image protocol support, we can [query the terminal itself](https://sw.kovidgoyal.net/kitty/graphics-protocol/#querying-support-and-available-transmission-mediums). This means we will never need a list of supported terminals, and any new ones that add support will Just Work™.

Also, we add support for auto-detecting Ghostty in `rifle.conf`, just because that's not worth opening a whole new PR for.


#### MOTIVATION AND CONTEXT
Resolves #3035.
Currently, the Kitty image protocol is enabled only if `$TERM` contains `kitty`. That ain't gonna cut it, now that support for the protocol is being more widely implemented.

#### TESTING
~~Currently, `make test` is broken (see #2976).~~ *Fixed now, and all tests pass!*
These changes have also been tested locally, and function as intended in both Kitty and Ghostty.