### PR TITLE
actions: Drop Directory object

### DIFF
--- a/ranger/container/directory.py
+++ b/ranger/container/directory.py
@@ -203,6 +203,9 @@ class Directory(  # pylint: disable=too-many-instance-attributes,too-many-public
             return Vcs(self)
         return None
 
+    def clear_signal_handlers(self):
+        self._signal_functions = None
+
     def signal_function_factory(self, function):
         def signal_function():
             self.load_if_outdated()

--- a/ranger/core/actions.py
+++ b/ranger/core/actions.py
@@ -1665,6 +1665,9 @@ class Actions(  # pylint: disable=too-many-instance-attributes,too-many-public-m
             if isdir(path) and not os.path.islink(path):
                 try:
                     shutil.rmtree(path)
+                    if path in self.fm.directories:
+                        self.fm.directories[path].clear_signal_handlers()
+                        del self.fm.directories[path]
                 except OSError as err:
                     self.notify(err)
             else:


### PR DESCRIPTION
Additionally erase its signal handlers. Since those were registered as weak references, this should also clear the associated bound signals.

Fixes #1613