### PR TITLE
fix: handle Ghostty 1.3.x EINVAL response gracefully

### DIFF
--- a/ranger/ext/img_display.py
+++ b/ranger/ext/img_display.py
@@ -770,6 +770,10 @@ class KittyImageDisplayer(ImageDisplayer, FileManagerAware):
                     )
         elif b'EBADF' in resp:
             self.stream = True
+        elif b'EINVAL' in resp or b'I' not in resp:
+            # Ghostty 1.3.x sends EINVAL error responses; treat as unsupported
+            raise ImgDisplayUnsupportedException(
+                'terminal does not support kitty graphics protocol (EINVAL); disabling')
         else:
             raise ImgDisplayUnsupportedException(
                 'unexpected response from terminal emulator: {r}'.format(r=resp))


### PR DESCRIPTION
## Summary

**Issue:** Ghostty 1.3.x returns EINVAL error responses for kitty graphics protocol queries, causing ranger to crash with `ImgDisplayUnsupportedException`.

**Root Cause:** The `_late_init()` method in `img_display.py` only checked for `OK` and `EBADF` responses. Ghostty 1.3.x returns `_Gi=1;EINVAL: invalid data` which contains neither, causing the `else` branch to raise an exception and crash.

**Fix:** Added detection for `EINVAL` responses (Ghostty 1.3.x) and treat as unsupported terminal with a clear error message, enabling graceful degradation instead of crash.

**Changed file:** `ranger/ext/img_display.py`

Fixes: ranger/ranger#3203