### PR TITLE
fixed bug with command info staying

### DIFF
--- a/ranger/core/actions.py
+++ b/ranger/core/actions.py
@@ -955,6 +955,7 @@ class Actions(  # pylint: disable=too-many-instance-attributes,too-many-public-m
 
     def hide_console_info(self):
         self.ui.browser.draw_info = False
+        self.ui.browser.need_clear = True
 
     # --------------------------
     # -- Pager

--- a/ranger/gui/widgets/view_base.py
+++ b/ranger/gui/widgets/view_base.py
@@ -95,8 +95,6 @@ class ViewBase(Widget, DisplayableContainer):  # pylint: disable=too-many-instan
         self.win.chgat(ystart - 1, 0, curses.A_UNDERLINE)
 
     def _draw_info(self, lines):
-        self.columns[-1].clear_image(force=True)
-        self.need_clear = True
         hei = min(self.hei - 1, len(lines))
         ystart = self.hei - hei
         i = ystart


### PR DESCRIPTION
The screen is now cleared at the appropriate time. The command info is cleared when the cmd line is cleared. 