### PR TITLE
img_display: Avoid unicode escape sequences for Ueberzug input

### DIFF
--- a/ranger/ext/img_display.py
+++ b/ranger/ext/img_display.py
@@ -942,7 +942,7 @@ class UeberzugImageDisplayer(ImageDisplayer):
 
     def _execute(self, **kwargs):
         self.initialize()
-        self.process.stdin.write(json.dumps(kwargs) + '\n')
+        self.process.stdin.write(json.dumps(kwargs, ensure_ascii=False) + '\n')
         self.process.stdin.flush()
 
     # pylint: disable=too-many-positional-arguments


### PR DESCRIPTION
In [ueber-devel/ueberzug#26](https://github.com/ueber-devel/ueberzug/pull/26) Ueberzug stopped accepting `\` escape characters in input file names.

We should simply pass along the original filename rather than replace non-ASCII characters with `\uXXXX` escape sequences.