### PR TITLE
Warn about `:console [...] %s [...]` commands

### DIFF
--- a/doc/ranger.pod
+++ b/doc/ranger.pod
@@ -472,6 +472,9 @@ Note that macros are expanded twice when using chain. For example, to insert
 a space character in a chained command, you would write %%space:
  chain command1; command2%%space
 
+The macro %nowarn anywhere in the command will silence warnings about dangerous
+commands and key bindings.
+
 =head2 BOOKMARKS
 
 Type B<m<keyE<gt>> to bookmark the current directory. You can re-enter this

--- a/ranger/core/actions.py
+++ b/ranger/core/actions.py
@@ -242,11 +242,11 @@ class Actions(  # pylint: disable=too-many-instance-attributes,too-many-public-m
         cmd = cmd_class(string, quantifier=quantifier)
 
         if '%nowarn' not in string and re.search(r'\bconsole .*[^%]%s\b', string):
-            self.notify("WARNING: Your command `" + string + \
-                    "` seems to use the `%s` macro dangerously. "
-                    "`:console` does not escape `%s`, so you should escape it "
-                    "yourself by replacing it with `%%s`. "
-                    "Use %nowarn macro in the command if you know what you're doing.")
+            self.notify("WARNING: Your command `" + string
+                        + "` seems to use the `%s` macro dangerously. "
+                        "`:console` does not escape `%s`, so you should escape it "
+                        "yourself by replacing it with `%%s`. "
+                        "Use %nowarn macro in the command if you know what you're doing.")
 
         if cmd.resolve_macros and _MacroTemplate.delimiter in cmd.line:
             def any_macro(i, char):

--- a/ranger/core/actions.py
+++ b/ranger/core/actions.py
@@ -241,11 +241,12 @@ class Actions(  # pylint: disable=too-many-instance-attributes,too-many-public-m
             return None
         cmd = cmd_class(string, quantifier=quantifier)
 
-        if re.search(r'\bconsole .*[^%]%s\b', string):
+        if '%nowarn' not in string and re.search(r'\bconsole .*[^%]%s\b', string):
             self.notify("WARNING: Your command `" + string + \
                     "` seems to use the `%s` macro dangerously. "
                     "`:console` does not escape `%s`, so you should escape it "
-                    "yourself by replacing it with `%%s`.")
+                    "yourself by replacing it with `%%s`. "
+                    "Use %nowarn macro in the command if you know what you're doing.")
 
         if cmd.resolve_macros and _MacroTemplate.delimiter in cmd.line:
             def any_macro(i, char):
@@ -310,6 +311,7 @@ class Actions(  # pylint: disable=too-many-instance-attributes,too-many-public-m
             macros['confdir'] = self.fm.confpath()
             macros['datadir'] = self.fm.datapath()
         macros['space'] = ' '
+        macros['nowarn'] = ''  # used to suppress warnings about macro usage
 
         macros['f'] = lambda: self.fm.thisfile.relative_path
 

--- a/ranger/core/actions.py
+++ b/ranger/core/actions.py
@@ -241,6 +241,12 @@ class Actions(  # pylint: disable=too-many-instance-attributes,too-many-public-m
             return None
         cmd = cmd_class(string, quantifier=quantifier)
 
+        if re.search(r'\bconsole .*[^%]%s\b', string):
+            self.notify("WARNING: Your command `" + string + \
+                    "` seems to use the `%s` macro dangerously. "
+                    "`:console` does not escape `%s`, so you should escape it "
+                    "yourself by replacing it with `%%s`.")
+
         if cmd.resolve_macros and _MacroTemplate.delimiter in cmd.line:
             def any_macro(i, char):
                 return ('any{0:d}'.format(i), key_to_string(char))


### PR DESCRIPTION
The issue is described in https://github.com/ranger/ranger/issues/3261. This commit also fixes https://github.com/ranger/ranger/issues/3261.

Solution:

1. Add a warning when using commands matching the regex `\bconsole .*[^%]%s\b` with `fm.notify(..., bad=True)`
2. Add the macro `%nowarn` to silence the warning, e.g. in case of false positive warning