### PR TITLE
Default to case insensitive filter_stack name filter

### DIFF
--- a/ranger/config/rc.conf
+++ b/ranger/config/rc.conf
@@ -631,7 +631,7 @@ map .d filter_stack add type d
 map .f filter_stack add type f
 map .l filter_stack add type l
 map .m console filter_stack add mime%space
-map .n console filter_stack add name%space
+map .n console filter_stack add name (?i)
 map .# console filter_stack add hash%space
 map ." filter_stack add duplicate
 map .' filter_stack add unique


### PR DESCRIPTION
Resolves #3242

This only changes the default prompt as defined in the shipped rc.conf. As demonstrated by the issue reporter, the underlying mechanism already supports passing arbitrary arguments supported by the `re` module thanks to its inline flags. I'd rather avoid inventing our own syntax for that instead.

If the user want a case insensitive search, explicitly removing the inline flag is still possible. The flag getting auto-inserted might be confusing but at the same time it improves the discoverability of this feature as a whole, so YMMV.