### PR TITLE
shutil_g.copytree: fix infinite recursion bug (#1925)

### DIFF
--- a/ranger/ext/shutil_generatorized.py
+++ b/ranger/ext/shutil_generatorized.py
@@ -204,13 +204,12 @@ def copytree(  # pylint: disable=too-many-locals,too-many-branches
     it is false, the contents of the files pointed to by symbolic
     links are copied.
     """
-    realsrc = os.path.abspath(os.path.expanduser(src))
+    realsrc = os.path.realpath(os.path.expanduser(src))
     if _ignored_trees is None:
         _ignored_trees = set()
-        realdst = os.path.abspath(os.path.expanduser(dst))
+        realdst = os.path.realpath(os.path.expanduser(dst))
         realdstdir = os.path.dirname(realdst)
-        if _destinsrc(realsrc, realdstdir) \
-                and not (symlinks and os.path.islink(realdstdir)):
+        if _destinsrc(realsrc, realdstdir):
             # avoid infinite recursion
             _ignored_trees.add(realdst)
     if realsrc in _ignored_trees:

--- a/ranger/ext/shutil_generatorized.py
+++ b/ranger/ext/shutil_generatorized.py
@@ -190,10 +190,9 @@ def copytree(  # pylint: disable=too-many-locals,too-many-branches
     dst,
     *,
     symlinks=False,
-    ignore=None,
-    ignored_paths=None,
     overwrite=False,
     make_safe_path=get_safe_path,
+    _ignored_trees=None
 ):
     """Recursively copy a directory tree using copy2().
 
@@ -204,36 +203,17 @@ def copytree(  # pylint: disable=too-many-locals,too-many-branches
     source tree result in symbolic links in the destination tree; if
     it is false, the contents of the files pointed to by symbolic
     links are copied.
-
-    The optional ignore argument is a callable. If given, it
-    is called with the `src` parameter, which is the directory
-    being visited by copytree(), and `names` which is the list of
-    `src` contents, as returned by os.listdir():
-
-        callable(src, names) -> ignored_names
-
-    Since copytree() is called recursively, the callable will be
-    called once for each directory that is copied. It returns a
-    list of names relative to the `src` directory that should
-    not be copied.
-
-    XXX Consider this example code rather than the ultimate tool.
-
     """
-    names = os.listdir(src)
-    if ignore is not None:
-        ignored_names = ignore(src, names)
-    else:
-        ignored_names = set()
-
-    absolute_src = os.path.abspath(os.path.expanduser(src))
-    if ignored_paths is None:
-        ignored_paths = set()
-        absolute_dst = os.path.abspath(os.path.expanduser(dst))
-        if _destinsrc(absolute_src, os.path.dirname(absolute_dst)):
+    realsrc = os.path.abspath(os.path.expanduser(src))
+    if _ignored_trees is None:
+        _ignored_trees = set()
+        realdst = os.path.abspath(os.path.expanduser(dst))
+        realdstdir = os.path.dirname(realdst)
+        if _destinsrc(realsrc, realdstdir) \
+                and not (symlinks and os.path.islink(realdstdir)):
             # avoid infinite recursion
-            ignored_paths.add(absolute_dst)
-    if absolute_src in ignored_paths:
+            _ignored_trees.add(realdst)
+    if realsrc in _ignored_trees:
         return
 
     try:
@@ -244,9 +224,8 @@ def copytree(  # pylint: disable=too-many-locals,too-many-branches
             os.makedirs(dst)
     errors = []
     done = 0
+    names = os.listdir(src)
     for name in names:
-        if name in ignored_names:
-            continue
         srcname = os.path.join(src, name)
         dstname = os.path.join(dst, name)
         try:
@@ -262,10 +241,9 @@ def copytree(  # pylint: disable=too-many-locals,too-many-branches
                     srcname,
                     dstname,
                     symlinks=symlinks,
-                    ignore=ignore,
-                    ignored_paths=ignored_paths,
                     overwrite=overwrite,
                     make_safe_path=make_safe_path,
+                    _ignored_trees=_ignored_trees
                 ):
                     yield done + n
                 done += n

--- a/ranger/ext/shutil_generatorized.py
+++ b/ranger/ext/shutil_generatorized.py
@@ -191,6 +191,7 @@ def copytree(  # pylint: disable=too-many-locals,too-many-branches
     *,
     symlinks=False,
     ignore=None,
+    ignored_paths=None,
     overwrite=False,
     make_safe_path=get_safe_path,
 ):
@@ -225,6 +226,16 @@ def copytree(  # pylint: disable=too-many-locals,too-many-branches
     else:
         ignored_names = set()
 
+    absolute_src = os.path.abspath(os.path.expanduser(src))
+    if ignored_paths is None:
+        ignored_paths = set()
+        absolute_dst = os.path.abspath(os.path.expanduser(dst))
+        if _destinsrc(absolute_src, os.path.dirname(absolute_dst)):
+            # avoid infinite recursion
+            ignored_paths.add(absolute_dst)
+    if absolute_src in ignored_paths:
+        return
+
     try:
         os.makedirs(dst)
     except OSError:
@@ -252,6 +263,7 @@ def copytree(  # pylint: disable=too-many-locals,too-many-branches
                     dstname,
                     symlinks=symlinks,
                     ignore=ignore,
+                    ignored_paths=ignored_paths,
                     overwrite=overwrite,
                     make_safe_path=make_safe_path,
                 ):


### PR DESCRIPTION
<!-- Provide a descriptive summary of the changes in the title above -->

#### ISSUE TYPE
<!-- Pick relevant types and delete the rest -->
x Bug fix

#### RUNTIME ENVIRONMENT
<!-- Details of your runtime environment -->
<!-- Retrieve Python/ranger version and locale with `ranger -\-version` -->
- Operating system and version: 
- Terminal emulator and version: Tilix 1.9.5
- Python version: 3.11.2
- Ranger version/commit: master 6d5e0d8dc4cc5ddf53211e19f48c5b5e9ee47b18
- Locale: en_US.UTF-8

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [x] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [x] All changes follow the code style **[REQUIRED]**
- [x] All new and existing tests pass **[REQUIRED]**
- [ ] Changes require config files to be updated
    - [ ] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
<!-- Describe the changes in detail -->
Record the destination directory in a set of "ignored trees" and pass this variable down to recursive instances of `copytree()`.

Remove the `ignore` keyword argument mostly because Pylint complains that the function is too big otherwise. Fortunately it was never used anyway.

#### MOTIVATION AND CONTEXT
<!-- Why are these changes required? -->
When copying a folder into its subtree, `copytree()` will
recursively copy the newly created directory, and enter an infinite recursive descent, because it doesn't know which of the files it already created.

This is somewhat of an edge case and some file managers outright refuse to handle it. Even the version of `cp` running on my machine won't do this. But it seems like a simple bug for us to fix and it'd give the user more freedom.

<!-- What problems do these changes solve? -->
<!-- Link to relevant issues -->
#1925

#### TESTING
<!-- What tests have been run? -->
Create a directory, and create another directory inside of it.

Optionally create additional files and add them to either directory.

Now copy the first directory (`:copy`), navigate into the second directoy, and run the `:paste` command. All the contents of the source directory will be in the second directory as a user would expect.

<!-- How does the changes affect other areas of the codebase? -->
Changes to `shutil_generatorized` affect the `CopyLoader` class, which is its only user. The specific code paths involved would only affect copying directories using `:copy` followed by `:paste`.
