### PR TITLE
Fix: loading of cached directories

### DIFF
--- a/ranger/container/fsobject.py
+++ b/ranger/container/fsobject.py
@@ -315,6 +315,9 @@ class FileSystemObject(  # pylint: disable=too-many-instance-attributes,too-many
         # Set some attributes
 
         self.accessible = bool(new_stat)
+        if self.is_directory:
+            self.runnable = self.accessible
+
         mode = new_stat.st_mode if new_stat else 0
 
         fmt = mode & 0o170000


### PR DESCRIPTION
Inaccessible directories when deleted and recreated under looser permissions were still set to not runnable, correctly reload them as runnable. Fixes #3081, specifically https://github.com/ranger/ranger/issues/3081#issuecomment-2797950360.

<!-- Provide a descriptive summary of the changes in the title above -->

#### ISSUE TYPE
- Bug fix

#### CHECKLIST
- [X] All changes follow the code style
- [X] All new and existing tests pass