### PR TITLE
README: Update version, forge-agnostic URL and center logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <img src="https://ranger.github.io/ranger_logo.png" width="200">
 </a>
 
-ranger 1.9.3
+ranger 1.9.4
 ============
 
 [![Python lints and tests](https://github.com/ranger/ranger/actions/workflows/python.yml/badge.svg)](https://github.com/ranger/ranger/actions/workflows/python.yml)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <img src="https://ranger.github.io/ranger_logo.png" width="200">
 </a>
 
-ranger 1.9.4
+Ranger 1.9.4
 ============
 
 [![Python lints and tests](https://github.com/ranger/ranger/actions/workflows/python.yml/badge.svg)](https://github.com/ranger/ranger/actions/workflows/python.yml)
@@ -11,7 +11,7 @@ ranger 1.9.4
 [![Donate via Liberapay](https://img.shields.io/liberapay/patrons/ranger)](https://liberapay.com/ranger)
 </div>
 
-ranger is a console file manager with VI key bindings.  It provides a
+Ranger is a console file manager with VI key bindings.  It provides a
 minimalistic and nice curses interface with a view on the directory hierarchy.
 It ships with `rifle`, a file launcher that is good at automatically finding
 out which program to use for what file type.

--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
 <div align="center">
+<a href="https://ranger.fm/">
 <img src="https://ranger.github.io/ranger_logo.png" width="200">
+</a>
 
 ranger 1.9.3
 ============
 
-[![Build Status](https://travis-ci.org/ranger/ranger.svg?branch=master)](https://travis-ci.org/ranger/ranger)
+[![Python lints and tests](https://github.com/ranger/ranger/actions/workflows/python.yml/badge.svg)](https://github.com/ranger/ranger/actions/workflows/python.yml)
 <a href="https://repology.org/metapackage/ranger/versions"><img src="https://repology.org/badge/latest-versions/ranger.svg" alt="latest packaged version(s)"></a>
 [![Donate via Liberapay](https://img.shields.io/liberapay/patrons/ranger)](https://liberapay.com/ranger)
 </div>

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
+<img src="https://ranger.github.io/ranger_logo.png" width="150">
+
 ranger 1.9.3
 ============
-
-<img src="https://ranger.github.io/ranger_logo.png" width="150">
 
 [![Build Status](https://travis-ci.org/ranger/ranger.svg?branch=master)](https://travis-ci.org/ranger/ranger)
 <a href="https://repology.org/metapackage/ranger/versions"><img src="https://repology.org/badge/latest-versions/ranger.svg" alt="latest packaged version(s)"></a>

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<img src="https://ranger.github.io/ranger_logo.png" width="150">
+<img src="https://ranger.github.io/ranger_logo.png" width="200">
 
 ranger 1.9.3
 ============

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+<div align="center">
 <img src="https://ranger.github.io/ranger_logo.png" width="200">
 
 ranger 1.9.3
@@ -6,6 +7,7 @@ ranger 1.9.3
 [![Build Status](https://travis-ci.org/ranger/ranger.svg?branch=master)](https://travis-ci.org/ranger/ranger)
 <a href="https://repology.org/metapackage/ranger/versions"><img src="https://repology.org/badge/latest-versions/ranger.svg" alt="latest packaged version(s)"></a>
 [![Donate via Liberapay](https://img.shields.io/liberapay/patrons/ranger)](https://liberapay.com/ranger)
+</div>
 
 ranger is a console file manager with VI key bindings.  It provides a
 minimalistic and nice curses interface with a view on the directory hierarchy.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 <a href="https://ranger.fm/">
-<img src="https://ranger.github.io/ranger_logo.png" width="200">
+<img src="https://ranger.fm/ranger_logo.png" width="200">
 </a>
 
 Ranger 1.9.4
@@ -45,8 +45,8 @@ About
 -----
 * Authors:     see `AUTHORS` file
 * License:     GNU General Public License Version 3
-* Website:     https://ranger.github.io/
-* Download:    https://ranger.github.io/ranger-stable.tar.gz
+* Website:     https://ranger.fm/
+* Download:    https://ranger.fm/ranger-stable.tar.gz
 * Bug reports: https://github.com/ranger/ranger/issues
 * git clone    https://github.com/ranger/ranger.git
 


### PR DESCRIPTION
The release neglected to bump the version in the README.

Since we're considering changing forges, switching to forge-agnostic URLs for the homepage and assets makes it more future-proof.

Replace the Travis badge with a GHActions badge.

Consolidate some style changes for the header of the README.