### PR TITLE
feat(runner): add support for non-sudo in 'r' flag

### DIFF
--- a/ranger/core/runner.py
+++ b/ranger/core/runner.py
@@ -226,13 +226,26 @@ class Runner(object):  # pylint: disable=too-few-public-methods
                 wait_for_enter = True
         if 'r' in context.flags:
             # TODO: make 'r' flag work with pipes
-            if 'sudo' not in get_executables():
-                return self._log("Can not run with 'r' flag, sudo is not installed!")
+            # XXX: is there any way to make it better?
+            root_commands = ['sudo', 'doas', 'run0']
+            root_command = None
+            for tested_command in root_commands:
+                if tested_command not in get_executables():
+                    continue
+                else:
+                    root_command = tested_command
+                    break
             f_flag = ('f' in context.flags)
-            if isinstance(action, str):
-                action = 'sudo ' + (f_flag and '-b ' or '') + action
-            else:
-                action = ['sudo'] + (f_flag and ['-b'] or []) + action
+            # TODO: 'f' flag for doas/run0
+            match(root_command):
+                case 'sudo':
+                    action = 'sudo ' + ('-b ' if f_flag else '') + action
+                case 'doas':
+                    action = 'doas ' + action
+                case 'run0':
+                    action = 'run0 ' + action
+                case _:
+                    return self._log(f"Cannot run with 'r' flag, none of the allowed commands {root_commands} are installed!")  # noqa: E501 pylint: disable=C0301,E4240
             toggle_ui = True
             context.wait = True
         if 't' in context.flags:


### PR DESCRIPTION
<!-- Provide a descriptive summary of the changes in the title above -->

#### ISSUE TYPE
- Improvement/feature implementation

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [x] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [x] All changes follow the code style **[REQUIRED]**
- [x] All new and existing tests pass **[REQUIRED]**
- [ ] Changes require config files to be updated
    - [ ] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
Add support for `doas` and `run0` in `-r` flag (no support for `f` flag yet.)


#### MOTIVATION AND CONTEXT
Hard-coded `sudo` might cause problems on systems where `sudo` isn't installed.

#### TESTING
<!-- What tests have been run? -->
<!-- How does the changes affect other areas of the codebase? -->


#### IMAGES / VIDEOS<!-- Only if relevant -->
<!-- Link or embed images and videos of screenshots, sketches etc. -->
