### PR TITLE
Fix hashing for duplicate, unique and hash filter stack filters

### DIFF
--- a/ranger/core/filter_stack.py
+++ b/ranger/core/filter_stack.py
@@ -12,7 +12,7 @@ try:
 except ImportError:
     from itertools import zip_longest
 # pylint: enable=invalid-name
-from os.path import abspath
+from os.path import abspath, exists
 
 from ranger.core.shared import FileManagerAware
 from ranger.ext.hash import hash_chunks
@@ -93,13 +93,18 @@ class MimeFilter(BaseFilter, FileManagerAware):
 
 @stack_filter("hash")
 class HashFilter(BaseFilter, FileManagerAware):
-    def __init__(self, filepath=None):
-        if filepath is None:
+    def __init__(self, filepath=""):
+        if not filepath:
             self.filepath = self.fm.thisfile.path
         else:
             self.filepath = filepath
-        if self.filepath is None:
-            self.fm.notify("Error: No file selected for hashing!", bad=True)
+        if not exists(self.filepath):
+            self.fm.notify(
+                "Error: Can't hash non-existent file: '{fp}'".format(
+                    fp=filepath
+                ),
+                bad=True,
+            )
         # TODO: Lazily generated list would be more efficient, a generator
         #       isn't enough because this object is reused for every fsobject
         #       in the current directory.

--- a/ranger/ext/hash.py
+++ b/ranger/ext/hash.py
@@ -3,8 +3,8 @@
 
 from __future__ import (absolute_import, division, print_function)
 
-from os import listdir
-from os.path import getsize, isdir, join
+from os import listdir, readlink
+from os.path import dirname, getsize, isdir, islink, join
 from hashlib import sha256
 
 # pylint: disable=invalid-name
@@ -13,7 +13,16 @@ from hashlib import sha256
 def hash_chunks(filepath, h=None):
     if not h:
         h = sha256()
-    if isdir(filepath):
+    if islink(filepath):
+        # Finding duplicates is about saving space so we consider symlinks to
+        # be their own thing, not duplicates of their targets.
+        h.update(
+            "symlink to {0}".format(
+                join(dirname(filepath), readlink(filepath))
+            ).encode("utf-8")
+        )
+        yield h.hexdigest()
+    elif isdir(filepath):
         h.update(filepath.encode("utf-8"))
         yield h.hexdigest()
         for fp in listdir(filepath):

--- a/ranger/ext/hash.py
+++ b/ranger/ext/hash.py
@@ -4,7 +4,7 @@
 from __future__ import (absolute_import, division, print_function)
 
 from os import listdir
-from os.path import getsize, isdir
+from os.path import getsize, isdir, join
 from hashlib import sha256
 
 # pylint: disable=invalid-name
@@ -14,10 +14,10 @@ def hash_chunks(filepath, h=None):
     if not h:
         h = sha256()
     if isdir(filepath):
-        h.update(filepath)
+        h.update(filepath.encode("utf-8"))
         yield h.hexdigest()
         for fp in listdir(filepath):
-            for fp_chunk in hash_chunks(fp, h=h):
+            for fp_chunk in hash_chunks(join(filepath, fp), h=h):
                 yield fp_chunk
     elif getsize(filepath) == 0:
         yield h.hexdigest()


### PR DESCRIPTION
Somewhere along the line the hash we use started requiring strings be encoded explicitly.

Fixing that issue revealed some more bugs to me, which I try to fix here.