### PR TITLE
colorscheme: fix unreadable hostname color in solarized colorscheme

### DIFF
--- a/ranger/colorschemes/solarized.py
+++ b/ranger/colorschemes/solarized.py
@@ -93,7 +93,7 @@ class Solarized(ColorScheme):
         elif context.in_titlebar:
             attr |= bold
             if context.hostname:
-                fg = 16 if context.bad else 255
+                fg = default if context.bad else 255
                 if context.bad:
                     bg = 166
             elif context.directory:


### PR DESCRIPTION
See https://codeberg.org/ranger/colorschemes/issues/7

I tested and confirmed that it works on:

- the Solarized_Light colorscheme: https://codeberg.org/cornishbeaver/kitty-themes/src/branch/master/themes/Solarized_Light.conf
- The default dark kitty colorscheme