### PR TITLE
Support for JSON files without '.json' extension

### DIFF
--- a/ranger/config/rifle.conf
+++ b/ranger/config/rifle.conf
@@ -89,6 +89,7 @@ mime ^text,  label editor = ${VISUAL:-$EDITOR} -- "$@"
 mime ^text,  label pager  = $PAGER -- "$@"
 !mime ^text, label editor, ext xml|json|ya?ml|toml|conf|cfg|ini|env|csv|tex|py|pl|rb|rs|js|sh|php|dart|nim|patch = ${VISUAL:-$EDITOR} -- "$@"
 !mime ^text, label pager,  ext xml|json|ya?ml|toml|conf|cfg|ini|env|csv|tex|py|pl|rb|rs|js|sh|php|dart|nim|patch = $PAGER -- "$@"
+mime application/json,  label editor = ${VISUAL:-$EDITOR} -- "$@"
 
 ext 1                         = man "$1"
 ext s[wmf]c, has zsnes, X     = zsnes "$1"

--- a/ranger/data/scope.sh
+++ b/ranger/data/scope.sh
@@ -454,6 +454,12 @@ handle_mime() {
             exiftool "${FILE_PATH}" && exit 5
             exit 1;;
 
+        ## JSON
+        application/json)
+            jq --color-output . "${FILE_PATH}" && exit 5
+            python -m json.tool -- "${FILE_PATH}" && exit 5
+            ;;
+
         ## ELF files (executables and shared objects)
         application/x-executable | application/x-pie-executable | application/x-sharedlib)
             readelf -WCa "${FILE_PATH}" && exit 5


### PR DESCRIPTION

<!-- Provide a descriptive summary of the changes in the title above -->

#### ISSUE TYPE
<!-- Pick relevant types and delete the rest -->
- Improvement

#### RUNTIME ENVIRONMENT
<!-- Details of your runtime environment -->
<!-- Retrieve Python/ranger version and locale with `ranger -\-version` -->
- Operating system and version: `Arch Linux`
- Terminal emulator and version: `alacritty 0.17.0 (94e7c887)`
- Python version: `Python 3.14.6`
- Ranger version/commit: `00650d33`
- Locale: `de_DE.UTF-8`

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [X] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [X] The code was not generated by an LLM **[REQUIRED]**
- [X] All changes follow the code style **[REQUIRED]**
- [X] All new and existing tests pass **[REQUIRED]**

#### DESCRIPTION
<!-- Describe the changes in detail -->
Files for example `sha256-f0988ff50a2458c598ff6b1b87b94d0f5c44d73061c2795391878b00b2285e11` with mime `application/json` didn't show preview and not opened in editor.