### PR TITLE
`feat`: directory preview scrolling (#3020)

### DIFF
--- a/ranger/gui/mouse_event.py
+++ b/ranger/gui/mouse_event.py
@@ -19,6 +19,7 @@ class MouseEvent(object):
     def __init__(self, getmouse):
         """Creates a MouseEvent object from the result of win.getmouse()"""
         _, self.x, self.y, _, self.bstate = getmouse
+        self.direction = self.mouse_wheel_direction()
 
         # x-values above ~220 suddenly became negative, apparently
         # it's sufficient to add 0xFF to fix that error.

--- a/ranger/gui/widgets/browsercolumn.py
+++ b/ranger/gui/widgets/browsercolumn.py
@@ -61,8 +61,7 @@ class BrowserColumn(Pager):  # pylint: disable=too-many-instance-attributes
 
     def click(self, event):     # pylint: disable=too-many-branches
         """Handle a MouseEvent"""
-        direction = event.mouse_wheel_direction()
-        if not (event.pressed(1) or event.pressed(3) or direction):
+        if not (event.pressed(1) or event.pressed(3) or event.direction):
             return False
 
         if self.target is None:
@@ -72,11 +71,13 @@ class BrowserColumn(Pager):  # pylint: disable=too-many-instance-attributes
             if self.target.accessible and self.target.content_loaded:
                 index = self.scroll_begin + event.y - self.y
 
-                if direction:
+                if event.direction:
                     if self.level == -1:
-                        self.fm.move_parent(direction)
+                        self.fm.move_parent(event.direction)
+                        return True
                     else:
-                        return False
+                        return self.scroll(event.direction)
+                    return False
                 elif event.pressed(1):
                     if not self.main_column:
                         self.fm.enter_dir(self.target.path)
@@ -98,9 +99,9 @@ class BrowserColumn(Pager):  # pylint: disable=too-many-instance-attributes
             if event.pressed(3):
                 self.fm.execute_file(self.target)
             else:
-                self.scrollbit(direction)
+                self.scrollbit(event.direction)
         else:
-            if self.level > 0 and not direction:
+            if self.level > 0 and not event.direction:
                 self.fm.move(right=0)
 
         return True
@@ -597,6 +598,7 @@ class BrowserColumn(Pager):  # pylint: disable=too-many-instance-attributes
         self.need_redraw = True
         self.target.move(down=n)
         self.target.scroll_begin += 3 * n
+        return True
 
     def __str__(self):
         return self.__class__.__name__ + ' at level ' + str(self.level)

--- a/ranger/gui/widgets/browsercolumn.py
+++ b/ranger/gui/widgets/browsercolumn.py
@@ -77,7 +77,6 @@ class BrowserColumn(Pager):  # pylint: disable=too-many-instance-attributes
                         return True
                     else:
                         return self.scroll(event.direction)
-                    return False
                 elif event.pressed(1):
                     if not self.main_column:
                         self.fm.enter_dir(self.target.path)

--- a/ranger/gui/widgets/view_base.py
+++ b/ranger/gui/widgets/view_base.py
@@ -188,9 +188,6 @@ class ViewBase(Widget, DisplayableContainer):  # pylint: disable=too-many-instan
     def click(self, event):
         if DisplayableContainer.click(self, event):
             return True
-        direction = event.mouse_wheel_direction()
-        if direction:
-            self.main_column.scroll(direction)
         return False
 
     def resize(self, y, x, hei=None, wid=None):


### PR DESCRIPTION
#### ISSUE TYPE
- Improvement/feature implementation

#### RUNTIME ENVIRONMENT
- Operating system and version: Archlinux 6.12.9-arch1-1
- Terminal emulator and version: kitty 0.38.1
- Terminal emulator and version: terminator 2.1.4
- Python version: Python 3.13.1
- Ranger version/commit: ranger-master v1.9.2-1301-gbaa41320
- Locale: en_US.UTF-8

#### CHECKLIST
- [X] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [X] All changes follow the code style **[REQUIRED]**
- [X] All new and existing tests pass **[REQUIRED]**

#### DESCRIPTION
This PR introduces the ability to scroll the directory preview column.
It also refactors some code for effeciency and readability.

#### MOTIVATION AND CONTEXT
This feature request was brought up in issue #3020 which requested the ability
to scroll through the directory preview column


#### TESTING
scrolling was tested