### PR TITLE
Fix startup crash when screen executable is unavailable

### DIFF
--- a/ranger/gui/ui.py
+++ b/ranger/gui/ui.py
@@ -510,7 +510,7 @@ class UI(  # pylint: disable=too-many-instance-attributes,too-many-public-method
                     # gives out a warning if $TERM is not "screen"
                     self._multiplexer_title = check_output(
                         ['screen', '-Q', 'title']).strip()
-            except CalledProcessError:
+            except (CalledProcessError, OSError):
                 self.fm.notify("Couldn't access previous multiplexer window"
                                " name, won't be able to restore.",
                                bad=False)

--- a/tests/ranger/gui/test_ui.py
+++ b/tests/ranger/gui/test_ui.py
@@ -1,0 +1,38 @@
+from __future__ import absolute_import
+
+from ranger.gui import ui
+
+
+class Settings(object):
+    update_tmux_title = True
+
+
+class FileManager(object):
+    def __init__(self):
+        self.notifications = []
+
+    def notify(self, message, bad=False):
+        self.notifications.append((message, bad))
+
+
+def test_handle_multiplexer_missing_screen_executable(monkeypatch):
+    monkeypatch.setattr(ui, '_in_tmux', lambda: False)
+    monkeypatch.setattr(ui, '_in_screen', lambda: True)
+
+    def missing_screen(*args, **kwargs):
+        raise OSError(2, 'No such file or directory')
+
+    monkeypatch.setattr(ui, 'check_output', missing_screen)
+
+    file_manager = FileManager()
+    user_interface = ui.UI(fm=file_manager)
+    user_interface.settings = Settings()
+
+    user_interface.handle_multiplexer()
+
+    assert user_interface._multiplexer_title
+    assert file_manager.notifications == [(
+        "Couldn't access previous multiplexer window name, "
+        "won't be able to restore.",
+        False,
+    )]

--- a/tests/ranger/gui/test_ui.py
+++ b/tests/ranger/gui/test_ui.py
@@ -3,11 +3,11 @@ from __future__ import absolute_import
 from ranger.gui import ui
 
 
-class Settings(object):
+class Settings(object):  # pylint: disable=too-few-public-methods
     update_tmux_title = True
 
 
-class FileManager(object):
+class FileManager(object):  # pylint: disable=too-few-public-methods
     def __init__(self):
         self.notifications = []
 
@@ -30,7 +30,6 @@ def test_handle_multiplexer_missing_screen_executable(monkeypatch):
 
     user_interface.handle_multiplexer()
 
-    assert user_interface._multiplexer_title
     assert file_manager.notifications == [(
         "Couldn't access previous multiplexer window name, "
         "won't be able to restore.",


### PR DESCRIPTION
#### ISSUE TYPE
- Bug fix

#### RUNTIME ENVIRONMENT
- Operating system and version: macOS 26.5 (isolated regression test for the OpenBSD failure path)
- Terminal emulator and version: N/A
- Python version: 3.9.6
- Ranger version/commit: `4831012`
- Locale: `C.UTF-8`

#### CHECKLIST
- [x] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [x] All changes follow the code style **[REQUIRED]**
- [x] All new and existing tests pass **[REQUIRED]**
- [ ] Changes require config files to be updated
    - [ ] Config files have been updated
- [ ] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [x] Changes require tests to be updated
    - [x] Tests have been updated

#### DESCRIPTION

Catch OS-level launch failures while ranger queries GNU Screen. Ranger now uses its existing fallback title instead of crashing during startup.

#### MOTIVATION AND CONTEXT

On OpenBSD, a stale or unavailable `screen` executable can raise `FileNotFoundError` after the multiplexer check. Closes #3250.

#### TESTING

`pytest -q tests`: 24 passed. Flake8 passed on both changed files. The focused regression fails with `FileNotFoundError` without the source change and passes with it.

#### IMAGES / VIDEOS

N/A
