### PR TITLE
Add setting `sort_max_items`.

### DIFF
--- a/doc/ranger.1
+++ b/doc/ranger.1
@@ -1120,6 +1120,9 @@ its ASCII value is higher.
 .IP "sort_directories_first [bool] <zd>" 4
 .IX Item "sort_directories_first [bool] <zd>"
 Sort directories first?
+.IP "sort_max_items [int]" 4
+.IX Item "sort_max_items [int]"
+The maximum amount of items to attempt to sort.
 .IP "sort_reverse [bool] <or>" 4
 .IX Item "sort_reverse [bool] <or>"
 Reverse the order of files?

--- a/doc/ranger.pod
+++ b/doc/ranger.pod
@@ -1291,6 +1291,10 @@ its ASCII value is higher.
 
 Sort directories first?
 
+=item sort_max_items [int]
+
+The maximum amount of items to attempt to sort.
+
 =item sort_reverse [bool] <or>
 
 Reverse the order of files?

--- a/examples/rc_emacs.conf
+++ b/examples/rc_emacs.conf
@@ -184,6 +184,7 @@ set sort natural
 set sort_reverse false
 set sort_case_insensitive true
 set sort_directories_first true
+set sort_max_items 8192
 set sort_unicode false
 
 # Enable this if key combinations with the Alt Key don't work for you.

--- a/ranger/config/rc.conf
+++ b/ranger/config/rc.conf
@@ -253,6 +253,7 @@ set sort natural
 set sort_reverse false
 set sort_case_insensitive true
 set sort_directories_first true
+set sort_max_items 8192
 set sort_unicode false
 
 # Enable this if key combinations with the Alt Key don't work for you.

--- a/ranger/container/directory.py
+++ b/ranger/container/directory.py
@@ -529,6 +529,10 @@ class Directory(  # pylint: disable=too-many-instance-attributes,too-many-public
         if self.files_all is None:
             return
 
+        if len(self.files_all) > self.settings.sort_max_items:
+            self.refilter()
+            return
+
         try:
             sort_func = self.sort_dict[self.settings.sort]
         except KeyError:

--- a/ranger/container/settings.py
+++ b/ranger/container/settings.py
@@ -82,6 +82,7 @@ ALLOWED_SETTINGS = {
     'show_selection_in_titlebar': bool,
     'sort_case_insensitive': bool,
     'sort_directories_first': bool,
+    'sort_max_items': int,
     'sort_reverse': bool,
     'sort': str,
     'sort_unicode': bool,


### PR DESCRIPTION
<!-- Provide a descriptive summary of the changes in the title above -->

#### ISSUE TYPE
- Improvement/feature implementation

#### RUNTIME ENVIRONMENT
<!-- Details of your runtime environment -->
<!-- Retrieve Python/ranger version and locale with `ranger -\-version` -->
- Operating system and version: Guix System x86_64 v1.5.0rc1
- Terminal emulator and version: alacritty 0.16.1
- Python version: Python 3.11.14
- Ranger version/commit: 1.9.4 (reapplied my patch to master)
- Locale: en_US.UTF-8

#### CHECKLIST
- [x] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [x] All changes follow the code style **[REQUIRED]**
- [x] All new and existing tests pass **[REQUIRED]**
- [x] Changes require config files to be updated
    - [x] Config files have been updated
- [x] Changes require documentation to be updated
    - [x] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
Add a setting `sort_max_items`.
Ranger won't attempt to sort a directory if it contains more items than `sort_max_items`.
Defaults to 8192.

#### MOTIVATION AND CONTEXT
With the Guix package manager, all files and directories are stored in `/gnu/store`. This directory can easily contain 50 000 items, which takes upwards of 10 seconds to load in ranger.
Profiling with `python -m cProfile -o ranger.prof`, shows that the sorting logic takes up 80% of the load time. Sorting here doesn't even have any use as every filename starts with a 32-byte hash.

#### TESTING
/

#### IMAGES / VIDEOS
/
