### PR TITLE
fix: encode directory paths in hash_chunks (#2168)

### DIFF
--- a/ranger/ext/hash.py
+++ b/ranger/ext/hash.py
@@ -4,7 +4,7 @@
 from __future__ import (absolute_import, division, print_function)
 
 from os import listdir
-from os.path import getsize, isdir
+from os.path import getsize, isdir, join
 from hashlib import sha256
 
 # pylint: disable=invalid-name
@@ -14,10 +14,10 @@ def hash_chunks(filepath, h=None):
     if not h:
         h = sha256()
     if isdir(filepath):
-        h.update(filepath)
+        h.update(filepath.encode())
         yield h.hexdigest()
         for fp in listdir(filepath):
-            for fp_chunk in hash_chunks(fp, h=h):
+            for fp_chunk in hash_chunks(join(filepath, fp), h=h):
                 yield fp_chunk
     elif getsize(filepath) == 0:
         yield h.hexdigest()

--- a/tests/ranger/test_hash.py
+++ b/tests/ranger/test_hash.py
@@ -1,0 +1,22 @@
+from __future__ import (absolute_import, division, print_function)
+
+from ranger.ext.hash import hash_chunks
+
+
+def test_hash_chunks_accepts_directory_paths(tmp_path):
+    directory = tmp_path / "directory"
+    directory.mkdir()
+
+    hashes = list(hash_chunks(str(directory)))
+
+    assert len(hashes) == 1
+
+
+def test_hash_chunks_recurses_with_full_child_paths(tmp_path):
+    directory = tmp_path / "directory"
+    directory.mkdir()
+    (directory / "child.txt").write_text("content", encoding="utf-8")
+
+    hashes = list(hash_chunks(str(directory)))
+
+    assert len(hashes) >= 2


### PR DESCRIPTION
#### ISSUE TYPE
- Bug fix

#### RUNTIME ENVIRONMENT
- Operating system and version: Linux 6.17.0-PRoot-Distro
- Terminal emulator and version: n/a
- Python version: 3.12.3
- Ranger version/commit: master tarball
- Locale: C.UTF-8

#### CHECKLIST
- [X] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [X] All changes follow the code style **[REQUIRED]**
- [X] All new and existing tests pass **[REQUIRED]**
- [ ] Changes require config files to be updated
    - [ ] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [X] Changes require tests to be updated
    - [X] Tests have been updated

#### DESCRIPTION
Fix `hash_chunks()` so it can hash directories on Python 3.

The duplicate filter eventually hashes directory paths through `ranger.ext.hash.hash_chunks()`. For directory inputs, the function passed a `str` directly to `hashlib.update()`, which raises `TypeError: Strings must be encoded before hashing` on Python 3.

This PR encodes directory paths before hashing them, and also recurses into children using their full joined path instead of only the child basename.

#### MOTIVATION AND CONTEXT
Closes #2168.

The current directory branch in `hash_chunks()` is unusable on Python 3 because `hashlib.update()` requires bytes. The reporter also noted that encoding the path fixes the immediate crash.

#### TESTING
Ran:

```text
python3 -m pytest -q tests/ranger/test_hash.py tests/ranger/container/test_container.py
```

Result:

```text
4 passed in 0.31s
```

Also reproduced the original failure before the fix with:

```python
list(hash_chunks('/tmp/some-directory'))
```

which raised `TypeError: Strings must be encoded before hashing`.

#### IMAGES / VIDEOS
Not applicable.
