### PR TITLE
Implement SIXEL types with custom option

### DIFF
--- a/doc/ranger.pod
+++ b/doc/ranger.pod
@@ -365,9 +365,9 @@ C<custom>
 This type allows a custom command-line to be specified.
 
 Specify a custom command line by setting C<sixel_custom>. A command line, for example, 
-of which utilizes chafa with symbols instead of sixel, can be set as shown below:
+of which utilizes chafa to render an image in 16 colors, can be set as shown below:
 
- set sixel_custom chafa -f symbols --view-size {w}x{h} {p}
+ set sixel_custom chafaa -f sixel --view-size {w}x{h} -c 16 {p}
 
 =over 2
 

--- a/doc/ranger.pod
+++ b/doc/ranger.pod
@@ -336,10 +336,72 @@ C<iterm2_font_width> and C<iterm2_font_height> to the desired values.
 This works in most terminal emulators, including all terminals based on VTE >=0.68
 (e.g. GNOME Terminal), iTerm2, MinTTY, WezTerm and many others.
 
-To enable this feature, install C<imagemagick> and set the option
-C<preview_images_method> to sixel.
+A sixel processor can be setting C<sixel_type>. The default value is C<imagemagick>.
+
+=over 2
+
+=item The following sixel processor types are available:
+
+=over 2
+
+=item -
+
+C<imagemagick> 
+
+This sixel processor type requires imagemagick be installed on your system.
 
 Preferred dithering method can be specified by setting C<sixel_dithering>.
+
+=item -
+
+C<chafa>
+
+This sixel processor type requires chafa be installed on your system.
+
+=item -
+
+C<custom> 
+
+This type allows a custom command-line to be specified.
+
+Specify a custom command line by setting C<sixel_custom>. A command line, for example, 
+of which utilizes chafa with symbols instead of sixel, can be set as shown below:
+
+ set sixel_custom chafa -f symbols --view-size {w}x{h} {p}
+
+=over 2
+
+=item The following substitution options available:
+
+=over 2
+
+=item {w}
+
+Substitutes with the terminal row width.
+
+=item {h}
+
+Substitutes with the terminal column height.
+
+=item {fw}
+
+Substitutes with the terminal row width multipled by the font width.
+
+=item {fh}
+
+Substitutes with the terminal column height multipled by the font height.
+
+=item {p}
+
+Substitutes with the image path to provide to the sixel processor.
+
+=back
+
+=back
+
+=back
+
+=back
 
 =head3 kitty
 

--- a/ranger/config/rc.conf
+++ b/ranger/config/rc.conf
@@ -137,10 +137,21 @@ set w3m_offset 0
 set iterm2_font_width 8
 set iterm2_font_height 11
 
+# Sixel processor type.  One of:
+# imagemagick, chafa, custom
+# (see: preview_images_method: sixel)
+set sixel_type custom
+
 # Dithering mode for SIXEL previews.  One of:
 # None, Riemersma, FloydSteinberg
+# Note: Only applies to sixel_type imagemagick
 # (see: preview_images_method: sixel)
 set sixel_dithering FloydSteinberg
+
+# Custom sixel command line
+# Note: Only applies to sixel_type custom.
+# (see: preview_images_method: sixel)
+set sixel_custom chafaa -f symbols --view-size {w}x{h} {p}
 
 # Use a unicode "..." character to mark cut-off filenames?
 set unicode_ellipsis false

--- a/ranger/config/rc.conf
+++ b/ranger/config/rc.conf
@@ -151,7 +151,7 @@ set sixel_dithering FloydSteinberg
 # Custom sixel command line
 # Note: Only applies to sixel_type custom.
 # (see: preview_images_method: sixel)
-set sixel_custom chafaa -f symbols --view-size {w}x{h} {p}
+set sixel_custom chafaa -f sixel --view-size {w}x{h} -c 16 {p}
 
 # Use a unicode "..." character to mark cut-off filenames?
 set unicode_ellipsis false

--- a/ranger/container/settings.py
+++ b/ranger/container/settings.py
@@ -104,6 +104,8 @@ ALLOWED_SETTINGS = {
     'wrap_scroll': bool,
     'xterm_alt_key': bool,
     'sixel_dithering': str,
+    'sixel_type': str,
+    'sixel_custom': str,
 }
 
 ALLOWED_VALUES = {

--- a/ranger/ext/img_display.py
+++ b/ranger/ext/img_display.py
@@ -554,8 +554,8 @@ class SixelImageDisplayer(ImageDisplayer, FileManagerAware):
 
     # pylint: disable=too-many-positional-arguments
     def draw(self, path, start_x, start_y, width, height):
-        # Hide the cursor, so it doesn't randomly jump around the terminal
-        sys.stdout.write("\x1B[?25l")
+        # Obtain cursor position
+        row, col = self.fm.ui.win.getyx()
 
         if self.win is None:
             self.win = self.fm.ui.win.subwin(height, width, start_y, start_x)
@@ -569,6 +569,9 @@ class SixelImageDisplayer(ImageDisplayer, FileManagerAware):
                 sys.stdout.buffer.write(sixel)
             else:
                 sys.stdout.write(sixel)
+
+            # Hide the cursor, so it remains invisible and then reset cursor position
+            sys.stdout.write("\x1B[?25l\x1B[{row};{col}H".format(row=row + 1, col=col + 1))
             sys.stdout.flush()
 
     def clear(self, start_x, start_y, width, height):

--- a/ranger/ext/img_display.py
+++ b/ranger/ext/img_display.py
@@ -534,6 +534,7 @@ class SixelImageDisplayer(ImageDisplayer, FileManagerAware):
                 check_call(args,
                            stdout=cached,
                            stderr=DEVNULL,
+                           stdin=DEVNULL,
                            env=environ,
                            )
             except CalledProcessError:

--- a/ranger/ext/img_display.py
+++ b/ranger/ext/img_display.py
@@ -2,6 +2,7 @@
 # License: GNU GPL version 3, see the file "AUTHORS" for details.
 # Author: Emanuel Guevel, 2013
 # Author: Delisa Mason, 2015
+# pylint: disable=too-many-lines
 
 """Interface for drawing images into the console
 
@@ -24,6 +25,7 @@ import mmap
 import threading
 from subprocess import Popen, PIPE, check_call, CalledProcessError
 from collections import defaultdict, namedtuple
+from enum import StrEnum, auto
 
 import termios
 from contextlib import contextmanager
@@ -450,6 +452,17 @@ _CacheableSixelImage = namedtuple("_CacheableSixelImage", ("width", "height", "i
 _CachedSixelImage = namedtuple("_CachedSixelImage", ("image", "fh"))
 
 
+class SixelType(StrEnum):
+    CUSTOM = auto()
+    CHAFA = auto()
+    IMAGEMAGICK = auto()
+    UNIMPLEMENTED = auto()
+
+    @classmethod
+    def _missing_(cls, value):
+        return cls.UNIMPLEMENTED
+
+
 @register_image_displayer("sixel")
 class SixelImageDisplayer(ImageDisplayer, FileManagerAware):
     """Implementation of ImageDisplayer using SIXEL."""
@@ -467,6 +480,7 @@ class SixelImageDisplayer(ImageDisplayer, FileManagerAware):
                 if ce.inode != os.stat(path).st_ino
             }
 
+    # pylint: disable=too-many-locals
     def _sixel_cache(self, path, width, height):
         stat = os.stat(path)
         cacheable = _CacheableSixelImage(width, height, stat.st_ino)
@@ -476,35 +490,62 @@ class SixelImageDisplayer(ImageDisplayer, FileManagerAware):
             fit_width = font_width * width
             fit_height = font_height * height
 
+            sixel_custom = self.fm.settings.sixel_custom
             sixel_dithering = self.fm.settings.sixel_dithering
+            sixel_type_str = self.fm.settings.sixel_type
+            sixel_type = SixelType(sixel_type_str)
+
             cached = TemporaryFile("w+", prefix="ranger", suffix=path.replace(os.sep, "-"))
 
             environ = dict(os.environ)
-            environ.setdefault("MAGICK_OCL_DEVICE", "true")
-            try:
-                check_call(
-                    [
+
+            match sixel_type:
+                case SixelType.CHAFA:
+                    args = [
+                        "chafa",
+                        "-f",
+                        "sixel",
+                        "--view-size",
+                        "{0}x{1}".format(width, height),
+                        path]
+                case SixelType.IMAGEMAGICK:
+                    args = [
                         *MAGICK_CONVERT_CMD_BASE,
                         path + "[0]",
                         "-geometry",
                         "{0}x{1}>".format(fit_width, fit_height),
                         "-dither",
                         sixel_dithering,
-                        "sixel:-",
-                    ],
-                    stdout=cached,
-                    stderr=DEVNULL,
-                    env=environ,
-                )
+                        "sixel:-"]
+
+                    environ.setdefault("MAGICK_OCL_DEVICE", "true")
+                case SixelType.CUSTOM:
+                    args = sixel_custom.format(h=height,
+                                               w=width,
+                                               fh=font_height,
+                                               fw=font_width,
+                                               p="{p}").split(' ')
+                    args = list(map(lambda str: str.format(p=path), args))
+                case SixelType.UNIMPLEMENTED:
+                    raise ImageDisplayError("Invalid SIXEL backend: '{0}'".format(sixel_type_str))
+
+            try:
+                check_call(args,
+                           stdout=cached,
+                           stderr=DEVNULL,
+                           env=environ,
+                           )
             except CalledProcessError:
-                raise ImageDisplayError("ImageMagick failed processing the SIXEL image")
+                raise ImageDisplayError("'{0}' failed processing the SIXEL image".format(args[0]))
             except FileNotFoundError:
-                raise ImageDisplayError("SIXEL image previews require ImageMagick")
+                raise ImageDisplayError("Executable '{1}' for type {0}: Not found"
+                                        .format(sixel_type, args[0]))
             finally:
                 cached.flush()
 
             if os.fstat(cached.fileno()).st_size == 0:
-                raise ImageDisplayError("ImageMagick produced an empty SIXEL image file")
+                raise ImageDisplayError("'{0}' produced an empty SIXEL image file"
+                                        .format(args[0]))
 
             self.cache[cacheable] = _CachedSixelImage(mmap.mmap(cached.fileno(), 0), cached)
 
@@ -512,6 +553,9 @@ class SixelImageDisplayer(ImageDisplayer, FileManagerAware):
 
     # pylint: disable=too-many-positional-arguments
     def draw(self, path, start_x, start_y, width, height):
+        # Hide the cursor, so it doesn't randomly jump around the terminal
+        sys.stdout.write("\x1B[?25l")
+
         if self.win is None:
             self.win = self.fm.ui.win.subwin(height, width, start_y, start_x)
         else:

--- a/ranger/ext/img_display.py
+++ b/ranger/ext/img_display.py
@@ -505,6 +505,7 @@ class SixelImageDisplayer(ImageDisplayer, FileManagerAware):
                         "chafa",
                         "-f",
                         "sixel",
+                        "--passthrough=none",
                         "--view-size",
                         "{0}x{1}".format(width, height),
                         path]


### PR DESCRIPTION
Modifies the SixelImageDisplayer class to provide multiple processor backends as well as allowing the user to specify their own via setting a command-line option via sixel_custom in rc.conf.
    
<!-- Provide a descriptive summary of the changes in the title above -->

#### ISSUE TYPE
<!-- Pick relevant types and delete the rest -->
- Improvement/feature implementation

#### RUNTIME ENVIRONMENT
<!-- Details of your runtime environment -->
<!-- Retrieve Python/ranger version and locale with `ranger -\-version` -->
- Operating system and version: Arch Linux 
- Terminal emulator and version: alacritty 0.16.0-dev (814e8fef) (sixel patchset)
- Python version: Python version: 3.13.3 (main, Apr  9 2025, 07:44:25) [GCC 14.2.1 20250207]
- Ranger version/commit: ranger-master v1.9.3-794-gcc8fd2ac 
- Locale: en_CA.UTF-8

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [X] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [X] All changes follow the code style **[REQUIRED]**
- [X] All new and existing tests pass **[REQUIRED]**
- [X] Changes require config files to be updated
    - [X] Config files have been updated
- [X] Changes require documentation to be updated
    - [X] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
<!-- Describe the changes in detail -->

Provides the ability to set multiple different SIXEL processor types, as well as two new processor types in addition to imagemagick. 

A user may specify one of the following option types:

- `imagemagick`
- `chafa`
- `custom`

`imagemagick` is set as the default to preserve the current behaviour.

Custom option in particular allows the user to set a custom command-line to utilize 
their own SIXEL processor to output into the terminal. That can be set with `sixel_custom`.

String substitution options are provided to allow the user to specify a path, width&height, etc..

#### MOTIVATION AND CONTEXT
<!-- Why are these changes required? -->
<!-- What problems do these changes solve? -->
<!-- Link to relevant issues -->

The inability to set a different SIXEL processor for use with ranger. 

Since imagemagick is noticeably slow when navigating through directories of large images (e.g. background wallpapers, photographs, etc.), I decided to implement support for multiple processor types.

`chafa` is noticeably faster by comparison and doesn't require OpenCL acceleration to work. 

Since a custom option is also desirable, I decided to take a shot at that. Input is very much welcome on the approach I've taken. Not exactly sure if string substitution with `str.format(..)` is the appropriate way to approach this problem. It's simple, however, and takes up almost no footprint.

Solves and fixes these issues with https://github.com/ranger/ranger/pull/2466 having been merged:

- https://github.com/ranger/ranger/issues/2859
- https://github.com/ranger/ranger/issues/1434
- https://github.com/ranger/ranger/pull/2497 

#### TESTING
<!-- What tests have been run? -->
<!-- How does the changes affect other areas of the codebase? -->
Doesn't affect anything other than the SIXEL image preview functionality.

Both `imagemagick`, `chafa`, and the `custom` options have been tested as working.