### PR TITLE
Add shell command filter to filter_stack

### DIFF
--- a/doc/ranger.1
+++ b/doc/ranger.1
@@ -742,6 +742,9 @@ Apply a new mimetype filter.
 .IP .n 14
 .IX Item ".n"
 Apply a new filename filter.
+.IP .C 14
+.IX Item ".C"
+Apply a new shell command filter.
 .IP .# 14
 Apply a new hash filter.
 .IP ".""" 14
@@ -1433,6 +1436,20 @@ Filter files so only files with the same hash as PATH are shown.
 .IP "mimetype TYPE" 2
 .IX Item "mimetype TYPE"
 Filter files of a certain MIME type, regular expression syntax is allowed.
+.IP "command COMMAND" 2
+.IX Item "command COMMAND"
+Filter files by given shell command (no safety checks!). Only supports simple
+shell commands invoked with the path of each of the files being filtered. The
+filter matches files for which the command returns an exit status of 0. This is
+useful with grep, f.e.
+.Sp
+.Vb 1
+\&  :filter_stack add command grep \-I STRING
+.Ve
+.Sp
+to show all non-binary (\-I) files that match the given string. There's a
+timeout of 10 seconds per call to prevent hanging, so avoid commands with long
+run-times.
 .IP "typefilter [d|f|l]" 2
 .IX Item "typefilter [d|f|l]"
 Filter files of a certain type, \f(CW\*(C`d\*(C'\fR for directories, \f(CW\*(C`f\*(C'\fR for files and \f(CW\*(C`l\*(C'\fR

--- a/doc/ranger.pod
+++ b/doc/ranger.pod
@@ -828,6 +828,10 @@ Apply a new mimetype filter.
 
 Apply a new filename filter.
 
+=item .C
+
+Apply a new shell command filter.
+
 =item .#
 
 Apply a new hash filter.
@@ -1639,6 +1643,19 @@ Filter files so only files with the same hash as PATH are shown.
 =item mimetype TYPE
 
 Filter files of a certain MIME type, regular expression syntax is allowed.
+
+=item command COMMAND
+
+Filter files by given shell command (no safety checks!). Only supports simple
+shell commands invoked with the path of each of the files being filtered. The
+filter matches files for which the command returns an exit status of 0. This is
+useful with grep, f.e.
+
+  :filter_stack add command grep -I STRING
+
+to show all non-binary (-I) files that match the given string. There's a
+timeout of 10 seconds per call to prevent hanging, so avoid commands with long
+run-times.
 
 =item typefilter [d|f|l]
 

--- a/ranger/config/rc.conf
+++ b/ranger/config/rc.conf
@@ -633,6 +633,7 @@ map .f filter_stack add type f
 map .l filter_stack add type l
 map .m console filter_stack add mime%space
 map .n console filter_stack add name%space
+map .C console filter_stack add command grep -I%space
 map .# console filter_stack add hash%space
 map ." filter_stack add duplicate
 map .' filter_stack add unique

--- a/ranger/core/filter_stack.py
+++ b/ranger/core/filter_stack.py
@@ -13,9 +13,12 @@ except ImportError:
     from itertools import zip_longest
 # pylint: enable=invalid-name
 from os.path import abspath
+from subprocess import call, TimeoutExpired
 
 from ranger.core.shared import FileManagerAware
+from ranger.ext.cached_function import cached_function
 from ranger.ext.hash import hash_chunks
+from ranger.ext.popen23 import DEVNULL
 
 # pylint: disable=too-few-public-methods
 
@@ -89,6 +92,24 @@ class MimeFilter(BaseFilter, FileManagerAware):
 
     def __str__(self):
         return "<Filter: mimetype =~ /{pat}/>".format(pat=self.regex.pattern)
+
+
+@stack_filter("command")
+class CommandFilter(BaseFilter, FileManagerAware):
+    def __init__(self, command):
+        self.command = command
+
+    @cached_function
+    def __call__(self, fobj):
+        try:
+            return call([self.command + " " + fobj.path],
+                        shell=True, timeout=10,
+                        stdout=DEVNULL, stderr=DEVNULL) == 0
+        except (OSError, TimeoutExpired):
+            return False
+
+    def __str__(self):
+        return "<Filter: command '{cmd}'>".format(cmd=self.command)
 
 
 @stack_filter("hash")


### PR DESCRIPTION
Works nicely with grep, comments welcome.

I was about to take out the timeout again but wanted to get someone else's
perspective on it. A `-t` parameter would be nice, but replicating
`ranger.api.commands.parse_flags()` seems over the top for this, so I tend
towards removing the timeout again. Similar thing about the caching, it does
work but cached entries are bound to the specific filter instance and never
cleared, so not sure about that either.
