### PR TITLE
Fix automated pylint test

### DIFF
--- a/examples/plugin_chmod_keybindings.py
+++ b/examples/plugin_chmod_keybindings.py
@@ -9,11 +9,11 @@ from __future__ import (absolute_import, division, print_function)
 import ranger.api
 
 
-HOOK_INIT_OLD = ranger.api.hook_init
+original_hook = ranger.api.hook_init
 
 
 def hook_init(fm):
-    HOOK_INIT_OLD(fm)
+    original_hook(fm)
 
     # Generate key bindings for the chmod command
     command = "map {0}{1}{2} shell -d chmod {1}{0}{2} %s"

--- a/examples/plugin_fasd_add.py
+++ b/examples/plugin_fasd_add.py
@@ -8,7 +8,7 @@ import ranger.api
 from ranger.ext.spawn import check_output
 
 
-HOOK_INIT_OLD = ranger.api.hook_init
+original_hook = ranger.api.hook_init
 
 
 def hook_init(fm):
@@ -19,7 +19,7 @@ def hook_init(fm):
             except subprocess.CalledProcessError:
                 pass
     fm.signal_bind('execute.before', fasd_add)
-    return HOOK_INIT_OLD(fm)
+    return original_hook(fm)
 
 
 ranger.api.hook_init = hook_init

--- a/examples/plugin_file_filter.py
+++ b/examples/plugin_file_filter.py
@@ -10,7 +10,7 @@ from __future__ import (absolute_import, division, print_function)
 import ranger.container.directory
 
 
-ACCEPT_FILE_OLD = ranger.container.directory.accept_file
+original_hook = ranger.container.directory.accept_file
 
 HIDE_FILES = ("/boot", "/sbin", "/proc", "/sys")
 
@@ -19,7 +19,7 @@ HIDE_FILES = ("/boot", "/sbin", "/proc", "/sys")
 def custom_accept_file(fobj, filters):
     if not fobj.fm.settings.show_hidden and fobj.path in HIDE_FILES:
         return False
-    return ACCEPT_FILE_OLD(fobj, filters)
+    return original_hook(fobj, filters)
 
 
 # Overwrite the old function

--- a/examples/plugin_hello_world.py
+++ b/examples/plugin_hello_world.py
@@ -11,7 +11,7 @@ import ranger.api
 
 # Save the previously existing hook, because maybe another module already
 # extended that hook and we don't want to lose it:
-HOOK_READY_OLD = ranger.api.hook_ready
+original_hook = ranger.api.hook_ready
 
 # Create a replacement for the hook that...
 
@@ -21,7 +21,7 @@ def hook_ready(fm):
     fm.notify("Hello World")
     # ...and calls the saved hook.  If you don't care about the return value,
     # simply return the return value of the previous hook to be safe.
-    return HOOK_READY_OLD(fm)
+    return original_hook(fm)
 
 
 # Finally, "monkey patch" the existing hook_ready function with our replacement:

--- a/examples/plugin_ipc.py
+++ b/examples/plugin_ipc.py
@@ -12,7 +12,7 @@ from __future__ import (absolute_import, division, print_function)
 import ranger.api
 
 
-HOOK_INIT_OLD = ranger.api.hook_init
+original_hook = ranger.api.hook_init
 
 
 def hook_init(fm):
@@ -50,7 +50,7 @@ def hook_init(fm):
         # IPC support disabled
         pass
     finally:
-        HOOK_INIT_OLD(fm)
+        original_hook(fm)
 
 
 ranger.api.hook_init = hook_init

--- a/examples/plugin_pmount.py
+++ b/examples/plugin_pmount.py
@@ -18,7 +18,7 @@ UMOUNT_KEY = '<alt>M'
 LIST_MOUNTS_KEY = '<alt>N'
 
 
-HOOK_INIT_OLD = ranger.api.hook_init
+original_hook = ranger.api.hook_init
 
 
 def hook_init(fm):
@@ -36,7 +36,7 @@ def hook_init(fm):
             fm.execute_console("map {key}{0}{1} chain cd; shell pumount sd{0}{1}".format(
                 disk, part, key=UMOUNT_KEY))
 
-    return HOOK_INIT_OLD(fm)
+    return original_hook(fm)
 
 
 ranger.api.hook_init = hook_init

--- a/examples/plugin_pmount_dynamic.py
+++ b/examples/plugin_pmount_dynamic.py
@@ -21,7 +21,7 @@ import ranger.api
 MOUNT_KEY = '<alt>m'
 UMOUNT_KEY = '<alt>M'
 LIST_MOUNTS_KEY = '<alt>n'
-HOOK_INIT_OLD = ranger.api.hook_init
+original_hook = ranger.api.hook_init
 
 
 def hook_init(fm):
@@ -64,7 +64,7 @@ def hook_init(fm):
                 fm.execute_console("map {key}{0}{1} chain cd; shell pumount sd{0}{1}".format(
                     disk, part, key=UMOUNT_KEY))
 
-    return HOOK_INIT_OLD(fm)
+    return original_hook(fm)
 
 
 ranger.api.hook_init = hook_init

--- a/ranger/container/file.py
+++ b/ranger/container/file.py
@@ -9,9 +9,10 @@ from ranger import PY3
 from ranger.container.fsobject import FileSystemObject
 
 N_FIRST_BYTES = 256
-CONTROL_CHARACTERS = set(list(range(0, 9)) + list(range(14, 32)))
-if not PY3:
-    CONTROL_CHARACTERS = set(chr(n) for n in CONTROL_CHARACTERS)
+if PY3:
+    CONTROL_CHARACTERS = set(range(0, 9)) | set(range(14, 32))
+else:
+    CONTROL_CHARACTERS = set(chr(n) for n in set(range(0, 9)) | set(range(14, 32)))
 
 # Don't even try to preview files which match this regular expression:
 PREVIEW_BLACKLIST = re.compile(r"""

--- a/ranger/core/actions.py
+++ b/ranger/core/actions.py
@@ -1058,15 +1058,20 @@ class Actions(  # pylint: disable=too-many-instance-attributes,too-many-public-m
             return None
 
         if not self.settings.preview_script or not self.settings.use_preview_script:
-            try:
-                # XXX: properly determine file's encoding
-                # Disable the lint because the preview is read outside the
-                # local scope.
-                # pylint: disable=consider-using-with
-                return codecs.open(path, 'r', errors='ignore')
-            # IOError for Python2, OSError for Python3
-            except (IOError, OSError):
-                return None
+            if PY3:
+                try:
+                    return open(path, 'r', errors='ignore', encoding='utf-8')
+                except OSError:
+                    return None
+            else:
+                try:
+                    # XXX: properly determine file's encoding
+                    # Disable the lint because the preview is read outside the
+                    # local scope.
+                    # pylint: disable=consider-using-with,deprecated-method
+                    return codecs.open(path, 'r', errors='ignore')
+                except IOError:
+                    return None
 
         # self.previews is a 2 dimensional dict:
         # self.previews['/tmp/foo.jpg'][(80, 24)] = "the content..."

--- a/ranger/core/actions.py
+++ b/ranger/core/actions.py
@@ -818,6 +818,8 @@ class Actions(  # pylint: disable=too-many-instance-attributes,too-many-public-m
             elif order == 'tag':
                 def fnc(obj):
                     return obj.realpath in self.tags
+            else:
+                raise RuntimeError("Unreachable code has been reached")
 
             return self.thisdir.search_fnc(fnc=fnc, offset=offset, forward=forward)
 

--- a/ranger/ext/rifle.py
+++ b/ranger/ext/rifle.py
@@ -37,13 +37,13 @@ ENCODING = 'utf-8'
 try:
     from ranger.ext.get_executables import get_executables
 except ImportError:
-    _CACHED_EXECUTABLES = None
+    cached_executables = None
 
     def get_executables():
         """Return all executable files in $PATH + Cache them."""
-        global _CACHED_EXECUTABLES  # pylint: disable=global-statement
-        if _CACHED_EXECUTABLES is not None:
-            return _CACHED_EXECUTABLES
+        global cached_executables  # pylint: disable=global-statement
+        if cached_executables is not None:
+            return cached_executables
 
         if 'PATH' in os.environ:
             paths = os.environ['PATH'].split(':')
@@ -52,7 +52,7 @@ except ImportError:
 
         from stat import S_IXOTH, S_IFREG
         paths_seen = set()
-        _CACHED_EXECUTABLES = set()
+        cached_executables = set()
         for path in paths:
             if path in paths_seen:
                 continue
@@ -68,8 +68,8 @@ except ImportError:
                 except OSError:
                     continue
                 if filestat.st_mode & (S_IXOTH | S_IFREG):
-                    _CACHED_EXECUTABLES.add(item)
-        return _CACHED_EXECUTABLES
+                    cached_executables.add(item)
+        return cached_executables
 
 
 try:


### PR DESCRIPTION
See e.g. this run: https://github.com/ranger/ranger/actions/runs/19001975276/job/54269998746

```
Running pylint...
pylint ./ranger/api ./ranger/container ./ranger/ext ./ranger/core ./ranger/colorschemes ./ranger/gui ./ranger/__init__.py ./doc/tools/convert_papermode_to_metadata.py ./doc/tools/performance_test.py ./doc/tools/print_colors.py ./doc/tools/print_keys.py ./examples/plugin_avfs.py ./examples/plugin_file_filter.py ./examples/plugin_new_sorting_method.py ./examples/plugin_pmount.py ./examples/plugin_fasd_add.py ./examples/plugin_linemode.py ./examples/plugin_pmount_dynamic.py ./examples/plugin_new_macro.py ./examples/plugin_chmod_keybindings.py ./examples/plugin_ipc.py ./examples/plugin_hello_world.py ./ranger.py ./setup.py ./tests
************* Module ranger.container.file
ranger/container/file.py:12:0: C0103: Variable name "CONTROL_CHARACTERS" doesn't conform to snake_case naming style (invalid-name)
ranger/container/file.py:14:4: C0103: Variable name "CONTROL_CHARACTERS" doesn't conform to snake_case naming style (invalid-name)
************* Module ranger.ext.rifle
ranger/ext/rifle.py:40:4: C0103: Variable name "_CACHED_EXECUTABLES" doesn't conform to snake_case naming style (invalid-name)
************* Module ranger.core.actions
ranger/core/actions.py:822:47: E0606: Possibly using variable 'fnc' before assignment (possibly-used-before-assignment)
ranger/core/actions.py:1064:23: W4902: Using deprecated method open() (deprecated-method)
************* Module plugin_file_filter
examples/plugin_file_filter.py:13:0: C0103: Variable name "ACCEPT_FILE_OLD" doesn't conform to snake_case naming style (invalid-name)
************* Module plugin_pmount
examples/plugin_pmount.py:21:0: C0103: Variable name "HOOK_INIT_OLD" doesn't conform to snake_case naming style (invalid-name)
************* Module plugin_fasd_add
examples/plugin_fasd_add.py:11:0: C0103: Variable name "HOOK_INIT_OLD" doesn't conform to snake_case naming style (invalid-name)
************* Module plugin_pmount_dynamic
examples/plugin_pmount_dynamic.py:24:0: C0103: Variable name "HOOK_INIT_OLD" doesn't conform to snake_case naming style (invalid-name)
************* Module plugin_chmod_keybindings
examples/plugin_chmod_keybindings.py:12:0: C0103: Variable name "HOOK_INIT_OLD" doesn't conform to snake_case naming style (invalid-name)
************* Module plugin_ipc
examples/plugin_ipc.py:15:0: C0103: Variable name "HOOK_INIT_OLD" doesn't conform to snake_case naming style (invalid-name)
************* Module plugin_hello_world
examples/plugin_hello_world.py:14:0: C0103: Variable name "HOOK_READY_OLD" doesn't conform to snake_case naming style (invalid-name)
```