### PR TITLE
docs: document bulkrename flags

### DIFF
--- a/doc/ranger.1
+++ b/doc/ranger.1
@@ -1220,7 +1220,7 @@ ranger.  For your convenience, this is a list of the "public" commands including
 .PP
 .Vb 10
 \& alias [newcommand] [oldcommand]
-\& bulkrename
+\& bulkrename [\-FLAGS...]
 \& cd [path]
 \& chain command1[; command2[; command3...]]
 \& chmod octal_number
@@ -1292,14 +1292,18 @@ These are the public commands including their descriptions:
 .IP "alias [\fInewcommand\fR] [\fIoldcommand\fR]" 2
 .IX Item "alias [newcommand] [oldcommand]"
 Copies the oldcommand as newcommand.
-.IP bulkrename 2
-.IX Item "bulkrename"
+.IP "bulkrename [\-\fIflags\fR]" 2
+.IX Item "bulkrename [-flags]"
 This command opens a list of selected files in an external editor.  After you
 edit and save the file, it will generate a shell script which does bulk
 renaming according to the changes you did in the file.
 .Sp
 This shell script is opened in an editor for you to review.  After you close
 it, it will be executed.
+.Sp
+Optional flags may be supplied to control how the generated shell script is
+executed.  See the FLAGS section for details.  By default, the \f(CW\*(C`w\*(C'\fR flag is
+used.
 .IP "cd [\fIpath\fR]" 2
 .IX Item "cd [path]"
 The cd command changes the directory.  If path is a file, selects that file.

--- a/doc/ranger.pod
+++ b/doc/ranger.pod
@@ -1484,7 +1484,7 @@ These are the public commands including their descriptions:
 
 Copies the oldcommand as newcommand.
 
-=item bulkrename
+=item bulkrename [-I<flags>]
 
 This command opens a list of selected files in an external editor.  After you
 edit and save the file, it will generate a shell script which does bulk
@@ -1492,6 +1492,10 @@ renaming according to the changes you did in the file.
 
 This shell script is opened in an editor for you to review.  After you close
 it, it will be executed.
+
+Optional flags may be supplied to control how the generated shell script is
+executed.  See the FLAGS section for details.  By default, the C<w> flag is
+used.
 
 =item cd [I<path>]
 

--- a/doc/ranger.pod
+++ b/doc/ranger.pod
@@ -1409,7 +1409,7 @@ You can always get a list of the currently existing commands by typing "?c" in
 ranger.  For your convenience, this is a list of the "public" commands including their parameters, excluding descriptions:
 
  alias [newcommand] [oldcommand]
- bulkrename
+ bulkrename [-FLAGS...]
  cd [path]
  chain command1[; command2[; command3...]]
  chmod octal_number

--- a/ranger/config/commands.py
+++ b/ranger/config/commands.py
@@ -1228,7 +1228,7 @@ class chmod(Command):
 
 
 class bulkrename(Command):
-    """:bulkrename
+    """:bulkrename [-FLAGS...]
 
     This command opens a list of selected files in an external editor.
     After you edit and save the file, it will generate a shell script


### PR DESCRIPTION
#### ISSUE TYPE

* Improvement/feature implementation

#### RUNTIME ENVIRONMENT

* Operating system and version: Windows 11
* Terminal emulator and version: Command Prompt
* Python version: N/A
* Ranger version/commit: Current main branch
* Locale: en_CA.UTF-8

#### CHECKLIST

* [x] The `CONTRIBUTING` document has been read **[REQUIRED]**
* [x] All changes follow the code style **[REQUIRED]**
* [ ] All new and existing tests pass **[REQUIRED]**
* [ ] Changes require config files to be updated
* [x] Changes require documentation to be updated

  * [x] Documentation has been updated
* [ ] Changes require tests to be updated

#### DESCRIPTION

Document that `:bulkrename` accepts runner flags and indicate that the default flag is `w`.

#### MOTIVATION AND CONTEXT

Closes #3211

The available runner flags are documented in the FLAGS section, but the `bulkrename` command documentation did not indicate that flags could be supplied. This change makes that behavior discoverable.

#### TESTING

Reviewed the implementation of `bulkrename`, `parse_flags()`, and the runner flag handling to verify that the command accepts runner flags and defaults to the `w` flag.
