### PR TITLE
console: correctly display long lines with wide characters (#1780)

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ For general usage:
 * `sudo` to use the "run as root" feature
 * `python-bidi` (Python package) to display right-to-left file names correctly
   (Hebrew, Arabic)
+* `wcwidth` (Python package) to display some combining/non-spacing Unicode characters right way
 
 For enhanced file previews (with `scope.sh`):
 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ For general usage:
 * `sudo` to use the "run as root" feature
 * `python-bidi` (Python package) to display right-to-left file names correctly
   (Hebrew, Arabic)
-* `wcwidth` (Python package) to display some combining/non-spacing Unicode characters right way
+* `wcwidth` (Python package) to display combining/non-spacing Unicode characters right way (e.g. Bengali, Thai)
 
 For enhanced file previews (with `scope.sh`):
 

--- a/ranger/ext/widestring.py
+++ b/ranger/ext/widestring.py
@@ -9,7 +9,7 @@ from unicodedata import east_asian_width
 
 try:
     from wcwidth import wcwidth, wcswidth
-    WCWIDTH_AVAILABLE = True 
+    WCWIDTH_AVAILABLE = True
 except ImportError:
     WCWIDTH_AVAILABLE = False
 
@@ -21,22 +21,22 @@ WIDE = 2
 WIDE_SYMBOLS = set('WF')
 
 
-def uwid(string):	
-    """Return the width of a string"""	
-    if not PY3:	
-        string = string.decode('utf-8', 'ignore')	
+def uwid(string):
+    """Return the width of a string"""
+    if not PY3:
+        string = string.decode('utf-8', 'ignore')
     if WCWIDTH_AVAILABLE:
         return wcswidth(string)
-    return sum(utf_char_width(c) for c in string)	
+    return sum(utf_char_width(c) for c in string)
 
 
-def utf_char_width(string):	
-    """Return the width of a single character"""	
+def utf_char_width(string):
+    """Return the width of a single character"""
     if WCWIDTH_AVAILABLE:
         return wcwidth(string)
     else:
-        if east_asian_width(string) in WIDE_SYMBOLS:	
-            return WIDE	
+        if east_asian_width(string) in WIDE_SYMBOLS:
+            return WIDE
         return NARROW
 
 
@@ -178,7 +178,7 @@ class WideString(object):  # pylint: disable=too-few-public-methods
                 string = self.string.decode('utf-8', 'ignore')
             return wcswidth(string)
         else:
-            return len(self.chars) 
+            return len(self.chars)
 
 
 if __name__ == '__main__':

--- a/ranger/ext/widestring.py
+++ b/ranger/ext/widestring.py
@@ -9,13 +9,21 @@ from unicodedata import east_asian_width
 
 try:
     from wcwidth import wcwidth, wcswidth
+
+    def uwid(string):
+        """Return the width of a string"""
+        return wcswidth(string)
+
+    def utf_char_width(char):
+        """Return the width of a single character"""
+        return wcwidth(char)
 except ImportError:
-    def wcswidth(string):
+    def uwid(string):
         if not PY3:
             string = string.decode('utf-8', 'ignore')
         return sum(utf_char_width(c) for c in string)
 
-    def wcwidth(char):
+    def utf_char_width(char):
         if east_asian_width(char) in WIDE_SYMBOLS:
             return WIDE
         return NARROW
@@ -26,16 +34,6 @@ ASCIIONLY = set(chr(c) for c in range(1, 128))
 NARROW = 1
 WIDE = 2
 WIDE_SYMBOLS = set('WF')
-
-
-def uwid(string):
-    """Return the width of a string"""
-    return wcswidth(string)
-
-
-def utf_char_width(char):
-    """Return the width of a single character"""
-    return wcwidth(char)
 
 
 def string_to_charlist(string):

--- a/ranger/ext/widestring.py
+++ b/ranger/ext/widestring.py
@@ -7,6 +7,11 @@ from __future__ import (absolute_import, division, print_function)
 import sys
 from unicodedata import east_asian_width
 
+try:
+    from wcwidth import wcwidth, wcswidth
+except ImportError:
+    pass
+
 
 PY3 = sys.version_info[0] >= 3
 ASCIIONLY = set(chr(c) for c in range(1, 128))
@@ -20,18 +25,16 @@ def uwid(string):
     if not PY3:
         string = string.decode('utf-8', 'ignore')
     try:
-        from wcwidth import wcswidth
         return wcswidth(string)
-    except ImportError:
+    except NameError:
         return sum(utf_char_width(c) for c in string)
 
 
 def utf_char_width(char):
     """Return the width of a single character"""
     try:
-        from wcwidth import wcwidth
         return wcwidth(char)
-    except ImportError:
+    except NameError:
         if east_asian_width(char) in WIDE_SYMBOLS:
             return WIDE
         return NARROW
@@ -169,11 +172,10 @@ class WideString(object):  # pylint: disable=too-few-public-methods
         8
         """
         try:
-            from wcwidth import wcswidth
             if not PY3:
                 return wcswidth(self.string.decode('utf-8', 'ignore'))
             return wcswidth(self.string)
-        except ImportError:
+        except NameError:
             return len(self.chars)
 
 

--- a/ranger/ext/widestring.py
+++ b/ranger/ext/widestring.py
@@ -11,7 +11,7 @@ from wcwidth import wcwidth, wcswidth
 
 PY3 = sys.version_info[0] >= 3
 ASCIIONLY = set(chr(c) for c in range(1, 128))
-WIDE_SYMBOLS = set('WF')
+WIDE = 2
 
 
 def string_to_charlist(string):
@@ -22,7 +22,7 @@ def string_to_charlist(string):
     if PY3:
         for char in string:
             result.append(char)
-            if east_asian_width(char) in WIDE_SYMBOLS:
+            if wcwidth(char) == WIDE:
                 result.append('')
     else:
         try:
@@ -35,7 +35,7 @@ def string_to_charlist(string):
             return []
         for char in string:
             result.append(char.encode('utf-8'))
-            if east_asian_width(char) in WIDE_SYMBOLS:
+            if wcwidth(char) == WIDE:
                 result.append('')
     return result
 

--- a/ranger/ext/widestring.py
+++ b/ranger/ext/widestring.py
@@ -124,6 +124,8 @@ class WideString(object):  # pylint: disable=too-few-public-methods
         >>> WideString("aモ")[0:1]
         <WideString 'a'>
         """
+        if not len(self.chars):
+            return WideString('')
         if stop is None or stop > len(self.chars):
             stop = len(self.chars)
         if stop < 0:

--- a/ranger/ext/widestring.py
+++ b/ranger/ext/widestring.py
@@ -137,7 +137,7 @@ class WideString(object):  # pylint: disable=too-few-public-methods
                 return WideString(' ' + ''.join(self.chars[start:stop - 1]) + ' ')
             return WideString(''.join(self.chars[start:stop - 1]) + ' ')
         if self.chars[start] == '':
-            return WideString(' ' + ''.join(self.chars[start:stop - 1]))
+            return WideString(' ' + ''.join(self.chars[start + 1:stop]))
         return WideString(''.join(self.chars[start:stop]))
 
     def __getitem__(self, i):

--- a/ranger/ext/widestring.py
+++ b/ranger/ext/widestring.py
@@ -7,10 +7,12 @@ from __future__ import (absolute_import, division, print_function)
 import sys
 from unicodedata import east_asian_width
 
+from wcwidth import wcswidth
+
 PY3 = sys.version_info[0] >= 3
 ASCIIONLY = set(chr(c) for c in range(1, 128))
-NARROW = 1
-WIDE = 2
+NARROW = 1 
+WIDE = 2 
 WIDE_SYMBOLS = set('WF')
 
 
@@ -159,7 +161,7 @@ class WideString(object):  # pylint: disable=too-few-public-methods
         >>> len(WideString("モヒカン"))
         8
         """
-        return len(self.chars)
+        return wcswidth(self.string)
 
 
 if __name__ == '__main__':

--- a/ranger/ext/widestring.py
+++ b/ranger/ext/widestring.py
@@ -176,6 +176,7 @@ class WideString(object):  # pylint: disable=too-few-public-methods
         except ImportError:
             return len(self.chars)
 
+
 if __name__ == '__main__':
     import doctest
     sys.exit(doctest.testmod()[0])

--- a/ranger/ext/widestring.py
+++ b/ranger/ext/widestring.py
@@ -6,6 +6,7 @@ from __future__ import (absolute_import, division, print_function)
 
 import sys
 from unicodedata import east_asian_width
+from unicodedata import normalize as unicodedata_normalize
 
 from ranger import PY3
 
@@ -15,8 +16,15 @@ WIDE = 2
 WIDE_SYMBOLS = set('WF')
 
 
+def normalize(string):
+    return unicodedata_normalize('NFKC', string)
+
+
 def uwid(string):
     """Return the width of a string"""
+    if isinstance(string, WideString):
+        string = string.string
+    string = normalize(string)
     if not PY3:
         string = string.decode('utf-8', 'ignore')
     return sum(utf_char_width(c) for c in string)
@@ -24,6 +32,7 @@ def uwid(string):
 
 def utf_char_width(string):
     """Return the width of a single character"""
+    string = normalize(string)
     if east_asian_width(string) in WIDE_SYMBOLS:
         return WIDE
     return NARROW

--- a/ranger/ext/widestring.py
+++ b/ranger/ext/widestring.py
@@ -24,7 +24,7 @@ except ImportError:
     def uwid(string):
         if not PY3:
             string = string.decode('utf-8', 'ignore')
-        return sum(utf_char_width(c) for c in string)
+        return sum(max(0, utf_char_width(c)) for c in string)
 
     def utf_char_width(char):
         if east_asian_width(char) in WIDE_SYMBOLS:

--- a/ranger/ext/widestring.py
+++ b/ranger/ext/widestring.py
@@ -144,9 +144,11 @@ class WideString(object):  # pylint: disable=too-few-public-methods
         >>> len(WideString("モヒカン"))
         8
         """
-        if not PY3:
-            self.string = self.string.decode('utf-8', 'ignore')
-        return wcswidth(self.string)
+        if PY3:
+            string = self.string
+        else:
+            string = self.string.decode('utf-8', 'ignore')
+        return wcswidth(string)
 
 
 if __name__ == '__main__':

--- a/ranger/ext/widestring.py
+++ b/ranger/ext/widestring.py
@@ -5,7 +5,6 @@
 from __future__ import (absolute_import, division, print_function)
 
 import sys
-from unicodedata import east_asian_width
 
 try:
     from wcwidth import wcwidth, wcswidth
@@ -18,6 +17,8 @@ try:
         """Return the width of a single character"""
         return wcwidth(char)
 except ImportError:
+    from unicodedata import east_asian_width
+
     def uwid(string):
         if not PY3:
             string = string.decode('utf-8', 'ignore')

--- a/ranger/ext/widestring.py
+++ b/ranger/ext/widestring.py
@@ -44,7 +44,7 @@ def string_to_charlist(string):
     if PY3:
         for char in string:
             result.append(char)
-            if east_asian_width(char) in WIDE_SYMBOLS:
+            if utf_char_width(char) == WIDE:
                 result.append('')
     else:
         try:
@@ -57,7 +57,7 @@ def string_to_charlist(string):
             return []
         for char in string:
             result.append(char.encode('utf-8'))
-            if east_asian_width(char) in WIDE_SYMBOLS:
+            if utf_char_width(char) == WIDE:
                 result.append('')
     return result
 

--- a/ranger/ext/widestring.py
+++ b/ranger/ext/widestring.py
@@ -172,6 +172,7 @@ class WideString(object):  # pylint: disable=too-few-public-methods
         """
         return uwid(self.string)
 
+
 if __name__ == '__main__':
     import doctest
     sys.exit(doctest.testmod()[0])

--- a/ranger/ext/widestring.py
+++ b/ranger/ext/widestring.py
@@ -145,7 +145,7 @@ class WideString(object):  # pylint: disable=too-few-public-methods
         8
         """
         if not PY3:
-            string = string.decode('utf-8', 'ignore')
+            self.string = self.string.decode('utf-8', 'ignore')
         return wcswidth(self.string)
 
 

--- a/ranger/ext/widestring.py
+++ b/ranger/ext/widestring.py
@@ -16,9 +16,9 @@ except ImportError:
 
 PY3 = sys.version_info[0] >= 3
 ASCIIONLY = set(chr(c) for c in range(1, 128))
-NARROW = 1	
+NARROW = 1
 WIDE = 2
-WIDE_SYMBOLS = set('WF')	
+WIDE_SYMBOLS = set('WF')
 
 
 def uwid(string):	
@@ -27,8 +27,7 @@ def uwid(string):
         string = string.decode('utf-8', 'ignore')	
     if WCWIDTH_AVAILABLE:
         return wcswidth(string)
-    else:
-        return sum(utf_char_width(c) for c in string)	
+    return sum(utf_char_width(c) for c in string)	
 
 
 def utf_char_width(string):	

--- a/ranger/ext/widestring.py
+++ b/ranger/ext/widestring.py
@@ -11,6 +11,8 @@ try:
 
     def uwid(string):
         """Return the width of a string"""
+        if not PY3:
+            string = string.decode('utf-8', 'ignore')
         return wcswidth(string)
 
     def utf_char_width(char):
@@ -169,7 +171,6 @@ class WideString(object):  # pylint: disable=too-few-public-methods
         8
         """
         return uwid(self.string)
-
 
 if __name__ == '__main__':
     import doctest

--- a/ranger/ext/widestring.py
+++ b/ranger/ext/widestring.py
@@ -7,27 +7,11 @@ from __future__ import (absolute_import, division, print_function)
 import sys
 from unicodedata import east_asian_width
 
-from wcwidth import wcswidth
+from wcwidth import wcwidth, wcswidth
 
 PY3 = sys.version_info[0] >= 3
 ASCIIONLY = set(chr(c) for c in range(1, 128))
-NARROW = 1 
-WIDE = 2 
 WIDE_SYMBOLS = set('WF')
-
-
-def uwid(string):
-    """Return the width of a string"""
-    if not PY3:
-        string = string.decode('utf-8', 'ignore')
-    return sum(utf_char_width(c) for c in string)
-
-
-def utf_char_width(string):
-    """Return the width of a single character"""
-    if east_asian_width(string) in WIDE_SYMBOLS:
-        return WIDE
-    return NARROW
 
 
 def string_to_charlist(string):
@@ -161,6 +145,8 @@ class WideString(object):  # pylint: disable=too-few-public-methods
         >>> len(WideString("モヒカン"))
         8
         """
+        if not PY3:
+            string = string.decode('utf-8', 'ignore')
         return wcswidth(self.string)
 
 

--- a/ranger/ext/widestring.py
+++ b/ranger/ext/widestring.py
@@ -15,7 +15,7 @@ WIDE = 2
 WIDE_SYMBOLS = set('WF')
 
 
-def wcswidth(string):
+def uwid(string):
     """Return the width of a string"""
     if not PY3:
         string = string.decode('utf-8', 'ignore')
@@ -23,10 +23,10 @@ def wcswidth(string):
         from wcwidth import wcswidth
         return wcswidth(string)
     except ImportError:
-        return sum(wcwidth(c) for c in string)
+        return sum(utf_char_width(c) for c in string)
 
 
-def wcwidth(char):
+def utf_char_width(char):
     """Return the width of a single character"""
     try:
         from wcwidth import wcwidth

--- a/ranger/ext/widestring.py
+++ b/ranger/ext/widestring.py
@@ -33,8 +33,7 @@ try:
 
     def utf_char_width(char):
         """Return the width of a single character"""
-        char = normalize(char)
-        return wcwidth(char)
+        return max(0, wcwidth(char))
 except ImportError:
     from unicodedata import east_asian_width
 
@@ -44,7 +43,7 @@ except ImportError:
         string = normalize(string)
         if not PY3:
             string = string.decode('utf-8', 'ignore')
-        return sum(max(0, utf_char_width(c)) for c in string)
+        return sum(utf_char_width(c) for c in string)
 
     def utf_char_width(char):
         char = normalize(char)

--- a/ranger/ext/widestring.py
+++ b/ranger/ext/widestring.py
@@ -5,7 +5,6 @@
 from __future__ import (absolute_import, division, print_function)
 
 import sys
-from unicodedata import east_asian_width
 
 from wcwidth import wcwidth, wcswidth
 

--- a/ranger/gui/ansi.py
+++ b/ranger/gui/ansi.py
@@ -8,7 +8,7 @@ from __future__ import (absolute_import, division, print_function)
 
 import re
 
-from ranger.ext.widestring import WideString
+from ranger.ext.widestring import uwid, WideString
 from ranger.gui import color
 
 
@@ -126,7 +126,7 @@ def char_len(ansi_text):
     if isinstance(ansi_text, WideString):
         ansi_text = ansi_text.string
 
-    return len(WideString(ansi_re.sub('', ansi_text)))
+    return uwid(ansi_re.sub('', ansi_text))
 
 
 def char_slice(ansi_text, start, length):
@@ -163,7 +163,7 @@ def char_slice(ansi_text, start, length):
 
         chunk = WideString(chunk)
         old_pos = pos
-        pos += len(chunk)
+        pos += uwid(chunk)
         if pos <= start:
             pass  # seek
         elif old_pos < start <= pos:

--- a/ranger/gui/bar.py
+++ b/ranger/gui/bar.py
@@ -5,7 +5,9 @@ from __future__ import (absolute_import, division, print_function)
 
 import sys
 
-from ranger.ext.widestring import WideString, utf_char_width
+from ranger.ext.widestring import WideString
+
+from wcwidth import wcwidth
 
 
 PY3 = sys.version_info[0] >= 3
@@ -127,9 +129,9 @@ class ColoredString(object):
         if not string or not self.string.chars:
             self.min_size = 0
         elif PY3:
-            self.min_size = utf_char_width(string[0])
+            self.min_size = wcwidth(string[0])
         else:
-            self.min_size = utf_char_width(self.string.chars[0].decode('utf-8'))
+            self.min_size = wcwidth(self.string.chars[0].decode('utf-8'))
 
     def cut_off(self, n):
         if n >= 1:

--- a/ranger/gui/bar.py
+++ b/ranger/gui/bar.py
@@ -5,7 +5,7 @@ from __future__ import (absolute_import, division, print_function)
 
 import sys
 
-from ranger.ext.widestring import WideString, wcwidth
+from ranger.ext.widestring import WideString, utf_char_width
 
 
 PY3 = sys.version_info[0] >= 3
@@ -127,9 +127,9 @@ class ColoredString(object):
         if not string or not self.string.chars:
             self.min_size = 0
         elif PY3:
-            self.min_size = wcwidth(string[0])
+            self.min_size = utf_char_width(string[0])
         else:
-            self.min_size = wcwidth(self.string.chars[0].decode('utf-8'))
+            self.min_size = utf_char_width(self.string.chars[0].decode('utf-8'))
 
     def cut_off(self, n):
         if n >= 1:

--- a/ranger/gui/bar.py
+++ b/ranger/gui/bar.py
@@ -5,9 +5,9 @@ from __future__ import (absolute_import, division, print_function)
 
 import sys
 
-from ranger.ext.widestring import WideString
-
 from wcwidth import wcwidth
+
+from ranger.ext.widestring import WideString
 
 
 PY3 = sys.version_info[0] >= 3

--- a/ranger/gui/bar.py
+++ b/ranger/gui/bar.py
@@ -5,7 +5,7 @@ from __future__ import (absolute_import, division, print_function)
 
 import sys
 
-from ranger.ext.widestring import WideString, utf_char_width
+from ranger.ext.widestring import WideString, wcwidth
 
 
 PY3 = sys.version_info[0] >= 3
@@ -127,9 +127,9 @@ class ColoredString(object):
         if not string or not self.string.chars:
             self.min_size = 0
         elif PY3:
-            self.min_size = utf_char_width(string[0])
+            self.min_size = wcwidth(string[0])
         else:
-            self.min_size = utf_char_width(self.string.chars[0].decode('utf-8'))
+            self.min_size = wcwidth(self.string.chars[0].decode('utf-8'))
 
     def cut_off(self, n):
         if n >= 1:

--- a/ranger/gui/bar.py
+++ b/ranger/gui/bar.py
@@ -5,9 +5,7 @@ from __future__ import (absolute_import, division, print_function)
 
 import sys
 
-from wcwidth import wcwidth
-
-from ranger.ext.widestring import WideString
+from ranger.ext.widestring import WideString, utf_char_width
 
 
 PY3 = sys.version_info[0] >= 3
@@ -129,9 +127,9 @@ class ColoredString(object):
         if not string or not self.string.chars:
             self.min_size = 0
         elif PY3:
-            self.min_size = wcwidth(string[0])
+            self.min_size = utf_char_width(string[0])
         else:
-            self.min_size = wcwidth(self.string.chars[0].decode('utf-8'))
+            self.min_size = utf_char_width(self.string.chars[0].decode('utf-8'))
 
     def cut_off(self, n):
         if n >= 1:

--- a/ranger/gui/widgets/__init__.py
+++ b/ranger/gui/widgets/__init__.py
@@ -3,6 +3,7 @@
 from __future__ import (absolute_import, division, print_function)
 
 from ranger.gui.displayable import Displayable
+from ranger.ext.widestring import normalize
 
 
 class Widget(Displayable):
@@ -44,4 +45,4 @@ class Widget(Displayable):
             '!', ['vcsunknown']),
     }
 
-    ellipsis = {False: '~', True: '…'}
+    ellipsis = {False: '~', True: normalize('…')}

--- a/ranger/gui/widgets/browsercolumn.py
+++ b/ranger/gui/widgets/browsercolumn.py
@@ -10,7 +10,7 @@ import stat
 from time import time
 from os.path import splitext
 
-from ranger.ext.widestring import WideString
+from ranger.ext.widestring import normalize, WideString
 from ranger.core import linemode
 
 from ranger.gui import ansi
@@ -461,9 +461,9 @@ class BrowserColumn(Pager):  # pylint: disable=too-many-instance-attributes
 
     def _draw_text_display(self, text, space):
         bidi_text = self.bidi_transpose(text)
-        wtext = WideString(bidi_text)
-        wext = WideString(splitext(bidi_text)[1])
-        wellip = WideString(self.ellipsis[self.settings.unicode_ellipsis])
+        wtext = WideString(normalize(bidi_text))
+        wext = WideString(normalize(splitext(bidi_text)[1]))
+        wellip = WideString(normalize(self.ellipsis[self.settings.unicode_ellipsis]))
         wtext_len = ansi.char_len(wtext)
         wext_len = ansi.char_len(wext)
         wellip_len = ansi.char_len(wellip)

--- a/ranger/gui/widgets/console.py
+++ b/ranger/gui/widgets/console.py
@@ -95,11 +95,16 @@ class Console(Widget):  # pylint: disable=too-many-instance-attributes,too-many-
     def _calculate_offset(self):
         wid = self.wid - 2
         whalf = wid // 2
-        if self.pos < whalf or len(self.line) < wid:
+        pos = self._calculate_screen_pos()
+        length = uwid(self.line)
+        if pos < whalf or length < wid:
             return 0
-        if self.pos > len(self.line) - (wid - whalf):
-            return len(self.line) - wid
-        return self.pos - whalf
+        if pos > length - (wid - whalf):
+            return length - wid
+        return pos - whalf
+
+    def _calculate_screen_pos(self):
+        return uwid(self.line[:self.pos])
 
     def draw(self):
         self.win.erase()
@@ -111,9 +116,7 @@ class Console(Widget):  # pylint: disable=too-many-instance-attributes,too-many-
 
         self.addstr(0, 0, self.prompt)
         line = WideString(self.line)
-        if line:
-            x = self._calculate_offset()
-            self.addstr(0, len(self.prompt), str(line[x:]))
+        self.addstr(0, len(self.prompt), str(line[self._calculate_offset():]))
 
     def finalize(self):
         move = self.fm.ui.win.move
@@ -124,8 +127,8 @@ class Console(Widget):  # pylint: disable=too-many-instance-attributes,too-many-
                 pass
         else:
             try:
-                x = self._calculate_offset()
-                pos = uwid(self.line[x:self.pos]) + len(self.prompt)
+                real_pos = len(self.prompt) + self._calculate_screen_pos()
+                pos = real_pos - self._calculate_offset()
                 move(self.y, self.x + min(self.wid - 1, pos))
             except curses.error:
                 pass

--- a/ranger/gui/widgets/console.py
+++ b/ranger/gui/widgets/console.py
@@ -34,6 +34,7 @@ class Console(Widget):  # pylint: disable=too-many-instance-attributes,too-many-
     historypath = None
     wait_for_command_input = False
     unicode_buffer = ""
+    right_margin = 1
 
     def __init__(self, win):
         Widget.__init__(self, win)
@@ -93,7 +94,7 @@ class Console(Widget):  # pylint: disable=too-many-instance-attributes,too-many-
         Widget.destroy(self)
 
     def _calculate_offset(self):
-        wid = self.wid - 2
+        wid = self.wid - (len(self.prompt) + self.right_margin)
         whalf = wid // 2
         pos = self._calculate_screen_pos()
         length = uwid(self.line)
@@ -129,7 +130,7 @@ class Console(Widget):  # pylint: disable=too-many-instance-attributes,too-many-
             try:
                 real_pos = len(self.prompt) + self._calculate_screen_pos()
                 pos = real_pos - self._calculate_offset()
-                move(self.y, self.x + min(self.wid - 1, pos))
+                move(self.y, self.x + min(self.wid - self.right_margin, pos))
             except curses.error:
                 pass
 

--- a/ranger/gui/widgets/console.py
+++ b/ranger/gui/widgets/console.py
@@ -94,7 +94,7 @@ class Console(Widget):  # pylint: disable=too-many-instance-attributes,too-many-
         Widget.destroy(self)
 
     def _calculate_offset(self):
-        wid = self.wid - (len(self.prompt) + self.right_margin)
+        wid = self.wid - (uwid(self.prompt) + self.right_margin)
         whalf = wid // 2
         pos = self._calculate_screen_pos()
         length = uwid(self.line)
@@ -128,7 +128,7 @@ class Console(Widget):  # pylint: disable=too-many-instance-attributes,too-many-
 
         self.addstr(0, 0, self.prompt)
         line = WideString(self.line)
-        self.addstr(0, len(self.prompt), str(line[self._calculate_offset():]))
+        self.addstr(0, uwid(self.prompt), str(line[self._calculate_offset():]))
 
     def finalize(self):
         move = self.fm.ui.win.move
@@ -139,7 +139,7 @@ class Console(Widget):  # pylint: disable=too-many-instance-attributes,too-many-
                 pass
         else:
             try:
-                real_pos = len(self.prompt) + self._calculate_screen_pos()
+                real_pos = uwid(self.prompt) + self._calculate_screen_pos()
                 pos = real_pos - self._calculate_offset()
                 move(self.y, self.x + min(self.wid - self.right_margin, pos))
             except curses.error:

--- a/ranger/gui/widgets/console.py
+++ b/ranger/gui/widgets/console.py
@@ -14,7 +14,7 @@ from io import open
 from ranger import PY3
 from ranger.gui.widgets import Widget
 from ranger.ext.direction import Direction
-from ranger.ext.widestring import string_to_charlist, uwid, WideString
+from ranger.ext.widestring import normalize, string_to_charlist, uwid, WideString
 from ranger.container.history import History, HistoryEmptyException
 import ranger
 
@@ -132,7 +132,8 @@ class Console(Widget):  # pylint: disable=too-many-instance-attributes,too-many-
 
         self.addstr(0, 0, self.prompt)
         line = WideString(self.line, chars=self._get_chars())
-        self.addstr(0, uwid(self.prompt), str(line[self._calculate_offset():]))
+        line = normalize(str(line[self._calculate_offset():]))
+        self.addstr(0, uwid(self.prompt), line)
 
     def finalize(self):
         move = self.fm.ui.win.move
@@ -143,9 +144,9 @@ class Console(Widget):  # pylint: disable=too-many-instance-attributes,too-many-
                 pass
         else:
             try:
-                real_pos = uwid(self.prompt) + self._calculate_screen_pos()
-                pos = real_pos - self._calculate_offset()
-                move(self.y, self.x + min(self.wid - self.right_margin, pos))
+                pos = self._calculate_screen_pos() - self._calculate_offset()
+                cursor = pos + 1
+                move(self.y, self.x + min(self.wid - 1, cursor))
             except curses.error:
                 pass
 

--- a/ranger/gui/widgets/console.py
+++ b/ranger/gui/widgets/console.py
@@ -12,7 +12,7 @@ from collections import deque
 
 from ranger.gui.widgets import Widget
 from ranger.ext.direction import Direction
-from ranger.ext.widestring import uwid, WideString
+from ranger.ext.widestring import wcswidth, WideString
 from ranger.container.history import History, HistoryEmptyException
 import ranger
 
@@ -120,7 +120,7 @@ class Console(Widget):  # pylint: disable=too-many-instance-attributes,too-many-
         else:
             try:
                 x = self._calculate_offset()
-                pos = uwid(self.line[x:self.pos]) + len(self.prompt)
+                pos = wcswidth(self.line[x:self.pos]) + len(self.prompt)
                 move(self.y, self.x + min(self.wid - 1, pos))
             except curses.error:
                 pass

--- a/ranger/gui/widgets/console.py
+++ b/ranger/gui/widgets/console.py
@@ -12,7 +12,7 @@ from collections import deque
 
 from ranger.gui.widgets import Widget
 from ranger.ext.direction import Direction
-from ranger.ext.widestring import WideString
+from ranger.ext.widestring import uwid, WideString
 from ranger.container.history import History, HistoryEmptyException
 import ranger
 
@@ -120,7 +120,7 @@ class Console(Widget):  # pylint: disable=too-many-instance-attributes,too-many-
         else:
             try:
                 x = self._calculate_offset()
-                pos = len(self.line[x:self.pos]) + len(self.prompt)
+                pos = uwid(self.line[x:self.pos]) + len(self.prompt)
                 move(self.y, self.x + min(self.wid - 1, pos))
             except curses.error:
                 pass

--- a/ranger/gui/widgets/console.py
+++ b/ranger/gui/widgets/console.py
@@ -12,7 +12,7 @@ from collections import deque
 
 from ranger.gui.widgets import Widget
 from ranger.ext.direction import Direction
-from ranger.ext.widestring import wcswidth, WideString
+from ranger.ext.widestring import uwid, WideString
 from ranger.container.history import History, HistoryEmptyException
 import ranger
 
@@ -120,7 +120,7 @@ class Console(Widget):  # pylint: disable=too-many-instance-attributes,too-many-
         else:
             try:
                 x = self._calculate_offset()
-                pos = wcswidth(self.line[x:self.pos]) + len(self.prompt)
+                pos = uwid(self.line[x:self.pos]) + len(self.prompt)
                 move(self.y, self.x + min(self.wid - 1, pos))
             except curses.error:
                 pass

--- a/ranger/gui/widgets/console.py
+++ b/ranger/gui/widgets/console.py
@@ -12,7 +12,7 @@ from collections import deque
 
 from ranger.gui.widgets import Widget
 from ranger.ext.direction import Direction
-from ranger.ext.widestring import uwid, WideString
+from ranger.ext.widestring import WideString
 from ranger.container.history import History, HistoryEmptyException
 import ranger
 
@@ -120,7 +120,7 @@ class Console(Widget):  # pylint: disable=too-many-instance-attributes,too-many-
         else:
             try:
                 x = self._calculate_offset()
-                pos = uwid(self.line[x:self.pos]) + len(self.prompt)
+                pos = len(self.line[x:self.pos]) + len(self.prompt)
                 move(self.y, self.x + min(self.wid - 1, pos))
             except curses.error:
                 pass

--- a/ranger/gui/widgets/pager.py
+++ b/ranger/gui/widgets/pager.py
@@ -11,6 +11,7 @@ import logging
 from ranger.gui import ansi
 from ranger.ext.direction import Direction
 from ranger.ext.img_display import ImgDisplayUnsupportedException
+from ranger.ext.widestring import normalize
 
 from . import Widget
 
@@ -125,7 +126,8 @@ class Pager(Widget):  # pylint: disable=too-many-instance-attributes
             else:
                 self.image_drawn = True
 
-    def _draw_line(self, i, line):
+    def _draw_line(self, i, rawline):
+        line = normalize(rawline)
         if self.markup is None:
             self.addstr(i, 0, line)
         elif self.markup == 'ansi':

--- a/ranger/gui/widgets/statusbar.py
+++ b/ranger/gui/widgets/statusbar.py
@@ -18,6 +18,7 @@ from grp import getgrgid
 from time import time, strftime, localtime
 
 from ranger.ext.human_readable import human_readable
+from ranger.ext.widestring import normalize
 from ranger.gui.bar import Bar
 
 from . import Widget
@@ -122,7 +123,7 @@ class StatusBar(Widget):  # pylint: disable=too-many-instance-attributes
         self.win.erase()
         self.color('in_statusbar', 'message',
                    self.msg.bad and 'bad' or 'good')
-        self.addnstr(0, 0, self.msg.text, self.wid)
+        self.addnstr(0, 0, normalize(self.msg.text), self.wid)
 
     def _draw_hint(self):
         self.win.erase()
@@ -326,7 +327,7 @@ class StatusBar(Widget):  # pylint: disable=too-many-instance-attributes
         self.win.move(0, 0)
         for part in result:
             self.color(*part.lst)
-            self.addstr(str(part))
+            self.addstr(normalize(str(part)))
 
         if self.settings.draw_progress_bar_in_status_bar:
             queue = self.fm.loader.queue

--- a/ranger/gui/widgets/taskview.py
+++ b/ranger/gui/widgets/taskview.py
@@ -6,6 +6,7 @@
 from __future__ import (absolute_import, division, print_function)
 
 from ranger.ext.accumulator import Accumulator
+from ranger.ext.widestring import normalize
 
 from . import Widget
 
@@ -52,7 +53,7 @@ class TaskView(Widget, Accumulator):
                     if self.pointer == i:
                         clr.append('selected')
 
-                    descr = obj.get_description()
+                    descr = normalize(obj.get_description())
                     if obj.progressbar_supported and obj.percent >= 0 and obj.percent <= 100:
                         self.addstr(y, 0, "%3.2f%% - %s" % (obj.percent, descr), self.wid)
                         wid = int((self.wid / 100) * obj.percent)

--- a/ranger/gui/widgets/view_base.py
+++ b/ranger/gui/widgets/view_base.py
@@ -7,6 +7,7 @@ from __future__ import (absolute_import, division, print_function)
 
 import curses
 from ranger.ext.keybinding_parser import key_to_string
+from ranger.ext.widestring import normalize
 from . import Widget
 from ..displayable import DisplayableContainer
 
@@ -103,7 +104,7 @@ class ViewBase(Widget, DisplayableContainer):  # pylint: disable=too-many-instan
             if i >= self.hei:
                 break
             self.addstr(i, 0, whitespace)
-            self.addnstr(i, 0, line, self.wid)
+            self.addnstr(i, 0, normalize(line), self.wid)
             i += 1
 
     def _draw_hints(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 flake8
 pylint<2
 pytest
+wcwidth

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 flake8
 pylint<2
 pytest
-wcwidth


### PR DESCRIPTION
<!-- Provide a descriptive summary of the changes in the title above -->

#### ISSUE TYPE
<!-- Pick relevant types and delete the rest -->
x Bug fix

#### RUNTIME ENVIRONMENT
<!-- Details of your runtime environment -->
<!-- Retrieve Python/ranger version and locale with `ranger -\-version` -->
- Operating system and version: 
- Terminal emulator and version: Tilix 1.9.5
- Python version: 3.11.2
- Ranger version/commit: master 6d5e0d8dc4cc5ddf53211e19f48c5b5e9ee47b18
- Locale: en_US.UTF-8

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [x] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [x] All changes follow the code style **[REQUIRED]**
- [x] All new and existing tests pass **[REQUIRED]**
- [ ] Changes require config files to be updated
    - [ ] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
<!-- Describe the changes in detail -->
* Change `Console._calculate_offset()` to calculate an offset based on the *screen width* of the line that will be drawn, instead of performing the calculations in terms of *string length*. Strings with wide characters always a larger screen width, this is why the issue doesn't appear with ASCII strings.
* Change the call sites of `_calculate_offset()` to also correctly distinguish between *screen position* and *character position*. This fixes both the rendering of the (possibly offset) line, and the cursor positioning.

#### MOTIVATION AND CONTEXT
<!-- Why are these changes required? -->
The console cursor can't reach the end of long filenames containing wide characters, if the terminal is too narrow to just display the name in full. And the filename is shown with a wrong offset.

This seems to be a problem with the Console class. It seems to mix up the concept of *character index* with that of *screen index,* so when wide characters are involved it miscalculates both the cursor position and how far the console line needs to be offset before having ncurses draw it onto the screen.

<!-- What problems do these changes solve? -->


<!-- Link to relevant issues -->
#1780

#### TESTING
<!-- What tests have been run? -->
As in issue #1780 I created a file named `おはよう|おはよう|おはよう|おはよう|おはよう|おはよう|おはよう|おはよう|おはよう|おはよう|おはよう|おはよう|おはよう|おはよう|おはよう|おはよう|おはよう|おはよう|.txt` and I tried renaming it in Ranger by hitting `a` (by default mapped to `rename_append`). Ranger now correctly positions the cursor and correctly displays the filename. Filenames without wide characters continue to be rendered the same.

<!-- How does the changes affect other areas of the codebase? -->
This changes the way the Console line is rendered, it's purely a UI change and I don't think there'll be any consequences in other areas of the codebase.

#### IMAGES / VIDEOS<!-- Only if relevant -->
<!-- Link or embed images and videos of screenshots, sketches etc. -->
