### PR TITLE
add :narrow!

### DIFF
--- a/ranger/config/commands.py
+++ b/ranger/config/commands.py
@@ -1753,6 +1753,21 @@ class narrow(Command):
         self.fm.thisdir.refilter()
 
 
+class narrow_bang(Command):
+    """
+    :narrow!
+
+    Disable narrowing.
+    """
+    name = 'narrow!'
+    allow_abbrev = False
+
+    def execute(self):
+
+        self.fm.thisdir.narrow_filter = None
+        self.fm.thisdir.refilter()
+
+
 class filter_inode_type(Command):
     """
     :filter_inode_type [dfl]


### PR DESCRIPTION
Adds command `:narrow!`, which will disable `:narrow` if it is enabled.

#### ISSUE TYPE

- Improvement/feature implementation

#### RUNTIME ENVIRONMENT
- Operating system and version: FreeBSD 14.2-p2 and macOS 14.7.4 (23H420).
- Terminal emulator and version: iTerm2 Build 3.5.11
- Python version: Python 3.11.11 (FreeBSD) and Python 3.13.2 (macOS Homebrew)
- Ranger version/commit: `master/a19517`
- Locale: `en_US.UTF-8`

#### CHECKLIST
- [X] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [X] All changes follow the code style **[REQUIRED]**
- [X] All new and existing tests pass **[REQUIRED]**
- [ ] Changes require config files to be updated
    - [ ] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
This patch adds a new command `:narrow!` which disables `:narrow`. If narrow is not enabled, it has no effect.


#### MOTIVATION AND CONTEXT
There is no easy way to disable the narrow feature without unselecting files. This command will allow the user to do that.

I initially thought to add a toggle to `:narrow` itself, which would obviate the need for an extra command, however this would prevent the user from unselecting files within a *narrowed context* and run narrow again to show the new subset of narrowed files. Adding this extra command allows the user to exit the narrowed environment entirely.

Fixes #3074.


#### TESTING
`make test` has been run successfully on FreeBSD and macOS.

Apart from adding a single class (`narrow_bang`) to `config/commands.py`, there are no changes to other areas of the codebase.