### PR TITLE
add: support for tilde in bookmarks

### DIFF
--- a/ranger/container/bookmarks.py
+++ b/ranger/container/bookmarks.py
@@ -9,6 +9,7 @@ import os
 from io import open
 
 from ranger import PY3
+from ranger.container import fsobject
 from ranger.core.shared import FileManagerAware
 
 ALLOWED_KEYS = string.ascii_letters + string.digits + "`'"
@@ -182,6 +183,8 @@ class Bookmarks(FileManagerAware):
                 for key, value in self.dct.items():
                     if key in ALLOWED_KEYS \
                             and key not in self.nonpersistent_bookmarks:
+                        if isinstance(value, fsobject.FileSystemObject):
+                            value = value.original_path
                         key_value = "{0}:{1}\n".format(key, value)
                         if not PY3 and isinstance(key_value, str):
                             key_value = key_value.decode("utf-8")

--- a/ranger/container/fsobject.py
+++ b/ranger/container/fsobject.py
@@ -6,7 +6,7 @@ from __future__ import (absolute_import, division, print_function)
 import re
 from grp import getgrgid
 from os import lstat, stat
-from os.path import abspath, basename, dirname, realpath, relpath, splitext
+from os.path import abspath, basename, dirname, realpath, relpath, splitext, expanduser
 from pwd import getpwuid
 from time import time
 
@@ -55,6 +55,7 @@ class FileSystemObject(  # pylint: disable=too-many-instance-attributes,too-many
     basename = None
     relative_path = None
     infostring = None
+    original_path = None
     path = None
     permissions = None
     stat = None
@@ -99,6 +100,8 @@ class FileSystemObject(  # pylint: disable=too-many-instance-attributes,too-many
     )
 
     def __init__(self, path, preload=None, path_is_abs=False, basename_is_rel_to=None):
+        self.original_path = path
+        path = expanduser(path)
         if not path_is_abs:
             path = abspath(path)
         self.path = path


### PR DESCRIPTION

#### ISSUE TYPE
- Improvement/feature implementation

#### RUNTIME ENVIRONMENT
- Operating system and version:  popOS 22.04
- Terminal emulator and version:  alacritty 0.14.0-dev (fd1a3cc7)
- Python version: 3.10.12 (main, Nov  6 2024, 20:22:13) [GCC 11.4.0]
- Ranger version/commit:  ranger-master
- Locale: en_US.UTF-8

#### CHECKLIST
- [x] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [x] All changes follow the code style **[REQUIRED]**
- [x] All new and existing tests pass **[REQUIRED]**
- [ ] Changes require config files to be updated
    - [ ] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
While loading saved bookmarks, we check if the path starts with `~` if it does then we replace the first occurrence of `~` with the current home directory.


#### MOTIVATION AND CONTEXT
This fixes #3032 


#### TESTING
Manual tests were conducted with various edge cases to ensure the changes doesn't break anything.