### PR TITLE
rifle.conf: add config-like extensions to non-text editor fallback

### DIFF
--- a/ranger/config/rifle.conf
+++ b/ranger/config/rifle.conf
@@ -87,8 +87,8 @@ ext x?html?, has w3m,               terminal = w3m "$@"
 # Define the "editor" for text files as first action
 mime ^text,  label editor = ${VISUAL:-$EDITOR} -- "$@"
 mime ^text,  label pager  = $PAGER -- "$@"
-!mime ^text, label editor, ext xml|json|ya?ml|csv|tex|py|pl|rb|rs|js|sh|php|dart|nim|patch = ${VISUAL:-$EDITOR} -- "$@"
-!mime ^text, label pager,  ext xml|json|ya?ml|csv|tex|py|pl|rb|rs|js|sh|php|dart|nim|patch = $PAGER -- "$@"
+!mime ^text, label editor, ext xml|json|ya?ml|toml|conf|cfg|ini|env|csv|tex|py|pl|rb|rs|js|sh|php|dart|nim|patch = ${VISUAL:-$EDITOR} -- "$@"
+!mime ^text, label pager,  ext xml|json|ya?ml|toml|conf|cfg|ini|env|csv|tex|py|pl|rb|rs|js|sh|php|dart|nim|patch = $PAGER -- "$@"
 
 ext 1                         = man "$1"
 ext s[wmf]c, has zsnes, X     = zsnes "$1"
@@ -290,9 +290,9 @@ label open, has xdg-open = xdg-open "$@"
 label open, has open     = open -- "$@"
 
 # Define the editor for non-text files + pager as last action
-              !mime ^text, !ext xml|json|ya?ml|csv|tex|py|pl|rb|rs|js|sh|php|dart|nim|patch  = ask
-label editor, !mime ^text, !ext xml|json|ya?ml|csv|tex|py|pl|rb|rs|js|sh|php|dart|nim|patch  = ${VISUAL:-$EDITOR} -- "$@"
-label pager,  !mime ^text, !ext xml|json|ya?ml|csv|tex|py|pl|rb|rs|js|sh|php|dart|nim|patch  = $PAGER -- "$@"
+              !mime ^text, !ext xml|json|ya?ml|toml|conf|cfg|ini|env|csv|tex|py|pl|rb|rs|js|sh|php|dart|nim|patch  = ask
+label editor, !mime ^text, !ext xml|json|ya?ml|toml|conf|cfg|ini|env|csv|tex|py|pl|rb|rs|js|sh|php|dart|nim|patch  = ${VISUAL:-$EDITOR} -- "$@"
+label pager,  !mime ^text, !ext xml|json|ya?ml|toml|conf|cfg|ini|env|csv|tex|py|pl|rb|rs|js|sh|php|dart|nim|patch  = $PAGER -- "$@"
 
 
 ######################################################################


### PR DESCRIPTION
#### ISSUE TYPE
- Bug fix

#### RUNTIME ENVIRONMENT
- Operating system and version: Ubuntu 24.04
- Terminal emulator and version: zsh 5.9 (x86_64-ubuntu-linux-gnu)
- Python version: 3.12.3 (main, Jan 22 2026, 20:57:42) [GCC 13.3.0]
- Ranger version/commit:  1.9.4
- Locale:  C.UTF-8

#### CHECKLIST
- [x] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [x] All changes follow the code style **[REQUIRED]**
- [x] All new and existing tests pass **[REQUIRED]**
- [x] Changes require config files to be updated
    - [x] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION

This change extends the existing non-text extension fallback rules in
`ranger/config/rifle.conf` to include common config-like file extensions:

- `conf`
- `cfg`
- `ini`
- `toml`
- `env`

The change is intentionally minimal and only updates the existing extension
lists used by the `editor`, `pager`, and lower fallback `ask` rules.

#### MOTIVATION AND CONTEXT

Currently, `rifle.conf` already has extension-based fallbacks for some known
text-like formats such as `xml`, `json`, and `yaml` when MIME detection does
not return `text/*`.

However, common config-like files such as `*.conf`, `*.cfg`, `*.ini`,
`*.toml`, and `*.env` are not included in those fallback lists.

As a result, empty config-like files may be detected as
`application/octet-stream`, skip the text editor rule, and fall through to
generic openers or `ask` instead of opening in `$EDITOR`.

This makes behavior inconsistent: the same config file may open in the editor
after content is added, but not while it is still empty.

This patch keeps the existing design intact:
- MIME detection is still used first
- known text-like extensions are used as a fallback when MIME detection is not
  helpful

This change intentionally does not add a generic
`mime ^application/octet-stream` editor rule, because that could also affect
real binary files.

#### TESTING

Manual testing performed:

~~~~sh
touch /tmp/test.conf
touch /tmp/test.ini
touch /tmp/test.toml
touch /tmp/test.env
touch /tmp/test.cfg
~~~~

Opened each file in ranger with the default action.

Before this change, these files could fall through to generic openers or `ask`
depending on MIME detection on the system.

After this change, they open in `$EDITOR` / `$VISUAL` via the existing
extension-based fallback behavior.

The change only affects config-like files with the listed extensions and does
not change the behavior for arbitrary binary files or extensionless dotfiles.

#### IMAGES / VIDEOS
N/A