### PR TITLE
Avoid running older Pylint with Pypy

### DIFF
--- a/.github/workflows/pypy.yml
+++ b/.github/workflows/pypy.yml
@@ -28,4 +28,14 @@ jobs:
         pip install -r requirements.txt
     - name: Pypy lints and tests
       run: |
-        make test_py
+        flake8_version=$(flake8 --version | head -1 | cut -f 1 -d ' ')
+        # If the versions are already sorted our flake8 is as or more recent
+        if [ $(printf '7.1.1\n%s\n' "$flake8_version" | sort -CV) ]; then
+          make test_flake8
+        fi
+        pylint_version=$(pylint --version | head -1 | cut -f 2 -d ' ')
+        # If the versions are already sorted our Pylint is as or more recent
+        if [ $(printf '3.3.1\n%s\n' "$pylint_version" | sort -CV) ]; then
+          make test_pylint
+        fi
+        make test_doctest test_pytest test_other

--- a/.github/workflows/pypy.yml
+++ b/.github/workflows/pypy.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [pypy2.7, pypy3.9]
+        python-version: [pypy2.7, pypy3.10]
     env:
       TERM: dumb
     steps:


### PR DESCRIPTION
Pypy 2.7 can only run Python 2.7 compatible Pylint and that effectively enforces a completely different linting standard. We can't satisfy both old and new Pylints so let's simply avoid running it altogether unless it's recent enough.

The only Pylint check that's really important is the one run for CPython 3. The version specified here, `3.3.1`, will have to manually be bumped if the Pylint versions for CPython 3 and Pypy 3 diverge sufficiently.