### PR TITLE
actions: prevent spawning of multiple preview tasks per file

### DIFF
--- a/ranger/core/actions.py
+++ b/ranger/core/actions.py
@@ -1035,7 +1035,8 @@ class Actions(  # pylint: disable=too-many-instance-attributes,too-many-public-m
     # --------------------------
     def update_preview(self, path):
         try:
-            del self.previews[path]
+            if not self.previews[path]['loading']:
+                del self.previews[path]
             self.signal_emit('preview.cleared', path=path)
         except KeyError:
             return False

--- a/ranger/core/actions.py
+++ b/ranger/core/actions.py
@@ -1037,11 +1037,10 @@ class Actions(  # pylint: disable=too-many-instance-attributes,too-many-public-m
         try:
             if not self.previews[path]['loading']:
                 del self.previews[path]
-            self.signal_emit('preview.cleared', path=path)
+                self.signal_emit('preview.cleared', path=path)
+                self.ui.need_redraw = True
         except KeyError:
-            return False
-        self.ui.need_redraw = True
-        return True
+            pass
 
     @staticmethod
     def sha512_encode(path, inode=None):


### PR DESCRIPTION
.. by not clearing preview state too zealously.

Fixes #1320 (?)
Fixes #2113 (?)

When accidentally enabling previews for virtual files like
`/var/lib/lxcfs/proc/diskstats`, I stumbled over this. The ever-changing
timestamp had ranger create vast numbers of preview tasks.. After some tracing
with pudb, I found this code for removing stale previews was also removing the
loading state marker, causing preview tasks to be rererecreated. Chaning to not
clear the dict entry when a preview tasks is still pending solves that.
Previews will still update on next refresh.

I could not quite reproduce the issues with SVG files again even without the
patch, but most likely this fixes those as well..
