### PR TITLE
FM: don't expand paths in group_paths_by_dirname (#3118)

### DIFF
--- a/ranger/core/fm.py
+++ b/ranger/core/fm.py
@@ -436,7 +436,7 @@ class FM(Actions,  # pylint: disable=too-many-instance-attributes
         """
         groups = {}
         for path in paths:
-            abspath = os.path.abspath(os.path.expanduser(path))
+            abspath = os.path.abspath(path)
             dirname, basename = os.path.split(abspath)
             groups.setdefault(dirname, set()).add(basename)
         return groups


### PR DESCRIPTION
<!-- Provide a descriptive summary of the changes in the title above -->

#### ISSUE TYPE
<!-- Pick relevant types and delete the rest -->
x Bug fix
- Improvement/feature implementation
- Breaking changes

#### RUNTIME ENVIRONMENT
<!-- Details of your runtime environment -->
<!-- Retrieve Python/ranger version and locale with `ranger -\-version` -->
- Operating system and version:
- Terminal emulator and version: Tilix 1.9.5
- Python version: 3.11.2
- Ranger version/commit: master 6d5e0d8dc4cc5ddf53211e19f48c5b5e9ee47b18
- Locale: en_US.UTF-8

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [x] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [x] All changes follow the code style **[REQUIRED]**
- [x] All new and existing tests pass **[REQUIRED]**
- [ ] Changes require config files to be updated
    - [ ] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
<!-- Describe the changes in detail -->
https://github.com/ranger/ranger/issues/3118#issuecomment-3408882071

#### MOTIVATION AND CONTEXT
<!-- Why are these changes required? -->
The `:trash %s` command will try to expand filenames even after the macro "%s" was expanded, which can for example cause it to delete the home folder when "%s" expands to the literal filename "~".
<!-- What problems do these changes solve? -->
https://github.com/ranger/ranger/issues/3118
<!-- Link to relevant issues -->
https://github.com/ranger/ranger/issues/3118

#### TESTING
<!-- What tests have been run? -->
[vejkse explains](https://github.com/ranger/ranger/issues/3118#issuecomment-3102090973) how to reproduce the bug, this commit fixes it.
<!-- How does the changes affect other areas of the codebase? -->
It shouldn't affect anything else since only the trash command calls the affected methods

#### IMAGES / VIDEOS<!-- Only if relevant -->
<!-- Link or embed images and videos of screenshots, sketches etc. -->
