### PR TITLE
Fix PyPy3 doctest in signals.py

### DIFF
--- a/ranger/ext/signals.py
+++ b/ranger/ext/signals.py
@@ -17,6 +17,13 @@ deleted when trying to call them (in signal_emit), but if they are never
 called, they accumulate and should be manually deleted with
 signal_garbage_collect().
 
+WARNING: Signal.signal_bind(..., weak=True) is buggy on PyPy!
+
+As of 2025-10-31, PyPy has delayed garbage collection, which results in
+signal handlers being run on objects that should have been deleted already.
+DO NOT put side effects in signal handler functions that might cause changes on
+the file system for this reason.
+
 >>> def test_function(signal):
 ...     if 'display' in signal:
 ...         print(signal.display)


### PR DESCRIPTION
Fixes the pypy3 doctest in signals.py and adds this warning:

> WARNING: Signal.signal_bind(..., weak=True) is buggy on PyPy!
> 
> As of 2025-10-31, PyPy has delayed garbage collection, which results in
> signal handlers being run on objects that should have been deleted already.
> DO NOT put side effects in signal handler functions that might cause changes on
> the file system for this reason.
