### PR TITLE
Remove pypy2.7 test from the workflow

### DIFF
--- a/.github/workflows/pypy.yml
+++ b/.github/workflows/pypy.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [pypy2.7, pypy3.10]
+        python-version: [pypy3.10]
     env:
       TERM: dumb
     steps:


### PR DESCRIPTION
As mentioned in #3159 - pypy2.7 is not working correctly, so it's time to give it a well deserved rest.