### PR TITLE
Adapt to NCurses endwin() error behavior

### DIFF
--- a/ranger/gui/ui.py
+++ b/ranger/gui/ui.py
@@ -151,10 +151,6 @@ class UI(  # pylint: disable=too-many-instance-attributes,too-many-public-method
         self.win.keypad(0)
         curses.nocbreak()
         curses.echo()
-        try:
-            curses.curs_set(1)
-        except curses.error:
-            pass
         if self.settings.mouse_enabled:
             _setup_mouse({"value": False})
         curses.endwin()

--- a/ranger/gui/ui.py
+++ b/ranger/gui/ui.py
@@ -128,8 +128,9 @@ class UI(  # pylint: disable=too-many-instance-attributes,too-many-public-method
             self.is_set_up = True
             self.setup()
             self.win.addstr("loading...")
-            self.win.refresh()
             self._draw_title = curses.tigetflag('hs')  # has_status_line
+
+        self.win.refresh()
 
         self.update_size()
         self.is_on = True


### PR DESCRIPTION
 NCurses errors when `endwin()` is called twice in a row without the window being refreshed.
    
Runner suspends the window (calling `endwin()` indirectly) and uses  `initialize` to resume the curses window. The latter was originally envisioned as more of a one-item setup and only refreshes the window the first time it is called. Refreshing unconditionally avoids the problem.

Fixes #2934
Closes #2935
Fixes #3000
Fixes #3005