### PR TITLE
Pylint: Disable invalid-name and too-many-lines for commands.py

### DIFF
--- a/ranger/config/commands.py
+++ b/ranger/config/commands.py
@@ -89,6 +89,8 @@
 # of ranger.
 # ===================================================================
 
+# pylint: disable=invalid-name,too-many-lines
+
 from __future__ import (absolute_import, division, print_function)
 
 from collections import deque


### PR DESCRIPTION
Try to make CI happy again.