### PR TITLE
Trival fix for config - Do not call catdoc with docx files because it does not work

### DIFF
--- a/ranger/config/rifle.conf
+++ b/ranger/config/rifle.conf
@@ -161,7 +161,7 @@ ext pdf, has qpdfview, X, flag f = qpdfview "$@"
 ext pdf, has open,     X, flag f = open "$@"
 
 ext sc,    has sc,                    = sc -- "$@"
-ext docx?, has catdoc,       terminal = catdoc -- "$@" | $PAGER
+ext doc, has catdoc,       terminal = catdoc -- "$@" | $PAGER
 
 ext                        sxc|xlsx?|xlt|xlw|gnm|gnumeric, has gnumeric,    X, flag f = gnumeric -- "$@"
 ext                        sxc|xlsx?|xlt|xlw|gnm|gnumeric, has kspread,     X, flag f = kspread -- "$@"

--- a/ranger/config/rifle.conf
+++ b/ranger/config/rifle.conf
@@ -161,7 +161,7 @@ ext pdf, has qpdfview, X, flag f = qpdfview "$@"
 ext pdf, has open,     X, flag f = open "$@"
 
 ext sc,    has sc,                    = sc -- "$@"
-ext docx?, has catdoc,       terminal = catdoc -- "$@" | $PAGER
+ext doc?, has catdoc,       terminal = catdoc -- "$@" | $PAGER
 
 ext                        sxc|xlsx?|xlt|xlw|gnm|gnumeric, has gnumeric,    X, flag f = gnumeric -- "$@"
 ext                        sxc|xlsx?|xlt|xlw|gnm|gnumeric, has kspread,     X, flag f = kspread -- "$@"


### PR DESCRIPTION
This is a super trivial change that would improve the default experience. catdoc doesn't work with docx file and this line in the default config causes confusion when nothing happens if you try and open a docx from ranger. I simply changed the file extension and it seems now to work on old files while not getting in the way of previews of docx.

#### ISSUE TYPE
- Improvement/feature implementation

#### RUNTIME ENVIRONMENT
- Operating system and version: KDE neon User Edition (Wayland)
Build ABI: x86_64-little_endian-lp64
Kernel: linux 6.14.0-37-generic
- Terminal emulator and version: Konsole: 25.12.1
KDE Frameworks: 6.22.0
Qt: Using 6.10.1 and built against 6.10.1
- Python version: 3.12.3 (main, Jan  8 2026, 11:30:50) [GCC 13.3.0]
- Ranger version/commit: ranger version: ranger 1.9.3
- Locale: en_GB.UTF-8

#### CHECKLIST
- [X] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [X] All changes follow the code style **[REQUIRED]**
- [ ] All new and existing tests pass **[REQUIRED]** **SEE NOTE BELOW!**
- [x] Changes require config files to be updated
    - [x] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
Simple change to the default rifle.conf so that the catdoc command is only triggered for .doc Word files and not the "new" .docx


#### MOTIVATION AND CONTEXT
If you try and open a docx file in ranger with the default setup by hitting RETURN, you get a blank screen. Confusing and unhelpful. The cause is that the default rifle.conf calls the catdoc command if present. catdoc doesn't handle .docx files, only .doc.  (While this is unclear from the man page it is clear from the error message when you pass it a docx.)
By merging this change, the next option for docx (libreoffice I think)will be used to launch the file, a better experience.
It also means the preview function for docx files (scope.sh  I think? Doesn't matter for the change) now works.
By keeping the doc match instead of just removing the line, you still get the catdoc functionality for old-style Word files. (Tested and confirmed by me) 


#### TESTING
I ran make test on the patched code branch. There were test failures but I don't have a real test setup and honestly this is a one line change.
More importantly, I tested this change on my version and it has the effect described. I can't see a mechanism where this would cause any of the other tests to fail. It is a one-char config tweak :P