### PR TITLE
tags: Snapshot items before mutating in update_path (fixes #3176)

### DIFF
--- a/ranger/container/tags.py
+++ b/ranger/container/tags.py
@@ -116,7 +116,13 @@ class Tags(FileManagerAware):
     def update_path(self, path_old, path_new):
         self.sync()
         changed = False
-        for path, tag in self.tags.items():
+        # Iterate over a snapshot of the items because the loop body mutates
+        # ``self.tags`` (deletes the old key, inserts the new one).  Iterating
+        # ``self.tags.items()`` directly raises
+        # ``RuntimeError: dictionary keys changed during iteration`` on
+        # Python 3, which would abort the update before ``dump()`` runs and
+        # leave the renamed path silently un-tagged on disk.
+        for path, tag in list(self.tags.items()):
             pnew = None
             if path == path_old:
                 pnew = path_new

--- a/tests/ranger/container/test_tags.py
+++ b/tests/ranger/container/test_tags.py
@@ -1,0 +1,99 @@
+from __future__ import (absolute_import, division, print_function)
+
+import os
+import pytest
+
+from ranger.container.tags import Tags
+from ranger.core.shared import FileManagerAware
+
+
+class _StubFM(object):  # pylint: disable=too-few-public-methods
+    """Minimal ``fm`` substitute for ``Tags`` -- only ``notify`` is exercised."""
+
+    def notify(self, *args, **kwargs):
+        pass
+
+
+@pytest.fixture(autouse=True)
+def _fm_stub():
+    # ``Tags`` inherits from ``FileManagerAware`` and calls ``self.fm.notify``
+    # from its IO helpers; install a no-op stub for the duration of each test.
+    previous_fm = getattr(FileManagerAware, "fm", None)
+    FileManagerAware.fm_set(_StubFM())
+    yield
+    if previous_fm is None:
+        try:
+            del FileManagerAware.fm
+        except AttributeError:
+            pass
+    else:
+        FileManagerAware.fm_set(previous_fm)
+
+
+def _write_tagfile(tmpdir, lines):
+    tagfile = tmpdir.join("tagged")
+    tagfile.write_text("".join(line + "\n" for line in lines), encoding="utf-8")
+    return str(tagfile)
+
+
+def test_update_path_renames_single_tag(tmpdir):
+    # Regression test for issue #3176: renaming a tagged file used to raise
+    # ``RuntimeError: dictionary keys changed during iteration`` because
+    # ``update_path`` mutated ``self.tags`` while iterating over it, which
+    # also meant the rename was never persisted to disk.
+    tagfile = _write_tagfile(tmpdir, ["/tmp/abcd"])
+    tags = Tags(tagfile)
+
+    tags.update_path("/tmp/abcd", "/tmp/efgh")
+
+    assert tags.tags == {"/tmp/efgh": "*"}
+    # The new path must also be persisted, otherwise the tag is silently
+    # forgotten the next time ranger re-reads the tag file.
+    with open(tagfile, encoding="utf-8") as fobj:
+        assert fobj.read() == "/tmp/efgh\n"
+
+
+def test_update_path_renames_directory_prefix(tmpdir):
+    # Renaming a directory should rewrite every tagged path that lives under
+    # it while leaving unrelated paths alone, and should preserve custom tag
+    # characters.
+    tagfile = _write_tagfile(tmpdir, [
+        "/tmp/foo/file1",
+        "a:/tmp/foo/file2",
+        "/tmp/bar/file3",
+        "b:/tmp/foo/sub/file4",
+    ])
+    tags = Tags(tagfile)
+
+    tags.update_path("/tmp/foo", "/new/foo")
+
+    assert tags.tags == {
+        "/new/foo/file1": "*",
+        "/new/foo/file2": "a",
+        "/tmp/bar/file3": "*",
+        "/new/foo/sub/file4": "b",
+    }
+
+
+def test_update_path_noop_does_not_rewrite_file(tmpdir):
+    # If nothing matches, the tag file should not be rewritten -- the
+    # ``changed`` flag is what gates ``dump()``.
+    tagfile = _write_tagfile(tmpdir, ["/tmp/abcd"])
+    tags = Tags(tagfile)
+    original_mtime = os.path.getmtime(tagfile)
+
+    tags.update_path("/nowhere", "/elsewhere")
+
+    assert tags.tags == {"/tmp/abcd": "*"}
+    assert os.path.getmtime(tagfile) == original_mtime
+
+
+def test_update_path_does_not_rename_partial_prefix_match(tmpdir):
+    # ``/tmp/foo`` must not match ``/tmp/foobar`` -- the separator boundary
+    # check exists for exactly this reason and we want a test that pins it.
+    tagfile = _write_tagfile(tmpdir, ["/tmp/foobar/file"])
+    tags = Tags(tagfile)
+
+    tags.update_path("/tmp/foo", "/new/foo")
+
+    assert tags.tags == {"/tmp/foobar/file": "*"}


### PR DESCRIPTION
<!-- Provide a descriptive summary of the changes in the title above -->

#### ISSUE TYPE
- Bug fix

#### RUNTIME ENVIRONMENT
- Operating system and version: macOS 15 (also reproduces on Linux)
- Terminal emulator and version: any
- Python version: 3.13 (and any Python 3.6+)
- Ranger version/commit: master at 057c8799
- Locale: en_US.UTF-8

#### CHECKLIST
- [x] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [x] All changes follow the code style **[REQUIRED]**
- [x] All new and existing tests pass **[REQUIRED]**
- [ ] Changes require config files to be updated
    - [ ] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [x] Changes require tests to be updated
    - [x] Tests have been updated

#### DESCRIPTION
`Tags.update_path` walked `self.tags.items()` while deleting the old key and inserting the renamed one inside the same loop. On Python 3 the dict iterator raises `RuntimeError: dictionary keys changed during iteration` as soon as the first key is rewritten, which means the function exits early — before `dump()` — so the tag is silently lost from the on-disk tag file even though the in-memory rename appears to succeed in the UI.

Snapshotting the items with `list(self.tags.items())` before the loop lets the body mutate the dict safely while still doing only one disk write at the end.

A new `tests/ranger/container/test_tags.py` covers:

- A single tagged file being renamed (the original `RuntimeError` repro) — asserts the new path is both in memory and persisted to the tag file.
- A directory-prefix rename with multiple tagged children, mixing the default `*` tag and custom tag characters (`a:`, `b:`).
- The no-op path: when nothing matches, the tag file's mtime is left untouched so we don't churn disk.
- The separator boundary check: `/tmp/foo` must not match `/tmp/foobar`.

#### MOTIVATION AND CONTEXT
Fixes #3176. Quoting the reporter's steps:

> 1. `:touch abcd`.
> 2. Tag the file: `:tag_add`.  The file is shown to be tagged.
> 3. Rename the file: `:rename efgh`.
> 4. The file is renamed, and shown to be tagged.  An error appears in red: `RuntimeError: dictionary keys changed during iteration`.
> 5. Reset: `:reset` or quit and restart ranger.  It appears the file `efgh` is not tagged (but `abcd` is still recorded as tagged in `share/ranger/tagged`).

`update_path` is called from the `rename` command in `ranger/config/commands.py` right after `fm.rename(...)`, so any tagged path goes through this code path.

The reporter also identified the exact line and proposed wrapping the iteration in `list(...)`; this PR does that and pins the behavior with tests so the regression cannot silently come back.

#### TESTING
- `make test_pytest` — 19 passed (4 new tests in `test_tags.py`, all existing tests still green).
- `make test_flake8` — clean on the two touched files.
- `make test_pylint` — `tags.py` and `test_tags.py` both rated 10.00/10.
- Reverting just the one-line fix while keeping the tests confirms the two interesting tests fail (`RuntimeError` on the single-file rename, partial mutation on the directory-prefix rename), so the regression coverage is real.

#### IMAGES / VIDEOS
N/A — pure behavior fix.
