### PR TITLE
shutil_generatorized: Return to raise StopIteration

### DIFF
--- a/ranger/ext/shutil_generatorized.py
+++ b/ranger/ext/shutil_generatorized.py
@@ -154,6 +154,7 @@ def copyfile(src, dst):
             try:
                 for done in copyfileobj_range(fsrc, fdst):
                     yield done
+                return
             except OSError:
                 # Return to start of files first, then use old method
                 fsrc.seek(0, 0)


### PR DESCRIPTION
When refactoring `copyfile` in 4a5c9fd1f2cac3a40bb75b9e7140025f359c42fe, I forgot to return after `copyfileobj_range` finishes successfully. This means `copyfileobj` is called right after and copies the entire file **again**, this time without potentially making a COW copy!

@qrvd, I noticed this when reviewing #3151, so double thanks : ) A review'd be welcome.