### PR TITLE
add :unnarrow to disable :narrow mode

### DIFF
--- a/ranger/config/commands.py
+++ b/ranger/config/commands.py
@@ -1743,13 +1743,23 @@ class narrow(Command):
 
     Show only the files selected right now. If no files are selected,
     disable narrowing.
+
+    To disable narrow mode when selection is still active, use the
+    :unnarrow command.
     """
+
     def execute(self):
-        if self.fm.thisdir.marked_items:
+
+        # by default, calling :narrow enables narrow mode
+        # uness it is called with :narrow False
+        narrow_mode = self.arg(1).lower() != "false"
+
+        if narrow_mode and self.fm.thisdir.marked_items:
             selection = [f.basename for f in self.fm.thistab.get_selection()]
             self.fm.thisdir.narrow_filter = selection
         else:
             self.fm.thisdir.narrow_filter = None
+
         self.fm.thisdir.refilter()
 
 

--- a/ranger/config/commands.py
+++ b/ranger/config/commands.py
@@ -1749,9 +1749,8 @@ class narrow(Command):
     """
 
     def execute(self):
-
-        # by default, calling :narrow enables narrow mode
-        # uness it is called with :narrow False
+        # Calling :narrow enables narrow mode unless it is called with a
+        # case-insensitive `false` argument
         narrow_mode = self.arg(1).lower() != "false"
 
         if narrow_mode and self.fm.thisdir.marked_items:

--- a/ranger/config/rc.conf
+++ b/ranger/config/rc.conf
@@ -368,6 +368,8 @@ alias search     scout -rs
 alias search_inc scout -rts
 alias travel     scout -aefklst
 
+alias unnarrow   narrow False
+
 # ===================================================================
 # == Define keys for the browser
 # ===================================================================


### PR DESCRIPTION
Add `:unnarrow` functionality to disable `:narrow` mode even if files are selected.

Implemented using a default argument for :narrow that defaults to True.

<!-- Provide a descriptive summary of the changes in the title above -->

#### ISSUE TYPE
- Improvement/feature implementation


#### RUNTIME ENVIRONMENT
- Operating system and version: FreeBSD 14.2-p3 and macOS Sonoma 14.7.4 (23H420)
- Terminal emulator and version: iTerm2 Build 3.15.3
- Python version: Python 3.11.11 (FreeBSD) and Python 3.13.3 (macOS Homebrew)
- Ranger version/commit: `master/b31db0` 
- Locale:  `en_US.UTF-8`

#### CHECKLIST
- [X] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [X] All changes follow the code style **[REQUIRED]**
- [X] All new and existing tests pass **[REQUIRED]**
- [X] Changes require config files to be updated
    - [X] Config files have been updated
- [X] Changes require documentation to be updated
    - [X] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
This patch adds a new command alias `:unnarrow` which disables `:narrow` functionality. If narrow is not enabled, it has no effect.

#### MOTIVATION AND CONTEXT
There is no easy way to disable narrow without unselecting files. This command will allow the user to do that.

#### TESTING
`make test` has been run successfully on FreeBSD and macOS.

Apart from adding a single alias (`:unnarrow`) to `config/rc.conf` and adding a default argument to `class narrow` in `config/commands.py`, there are no changes to other areas of the codebase.

