### PR TITLE
rc.conf: don't auto-hide irrelevant files like .bak

### DIFF
--- a/ranger/config/rc.conf
+++ b/ranger/config/rc.conf
@@ -30,7 +30,10 @@ set viewmode miller
 set column_ratios 1,3,4
 
 # Which files should be hidden? (regular expression)
-set hidden_filter ^\.|\.(?:pyc|pyo|bak|swp)$|^lost\+found$|^__(py)?cache__$
+set hidden_filter ^\.
+
+# To hide some commonly unneeded files automatically, enable this:
+#set hidden_filter ^\.|\.(?:pyc|pyo|bak|swp)$|^lost\+found$|^__(py)?cache__$
 
 # Show hidden files? You can toggle this by typing 'zh'
 set show_hidden false


### PR DESCRIPTION
Instead of hiding certain unused files like `*.bak`, ranger now hides only dotfiles, like the `ls` command would.

People already complained about this on #2476 and i just noticed it myself too and it irritated me. Let's work like `ls` by default.

Fixes https://github.com/ranger/ranger/issues/2476