### PR TITLE
TitleBar: always redraw when directory changes

### DIFF
--- a/ranger/gui/widgets/titlebar.py
+++ b/ranger/gui/widgets/titlebar.py
@@ -17,6 +17,7 @@ from . import Widget
 
 class TitleBar(Widget):
     old_thisfile = None
+    old_thisdir = None
     old_keybuffer = None
     old_wid = None
     result = None
@@ -34,11 +35,13 @@ class TitleBar(Widget):
     def draw(self):
         if self.need_redraw or \
                 self.fm.thisfile != self.old_thisfile or\
+                self.fm.thisdir != self.old_thisdir or\
                 str(self.fm.ui.keybuffer) != str(self.old_keybuffer) or\
                 self.wid != self.old_wid:
             self.need_redraw = False
             self.old_wid = self.wid
             self.old_thisfile = self.fm.thisfile
+            self.old_thisdir = self.fm.thisdir
             self._calc_bar()
         self._print_result(self.result)
         if self.wid > 2:


### PR DESCRIPTION
<!-- Provide a descriptive summary of the changes in the title above -->

#### ISSUE TYPE
<!-- Pick relevant types and delete the rest -->
x Bug fix

#### RUNTIME ENVIRONMENT
<!-- Details of your runtime environment -->
<!-- Retrieve Python/ranger version and locale with `ranger -\-version` -->
- Terminal emulator and version: Tilix 1.9.5
- Python version: 3.11.2
- Ranger version/commit: master 6d5e0d8dc4cc5ddf53211e19f48c5b5e9ee47b18
- Locale: en_US.UTF-8

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [x] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [x] All changes follow the code style **[REQUIRED]**
- [x] All new and existing tests pass **[REQUIRED]**
- [ ] Changes require config files to be updated
    - [ ] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
<!-- Describe the changes in detail -->
Make the TitleBar widget track the current directory and redraw as soon as it changes.

#### MOTIVATION AND CONTEXT
<!-- Why are these changes required? -->
When in an empty folder, `FM.thisfile` has a value of None. When navigating between directories, TitleBar will checks whether the value of `thisfile` has changed, among other things, to determine when to redraw. But all empty folders have the same value for `FM.thisfile` so it will neglect to for example update the tab title when navigating between empty folders.

#### TESTING
<!-- What tests have been run? -->
To test:
- Add `set dir_name_in_tabs true` to `rc.conf`, then launch Ranger.
- Create two or more folders, named such that they'll appear sequentially in the list
- Navigate into one of the folders
- Open a new tab (execute `:tab_new` or use the `gn` shortcut)
- Navigate to one of the other folders, by executing `:move_parent 1`/`:move_parent -1` or using the shortcuts `[` or `]` .
- Before this commit, observe that the name of the current tab remains unchanged, despite having entered a different directory.
