### PR TITLE
rifle: add file format integration for 3d graphic file formats #3122

### DIFF
--- a/ranger/config/rifle.conf
+++ b/ranger/config/rifle.conf
@@ -217,8 +217,8 @@ ext xcf,                    X, flag f = gimp -- "$@"
 #-------------------------------------------
 # 3D graphics
 #-------------------------------------------
-mime model/stl|model/step|model/3mf|model/iges, has f3d,          X     = f3d -- "$@"
-mime model/stl|model/step|model/3mf,            has prusa-slicer, X     = prusa-slicer -- "$@"
+mime ^model/(stl|step|3mf|iges),                has f3d,          X     = f3d -- "$@"
+mime ^model/(stl|step|3mf),                     has prusa-slicer, X     = prusa-slicer -- "$@"
 mime application/x-openscad,                    has openscad,     X     = openscad -- "$@"
 
 #-------------------------------------------

--- a/ranger/config/rifle.conf
+++ b/ranger/config/rifle.conf
@@ -215,6 +215,13 @@ ext kra,     has krita,     X, flag f = krita -- "$@"
 ext xcf,                    X, flag f = gimp -- "$@"
 
 #-------------------------------------------
+# 3D graphics
+#-------------------------------------------
+mime model/stl|model/step|model/3mf|model/iges, has f3d,          X     = f3d -- "$@"
+mime model/stl|model/step|model/3mf,            has prusa-slicer, X     = prusa-slicer -- "$@"
+mime application/x-openscad,                    has openscad,     X     = openscad -- "$@"
+
+#-------------------------------------------
 # Archives
 #-------------------------------------------
 

--- a/ranger/data/mime.types
+++ b/ranger/data/mime.types
@@ -40,3 +40,9 @@ video/webm              webm
 video/x-flv             flv
 video/x-matroska        mkv
 video/x-msvideo         divx
+
+application/x-openscad  scad
+model/stl               stl
+model/step              p21 stp step stpnc 210
+model/iges              iges
+model/3mf               3mf


### PR DESCRIPTION
This is an implementation for the Issue #3122 

Formats: stl, step, 3mf, iges, scad
Programs: f3d, prusa-slicer, openscad


#### ISSUE TYPE
- Improvement/feature implementation


#### RUNTIME ENVIRONMENT
<!-- Details of your runtime environment -->
<!-- Retrieve Python/ranger version and locale with `ranger -\-version` -->
- Operating system and version: Arch
- Terminal emulator and version: Foot
- Python version: 3.14.3
- Ranger version/commit: 1.9.4
- Locale: de_DE.UTF-8

#### CHECKLIST
- [X] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [X] All changes follow the code style **[REQUIRED]**
- [X] All new and existing tests pass **[REQUIRED]**
- [X] Changes require config files to be updated
    - [X] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
<!-- Describe the changes in detail -->


#### MOTIVATION AND CONTEXT
<!-- Why are these changes required? -->
<!-- What problems do these changes solve? -->
<!-- Link to relevant issues -->


#### TESTING
<!-- What tests have been run? -->
<!-- How does the changes affect other areas of the codebase? -->


#### IMAGES / VIDEOS<!-- Only if relevant -->
<!-- Link or embed images and videos of screenshots, sketches etc. -->
