### PR TITLE
Renumber tabs (feature, #2041)

### DIFF
--- a/doc/ranger.1
+++ b/doc/ranger.1
@@ -1081,6 +1081,9 @@ the content.
 .IX Item "relative_current_zero [bool]"
 When line_numbers is set to relative, show 0 on the current line if
 true or show the absolute number of the current line when false.
+.IP "renumber_tabs_on_tab_close [bool]" 4
+.IX Item "renumber_tabs_on_tab_close [bool]"
+After closing a tab the tabs will automatically renumber if true.
 .IP "save_backtick_bookmark [bool]" 4
 .IX Item "save_backtick_bookmark [bool]"
 Save the \f(CW\*(C`\`\*(C'\fR bookmark to disk.  This bookmark is used to switch to the last

--- a/doc/ranger.1
+++ b/doc/ranger.1
@@ -1082,6 +1082,9 @@ the content.
 .IX Item "relative_current_zero [bool]"
 When line_numbers is set to relative, show 0 on the current line if
 true or show the absolute number of the current line when false.
+.IP "renumber_tabs_on_tab_close [bool]" 4
+.IX Item "renumber_tabs_on_tab_close [bool]"
+After closing a tab the tabs will automatically renumber if true.
 .IP "save_backtick_bookmark [bool]" 4
 .IX Item "save_backtick_bookmark [bool]"
 Save the \f(CW\*(C`\`\*(C'\fR bookmark to disk.  This bookmark is used to switch to the last

--- a/doc/ranger.pod
+++ b/doc/ranger.pod
@@ -1241,6 +1241,10 @@ the content.
 When line_numbers is set to relative, show 0 on the current line if
 true or show the absolute number of the current line when false.
 
+=item renumber_tabs_on_tab_close [bool]
+
+After closing a tab the tabs will automatically renumber if true.
+
 =item save_backtick_bookmark [bool]
 
 Save the C<`> bookmark to disk.  This bookmark is used to switch to the last

--- a/doc/ranger.pod
+++ b/doc/ranger.pod
@@ -1242,6 +1242,10 @@ the content.
 When line_numbers is set to relative, show 0 on the current line if
 true or show the absolute number of the current line when false.
 
+=item renumber_tabs_on_tab_close [bool]
+
+After closing a tab the tabs will automatically renumber if true.
+
 =item save_backtick_bookmark [bool]
 
 Save the C<`> bookmark to disk.  This bookmark is used to switch to the last

--- a/ranger/config/rc.conf
+++ b/ranger/config/rc.conf
@@ -309,6 +309,9 @@ set one_indexed false
 # Save tabs on exit
 set save_tabs_on_exit false
 
+# Automatically renumber tabs on tab close
+set renumber_tabs_on_tab_close false
+
 # Remove tabs with unavailable paths on startup
 set filter_dead_tabs_on_startup false
 

--- a/ranger/config/rc.conf
+++ b/ranger/config/rc.conf
@@ -311,6 +311,9 @@ set one_indexed false
 # Save tabs on exit
 set save_tabs_on_exit false
 
+# Automatically renumber tabs on tab close
+set renumber_tabs_on_tab_close false
+
 # Remove tabs with unavailable paths on startup
 set filter_dead_tabs_on_startup false
 

--- a/ranger/container/settings.py
+++ b/ranger/container/settings.py
@@ -71,6 +71,7 @@ ALLOWED_SETTINGS = {
     'preview_max_size': int,
     'preview_script': (str, type(None)),
     'relative_current_zero': bool,
+    'renumber_tabs_on_tab_close': bool,
     'save_backtick_bookmark': bool,
     'save_console_history': bool,
     'save_tabs_on_exit': bool,

--- a/ranger/core/actions.py
+++ b/ranger/core/actions.py
@@ -1287,10 +1287,38 @@ class Actions(  # pylint: disable=too-many-instance-attributes,too-many-public-m
         if name in self.tabs:
             del self.tabs[name]
         self.restorable_tabs.append(tab)
+        self._try_tabs_renumber_handler(emit=False)
         self.signal_emit('tab.layoutchange')
 
     def tabclose(self, *args, **kwargs):
         return self.tab_close(*args, **kwargs)
+
+    def _do_tabs_renumber(self, emit=True):
+        tab_indices = sorted(self.fm.tabs.keys())
+        new_tabs = dict((name, self.fm.tabs[tab]) for name, tab in enumerate(tab_indices, 1))
+        if new_tabs.keys() != tab_indices:
+            current_tab_index_renumbered = tab_indices.index(self.fm.current_tab) + 1
+            self.tabs = new_tabs
+            self.current_tab = current_tab_index_renumbered
+            self.ui.titlebar.request_redraw()
+            if emit:
+                self.signal_emit('tab.layoutchange')
+
+    def _try_tabs_renumber_handler(self, *args, **kwargs):
+        force = kwargs.pop('force', False)
+        if force:
+            # for the alias (force) command renumber_tabs
+            self._do_tabs_renumber(emit=True, *args, **kwargs)
+        elif self.settings.renumber_tabs_on_tab_close:
+            self._do_tabs_renumber(*args, **kwargs)
+
+    def renumber_tabs(self, *args, **kwargs):
+        """:renumber_tabs
+
+        (Force) One-time renumbering of the tabs (like renumber-windows with tmux).
+        Useful manual override if renumber_tabs_on_tab_close is set to False.
+        """
+        self._try_tabs_renumber_handler(force=True, *args, **kwargs)
 
     def tab_restore(self):
         # NOTE: The name of the tab is not restored.

--- a/ranger/core/actions.py
+++ b/ranger/core/actions.py
@@ -1289,10 +1289,38 @@ class Actions(  # pylint: disable=too-many-instance-attributes,too-many-public-m
         if name in self.tabs:
             del self.tabs[name]
         self.restorable_tabs.append(tab)
+        self._try_tabs_renumber_handler(emit=False)
         self.signal_emit('tab.layoutchange')
 
     def tabclose(self, *args, **kwargs):
         return self.tab_close(*args, **kwargs)
+
+    def _do_tabs_renumber(self, emit=True):
+        tab_indices = sorted(self.fm.tabs.keys())
+        new_tabs = dict((name, self.fm.tabs[tab]) for name, tab in enumerate(tab_indices, 1))
+        if new_tabs.keys() != tab_indices:
+            current_tab_index_renumbered = tab_indices.index(self.fm.current_tab) + 1
+            self.tabs = new_tabs
+            self.current_tab = current_tab_index_renumbered
+            self.ui.titlebar.request_redraw()
+            if emit:
+                self.signal_emit('tab.layoutchange')
+
+    def _try_tabs_renumber_handler(self, *args, **kwargs):
+        force = kwargs.pop('force', False)
+        if force:
+            # for the alias (force) command renumber_tabs
+            self._do_tabs_renumber(emit=True, *args, **kwargs)
+        elif self.settings.renumber_tabs_on_tab_close:
+            self._do_tabs_renumber(*args, **kwargs)
+
+    def renumber_tabs(self, *args, **kwargs):
+        """:renumber_tabs
+
+        (Force) One-time renumbering of the tabs (like renumber-windows with tmux).
+        Useful manual override if renumber_tabs_on_tab_close is set to False.
+        """
+        self._try_tabs_renumber_handler(force=True, *args, **kwargs)
 
     def tab_restore(self):
         # NOTE: The name of the tab is not restored.


### PR DESCRIPTION
Manual command renumber_tabs (skips setting), and auto renumber tabs on tab close conditional on rc.conf setting.

#### ISSUE TYPE
- Improvement/feature implementation

#### RUNTIME ENVIRONMENT
Ubuntu 24.04.4 LTS
GNOME Terminal 3.52.0 using VTE 0.76.0 +BIDI +GNUTLS +ICU +SYSTEMD
ranger version: ranger-master v1.9.3-947-g26a25793
Python version: 3.12.2 | packaged by conda-forge | (main, Feb 16 2024, 20:50:58) [GCC 12.3.0]
Locale: en_US.UTF-8

#### CHECKLIST
- [X] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [X] The code was not generated by an LLM **[REQUIRED]**
- [X] All changes follow the code style **[REQUIRED]**
- [X] All new and existing tests pass **[REQUIRED]**
- [X] Changes require config files to be updated
    - [X] Config files have been updated
- [X] Changes require documentation to be updated
    - [X] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
Added renumber_tabs_on_tab_close setting:
    - default is False
    - added it also to relevant docs Added renumber_tabs() to actions.py (helper):
    - forces renumbering of tabs irrespective of setting Added tabsrenumber() to actions.py (helper handler):
    - tab_close() in actions.py (checking the config)
    - renumber_tabs() in actions.py (calling it with force=True) Added tabs_renumber() to actions.py (actual execution of renumbering the tabs).
    - enumerates tabs starting from 1
    - only actually changes the dict and (conditionally) emits a layout_change if the numbering changes
    - conditionally emits the layout_change if emit=True (emit=False when called from tabs_close) Modified tabs_close():
    - Added call to tabsrenumber(), making sure emit=False, so 'layoutchange' is only emitted once

#### MOTIVATION AND CONTEXT
Tab numbers become irregular when closing tabs, and opening new tabs opens them in irregular places as a result.
Discussed already and addresses issue #2041:
[Renumber tabs (like tmux config 'renumber-windows')](https://github.com/ranger/ranger/issues/2041)

#### TESTING
Tested implemented features in multiplane and miller (automatic and manual command).
Tested it loaded with rc.conf variable set to true.
Appears to work fine.
Shouldn't affect anything else in the code base other than tab_close (as intended).