### PR TITLE
Using $EDITOR instead of xdg_open for empty .patch .yaml .yml files

### DIFF
--- a/ranger/config/rifle.conf
+++ b/ranger/config/rifle.conf
@@ -87,8 +87,8 @@ ext x?html?, has w3m,               terminal = w3m "$@"
 # Define the "editor" for text files as first action
 mime ^text,  label editor = ${VISUAL:-$EDITOR} -- "$@"
 mime ^text,  label pager  = $PAGER -- "$@"
-!mime ^text, label editor, ext xml|json|csv|tex|py|pl|rb|rs|js|sh|php|dart|nim = ${VISUAL:-$EDITOR} -- "$@"
-!mime ^text, label pager,  ext xml|json|csv|tex|py|pl|rb|rs|js|sh|php|dart|nim = $PAGER -- "$@"
+!mime ^text, label editor, ext xml|json|ya?ml|csv|tex|py|pl|rb|rs|js|sh|php|dart|nim|patch = ${VISUAL:-$EDITOR} -- "$@"
+!mime ^text, label pager,  ext xml|json|ya?ml|csv|tex|py|pl|rb|rs|js|sh|php|dart|nim|patch = $PAGER -- "$@"
 
 ext 1                         = man "$1"
 ext s[wmf]c, has zsnes, X     = zsnes "$1"
@@ -290,9 +290,9 @@ label open, has xdg-open = xdg-open "$@"
 label open, has open     = open -- "$@"
 
 # Define the editor for non-text files + pager as last action
-              !mime ^text, !ext xml|json|csv|tex|py|pl|rb|rs|js|sh|php|dart|nim  = ask
-label editor, !mime ^text, !ext xml|json|csv|tex|py|pl|rb|rs|js|sh|php|dart|nim  = ${VISUAL:-$EDITOR} -- "$@"
-label pager,  !mime ^text, !ext xml|json|csv|tex|py|pl|rb|rs|js|sh|php|dart|nim  = $PAGER -- "$@"
+              !mime ^text, !ext xml|json|ya?ml|csv|tex|py|pl|rb|rs|js|sh|php|dart|nim|patch  = ask
+label editor, !mime ^text, !ext xml|json|ya?ml|csv|tex|py|pl|rb|rs|js|sh|php|dart|nim|patch  = ${VISUAL:-$EDITOR} -- "$@"
+label pager,  !mime ^text, !ext xml|json|ya?ml|csv|tex|py|pl|rb|rs|js|sh|php|dart|nim|patch  = $PAGER -- "$@"
 
 
 ######################################################################


### PR DESCRIPTION
<!-- Provide a descriptive summary of the changes in the title above -->

#### ISSUE TYPE
<!-- Pick relevant types and delete the rest -->
- Bug fix
- Improvement

#### RUNTIME ENVIRONMENT
<!-- Details of your runtime environment -->
<!-- Retrieve Python/ranger version and locale with `ranger -\-version` -->
- Operating system and version: Arch (kernel 6.15.4-zen2-1-zen)
- Terminal emulator and version: KGX 48.0.1
- Python version: 3.13.5 (main, Jun 21 2025, 09:35:00) [GCC 15.1.1 20250425]
- Ranger version/commit: ranger 1.9.4
- Locale: en_US.UTF-8

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [x] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [x] All changes follow the code style **[REQUIRED]**
- [x] All new and existing tests pass **[REQUIRED]**
- [ ] Changes require config files to be updated
    - [ ] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
<!-- Describe the changes in detail -->
This commit allows to open an empty .yaml .yml and .patch file in the proper text editor, the same as already selected in the $EDITOR for a similar file with contents.


#### MOTIVATION AND CONTEXT
<!-- Why are these changes required? -->
<!-- What problems do these changes solve? -->
<!-- Link to relevant issues -->
These file types currently open with xdg_open when empty.
This might cause a different editor to open the file than what's currently set in $EDITOR or $VISUAL.
For me it was opening a file in a gui text editor instead than in vim.
Similar issue to https://github.com/ranger/ranger/issues/3088 but with addition of .patch file.


#### TESTING
<!-- What tests have been run? -->
<!-- How does the changes affect other areas of the codebase? -->
I have checked the behavior of empty .yaml .yml and .patch files and they all open with editor set in $EDITOR now.
I don't believe these changes affect other areas of the codebase in any way.


#### IMAGES / VIDEOS<!-- Only if relevant -->
<!-- Link or embed images and videos of screenshots, sketches etc. -->
