### PR TITLE
shutil_generatorized: always move() symbolic links as files (#2881)

### DIFF
--- a/ranger/ext/shutil_generatorized.py
+++ b/ranger/ext/shutil_generatorized.py
@@ -309,7 +309,7 @@ def move(src, dst, overwrite=False, make_safe_path=get_safe_path):
     try:
         os.rename(src, real_dst)
     except OSError:
-        if os.path.isdir(src):
+        if os.path.isdir(src) and not os.path.islink(src):
             if _destinsrc(src, dst):
                 raise Error("Cannot move a directory '%s' into itself '%s'." % (src, dst))
             for done in copytree(src, real_dst, symlinks=True, overwrite=overwrite,


### PR DESCRIPTION
<!-- Provide a descriptive summary of the changes in the title above -->

#### ISSUE TYPE
<!-- Pick relevant types and delete the rest -->
x Bug fix

#### RUNTIME ENVIRONMENT
<!-- Details of your runtime environment -->
<!-- Retrieve Python/ranger version and locale with `ranger -\-version` -->
- Operating system and version: 
- Terminal emulator and version: Tilix 1.9.5
- Python version: 3.11.2
- Ranger version/commit: master 6d5e0d8dc4cc5ddf53211e19f48c5b5e9ee47b18
- Locale: en_US.UTF-8

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [x] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [x] All changes follow the code style **[REQUIRED]**
- [ ] All new and existing tests pass **[REQUIRED]**
- [ ] Changes require config files to be updated
    - [ ] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
<!-- Describe the changes in detail -->
Please read my comment on issue https://github.com/ranger/ranger/issues/2881#issuecomment-3412954268

#### MOTIVATION AND CONTEXT
<!-- Why are these changes required? -->
<!-- What problems do these changes solve? -->
<!-- Link to relevant issues -->
https://github.com/ranger/ranger/issues/2881


#### TESTING
<!-- What tests have been run? -->
Tested moving a symbolic link pointing to a directory, between filesystems as described by @vejkse in #2881. After this commit the issue no longer occurs.

<!-- How does the changes affect other areas of the codebase? -->
I grepped over the codebase and it looks like `shutil_generatorize.move()` is only used by `CopyLoader` in `ranger/core/loader.py`. `CopyLoader` is only used by the `:paste` command (`Actions.paste`). So this change should not affect
anything else.

#### IMAGES / VIDEOS<!-- Only if relevant -->
<!-- Link or embed images and videos of screenshots, sketches etc. -->
