### PR TITLE
Add a draw_borders_glyphset setting to choose between ┌┬┐/╭┬╮/┏┳┓/╔╦╗

### DIFF
--- a/doc/ranger.1
+++ b/doc/ranger.1
@@ -929,6 +929,12 @@ Draw borders around or between the columns? Possible values are:
 \& separators     draw only vertical lines between columns
 \& both           both of the above
 .Ve
+.IP "draw_borders_glyphset [string]" 4
+.IX Item "draw_borders_glyphset [string]"
+Define the glyph set used for drawing borders and separators. When unset, this
+defaults to the standard Alternative Character Set (ACS) "─│┌┬┐├┼┤└┴┘". The 11
+Characters must be given in this exact order (chosen for aesthetics): HLINE,
+VLINE, ULCORNER, TTEE, URCORNER, LTEE, PLUS, RTEE, LLCORNER, BTEE, LRCORNER.
 .IP "draw_borders_multipane [string]" 4
 .IX Item "draw_borders_multipane [string]"
 Draw borders around or between the panes. This setting overrides

--- a/doc/ranger.pod
+++ b/doc/ranger.pod
@@ -1069,6 +1069,13 @@ Draw borders around or between the columns? Possible values are:
  separators     draw only vertical lines between columns
  both           both of the above
 
+=item draw_borders_glyphset [string]
+
+Define the glyph set used for drawing borders and separators. When unset, this
+defaults to the standard Alternative Character Set (ACS) "─│┌┬┐├┼┤└┴┘". The 11
+Characters must be given in this exact order (chosen for aesthetics): HLINE,
+VLINE, ULCORNER, TTEE, URCORNER, LTEE, PLUS, RTEE, LLCORNER, BTEE, LRCORNER.
+
 =item draw_borders_multipane [string]
 
 Draw borders around or between the panes. This setting overrides

--- a/ranger/config/rc.conf
+++ b/ranger/config/rc.conf
@@ -185,6 +185,13 @@ set draw_progress_bar_in_status_bar true
 # Both combines the two.
 set draw_borders none
 
+# Override the default ACS (alternate character set) border glyphs?
+# default: ─│┌┬┐├┼┤└┴┘ (transformed from qxlwktnumvj in ACS mode)
+# rounded: ─│╭┬╮├┼┤╰┴╯
+# heavy:   ━┃┏┳┓┣╋┫┗┻┛
+# double:  ═║╔╦╗╠╬╣╚╩╝
+# set draw_borders_glyphset ─│╭┬╮├┼┤╰┴╯
+
 # Display the directory name in tabs?
 set dirname_in_tabs false
 

--- a/ranger/container/settings.py
+++ b/ranger/container/settings.py
@@ -42,6 +42,7 @@ ALLOWED_SETTINGS = {
     "display_free_space_in_status_bar": bool,
     'display_tags_in_all_columns': bool,
     'draw_borders': str,
+    'draw_borders_glyphset': (str, type(None)),
     'draw_borders_multipane': str,
     'draw_progress_bar_in_status_bar': bool,
     'filter_dead_tabs_on_startup': bool,

--- a/ranger/gui/curses_shortcuts.py
+++ b/ranger/gui/curses_shortcuts.py
@@ -25,6 +25,7 @@ class CursesShortcuts(SettingsAware):
     color_at(y, x, wid, *keys) -- sets the color at the given position
     color_reset() -- resets the color to the default
     addstr(*args) -- failsafe version of self.win.addstr(*args)
+    whline/wvline(y, x, ch, n) -- unicode-capable hline/vline
     """
 
     def __init__(self):
@@ -67,6 +68,20 @@ class CursesShortcuts(SettingsAware):
             self.win.addch(*args)
         except (curses.error, TypeError):
             pass
+
+    def whline(self, y, x, ch, n):
+        if isinstance(ch, int):
+            self.win.hline(y, x, ch, n)
+        else:
+            for _x in range(x, x + n):
+                self.addch(y, _x, ch)
+
+    def wvline(self, y, x, ch, n):
+        if isinstance(ch, int):
+            self.win.vline(y, x, ch, n)
+        else:
+            for _y in range(y, y + n):
+                self.addch(_y, x, ch)
 
     def color(self, *keys):
         """Change the colors from now on."""

--- a/ranger/gui/widgets/view_base.py
+++ b/ranger/gui/widgets/view_base.py
@@ -64,6 +64,19 @@ class ViewBase(Widget, DisplayableContainer):  # pylint: disable=too-many-instan
             except curses.error:
                 pass
 
+    def _draw_border_rectangle(self, left_start, right_end):
+        # Draw border lines
+        win.hline(0, left_start, curses.ACS_HLINE, right_end - left_start)
+        win.hline(self.hei - 1, left_start, curses.ACS_HLINE, right_end - left_start)
+        win.vline(1, left_start, curses.ACS_VLINE, self.hei - 2)
+        win.vline(1, right_end, curses.ACS_VLINE, self.hei - 2)
+
+        # Draw corners
+        self.addch(0, left_start, curses.ACS_ULCORNER)
+        self.addch(self.hei - 1, left_start, curses.ACS_LLCORNER)
+        self.addch(0, right_end, curses.ACS_URCORNER)
+        self.addch(self.hei - 1, right_end, curses.ACS_LRCORNER)
+
     def _draw_bookmarks(self):
         self.columns[-1].clear_image(force=True)
         self.fm.bookmarks.update_if_outdated()

--- a/ranger/gui/widgets/view_base.py
+++ b/ranger/gui/widgets/view_base.py
@@ -6,9 +6,44 @@
 from __future__ import (absolute_import, division, print_function)
 
 import curses
+from ranger.container import settings
 from ranger.ext.keybinding_parser import key_to_string
 from . import Widget
 from ..displayable import DisplayableContainer
+
+
+class BorderGlyphset(  # pylint: disable=too-few-public-methods,too-many-instance-attributes
+        object):
+
+    def __init__(  # pylint: disable=invalid-name
+            self, glyphstr):
+        if glyphstr is None or glyphstr == "":
+            # default ACS glyphs: ─│┌┬┐├┼┤└┴┘
+            self.HLINE = curses.ACS_HLINE
+            self.VLINE = curses.ACS_VLINE
+            self.ULCORNER = curses.ACS_ULCORNER
+            self.TTEE = curses.ACS_TTEE
+            self.URCORNER = curses.ACS_URCORNER
+            self.LTEE = curses.ACS_LTEE
+            self.PLUS = curses.ACS_PLUS
+            self.RTEE = curses.ACS_RTEE
+            self.LLCORNER = curses.ACS_LLCORNER
+            self.BTEE = curses.ACS_BTEE
+            self.LRCORNER = curses.ACS_LRCORNER
+        else:
+            (
+                self.HLINE,
+                self.VLINE,
+                self.ULCORNER,
+                self.TTEE,
+                self.URCORNER,
+                self.LTEE,
+                self.PLUS,
+                self.RTEE,
+                self.LLCORNER,
+                self.BTEE,
+                self.LRCORNER,
+            ) = glyphstr
 
 
 class ViewBase(Widget, DisplayableContainer):  # pylint: disable=too-many-instance-attributes
@@ -21,11 +56,17 @@ class ViewBase(Widget, DisplayableContainer):  # pylint: disable=too-many-instan
         DisplayableContainer.__init__(self, win)
 
         self.fm.signal_bind('move', self.request_clear)
+        self.settings.signal_bind('setopt.draw_borders_glyphset', self._reset_glyphset,
+                                  priority=settings.SIGNAL_PRIORITY_AFTER_SYNC)
         self.old_draw_borders = self.settings.draw_borders
+        self._reset_glyphset()
 
         self.columns = None
         self.main_column = None
         self.pager = None
+
+    def _reset_glyphset(self):
+        self.glyphs = BorderGlyphset(self.settings.draw_borders_glyphset)
 
     def request_clear(self):
         self.need_clear = True
@@ -66,16 +107,16 @@ class ViewBase(Widget, DisplayableContainer):  # pylint: disable=too-many-instan
 
     def _draw_border_rectangle(self, left_start, right_end):
         # Draw border lines
-        self.whline(0, left_start + 1, curses.ACS_HLINE, (right_end - left_start - 1))
-        self.whline(self.hei - 1, left_start + 1, curses.ACS_HLINE, (right_end - left_start - 1))
-        self.wvline(1, left_start, curses.ACS_VLINE, self.hei - 2)
-        self.wvline(1, right_end, curses.ACS_VLINE, self.hei - 2)
+        self.whline(0, left_start + 1, self.glyphs.HLINE, (right_end - left_start - 1))
+        self.whline(self.hei - 1, left_start + 1, self.glyphs.HLINE, (right_end - left_start - 1))
+        self.wvline(1, left_start, self.glyphs.VLINE, self.hei - 2)
+        self.wvline(1, right_end, self.glyphs.VLINE, self.hei - 2)
 
         # Draw corners
-        self.addch(0, left_start, curses.ACS_ULCORNER)
-        self.addch(self.hei - 1, left_start, curses.ACS_LLCORNER)
-        self.addch(0, right_end, curses.ACS_URCORNER)
-        self.addch(self.hei - 1, right_end, curses.ACS_LRCORNER)
+        self.addch(0, left_start, self.glyphs.ULCORNER)
+        self.addch(self.hei - 1, left_start, self.glyphs.LLCORNER)
+        self.addch(0, right_end, self.glyphs.URCORNER)
+        self.addch(self.hei - 1, right_end, self.glyphs.LRCORNER)
 
     def _draw_bookmarks(self):
         self.columns[-1].clear_image(force=True)

--- a/ranger/gui/widgets/view_base.py
+++ b/ranger/gui/widgets/view_base.py
@@ -66,10 +66,10 @@ class ViewBase(Widget, DisplayableContainer):  # pylint: disable=too-many-instan
 
     def _draw_border_rectangle(self, left_start, right_end):
         # Draw border lines
-        win.hline(0, left_start, curses.ACS_HLINE, right_end - left_start)
-        win.hline(self.hei - 1, left_start, curses.ACS_HLINE, right_end - left_start)
-        win.vline(1, left_start, curses.ACS_VLINE, self.hei - 2)
-        win.vline(1, right_end, curses.ACS_VLINE, self.hei - 2)
+        self.whline(0, left_start + 1, curses.ACS_HLINE, (right_end - left_start - 1))
+        self.whline(self.hei - 1, left_start + 1, curses.ACS_HLINE, (right_end - left_start - 1))
+        self.wvline(1, left_start, curses.ACS_VLINE, self.hei - 2)
+        self.wvline(1, right_end, curses.ACS_VLINE, self.hei - 2)
 
         # Draw corners
         self.addch(0, left_start, curses.ACS_ULCORNER)

--- a/ranger/gui/widgets/view_miller.py
+++ b/ranger/gui/widgets/view_miller.py
@@ -150,7 +150,7 @@ class ViewMiller(ViewBase):  # pylint: disable=too-many-ancestors,too-many-insta
                 y = self.hei - 1
                 try:
                     # pylint: disable=no-member
-                    win.vline(1, x, curses.ACS_VLINE, y - 1)
+                    self.wvline(1, x, curses.ACS_VLINE, y - 1)
                     if 'outline' in border_types:
                         self.addch(0, x, curses.ACS_TTEE, 0)
                         self.addch(y, x, curses.ACS_BTEE, 0)

--- a/ranger/gui/widgets/view_miller.py
+++ b/ranger/gui/widgets/view_miller.py
@@ -150,13 +150,13 @@ class ViewMiller(ViewBase):  # pylint: disable=too-many-ancestors,too-many-insta
                 y = self.hei - 1
                 try:
                     # pylint: disable=no-member
-                    self.wvline(1, x, curses.ACS_VLINE, y - 1)
+                    self.wvline(1, x, self.glyphs.VLINE, y - 1)
                     if 'outline' in border_types:
-                        self.addch(0, x, curses.ACS_TTEE, 0)
-                        self.addch(y, x, curses.ACS_BTEE, 0)
+                        self.addch(0, x, self.glyphs.TTEE, 0)
+                        self.addch(y, x, self.glyphs.BTEE, 0)
                     else:
-                        self.addch(0, x, curses.ACS_VLINE, 0)
-                        self.addch(y, x, curses.ACS_VLINE, 0)
+                        self.addch(0, x, self.glyphs.VLINE, 0)
+                        self.addch(y, x, self.glyphs.VLINE, 0)
                     # pylint: enable=no-member
                 except curses.error:
                     # in case it's off the boundaries

--- a/ranger/gui/widgets/view_miller.py
+++ b/ranger/gui/widgets/view_miller.py
@@ -36,8 +36,6 @@ class ViewMiller(ViewBase):  # pylint: disable=too-many-ancestors,too-many-insta
         self.settings.signal_bind('setopt.column_ratios', self.rebuild,
                                   priority=settings.SIGNAL_PRIORITY_AFTER_SYNC)
 
-        self.old_draw_borders = self.settings.draw_borders
-
     def rebuild(self):
         for child in self.container:
             if isinstance(child, BrowserColumn):
@@ -113,8 +111,6 @@ class ViewMiller(ViewBase):  # pylint: disable=too-many-ancestors,too-many-insta
             self._draw_info(self.draw_info)
 
     def _draw_borders(self, border_types):  # pylint: disable=too-many-branches
-        win = self.win
-
         self.color('in_browser', 'border')
 
         left_start = 0
@@ -134,14 +130,10 @@ class ViewMiller(ViewBase):  # pylint: disable=too-many-ancestors,too-many-insta
             if right_end < left_start:
                 right_end = self.wid - 1
 
-        # Draw horizontal lines and the leftmost vertical line
+        # Draw the outline border
         if 'outline' in border_types:
             try:
-                # pylint: disable=no-member
-                win.hline(0, left_start, curses.ACS_HLINE, right_end - left_start)
-                win.hline(self.hei - 1, left_start, curses.ACS_HLINE, right_end - left_start)
-                win.vline(1, left_start, curses.ACS_VLINE, self.hei - 2)
-                # pylint: enable=no-member
+                self._draw_border_rectangle(left_start, right_end)
             except curses.error:
                 pass
 
@@ -169,23 +161,6 @@ class ViewMiller(ViewBase):  # pylint: disable=too-many-ancestors,too-many-insta
                 except curses.error:
                     # in case it's off the boundaries
                     pass
-
-        if 'outline' in border_types:
-            # Draw the last vertical line
-            try:
-                # pylint: disable=no-member
-                win.vline(1, right_end, curses.ACS_VLINE, self.hei - 2)
-                # pylint: enable=no-member
-            except curses.error:
-                pass
-
-        if 'outline' in border_types:
-            # pylint: disable=no-member
-            self.addch(0, left_start, curses.ACS_ULCORNER)
-            self.addch(self.hei - 1, left_start, curses.ACS_LLCORNER)
-            self.addch(0, right_end, curses.ACS_URCORNER)
-            self.addch(self.hei - 1, right_end, curses.ACS_LRCORNER)
-            # pylint: enable=no-member
 
     def _collapse(self):
         # Should the last column be cut off? (Because there is no preview)

--- a/ranger/gui/widgets/view_multipane.py
+++ b/ranger/gui/widgets/view_multipane.py
@@ -17,8 +17,6 @@ class ViewMultipane(ViewBase):  # pylint: disable=too-many-ancestors
         self.fm.signal_bind('tab.change', self._tabchange_handler)
         self.rebuild()
 
-        self.old_draw_borders = self._draw_borders_setting()
-
     def _draw_borders_setting(self):
         # If draw_borders_multipane has not been set, it defaults to `None`
         # and we fallback to using draw_borders. Important to note:
@@ -77,21 +75,8 @@ class ViewMultipane(ViewBase):  # pylint: disable=too-many-ancestors
         elif self.draw_info:
             self._draw_info(self.draw_info)
 
-    def _draw_border_rectangle(self, left_start, right_end):
-        win = self.win
-        win.hline(0, left_start, curses.ACS_HLINE, right_end - left_start)
-        win.hline(self.hei - 1, left_start, curses.ACS_HLINE, right_end - left_start)
-        win.vline(1, left_start, curses.ACS_VLINE, self.hei - 2)
-        win.vline(1, right_end, curses.ACS_VLINE, self.hei - 2)
-        # Draw the four corners
-        self.addch(0, left_start, curses.ACS_ULCORNER)
-        self.addch(self.hei - 1, left_start, curses.ACS_LLCORNER)
-        self.addch(0, right_end, curses.ACS_URCORNER)
-        self.addch(self.hei - 1, right_end, curses.ACS_LRCORNER)
-
     def _draw_borders(self, border_types):
         # Referenced from ranger.gui.widgets.view_miller
-        win = self.win
         self.color('in_browser', 'border')
 
         left_start = 0

--- a/ranger/gui/widgets/view_multipane.py
+++ b/ranger/gui/widgets/view_multipane.py
@@ -96,13 +96,13 @@ class ViewMultipane(ViewBase):  # pylint: disable=too-many-ancestors
                     x = child.x + child.wid
                     y = self.hei - 1
                     try:
-                        self.wvline(1, x, curses.ACS_VLINE, y - 1)
+                        self.wvline(1, x, self.glyphs.VLINE, y - 1)
                         if 'outline' in border_types:
-                            self.addch(0, x, curses.ACS_TTEE, 0)
-                            self.addch(y, x, curses.ACS_BTEE, 0)
+                            self.addch(0, x, self.glyphs.TTEE, 0)
+                            self.addch(y, x, self.glyphs.BTEE, 0)
                         else:
-                            self.addch(0, x, curses.ACS_VLINE, 0)
-                            self.addch(y, x, curses.ACS_VLINE, 0)
+                            self.addch(0, x, self.glyphs.VLINE, 0)
+                            self.addch(y, x, self.glyphs.VLINE, 0)
                     except curses.error:
                         pass
         else:

--- a/ranger/gui/widgets/view_multipane.py
+++ b/ranger/gui/widgets/view_multipane.py
@@ -96,7 +96,7 @@ class ViewMultipane(ViewBase):  # pylint: disable=too-many-ancestors
                     x = child.x + child.wid
                     y = self.hei - 1
                     try:
-                        win.vline(1, x, curses.ACS_VLINE, y - 1)
+                        self.wvline(1, x, curses.ACS_VLINE, y - 1)
                         if 'outline' in border_types:
                             self.addch(0, x, curses.ACS_TTEE, 0)
                             self.addch(y, x, curses.ACS_BTEE, 0)


### PR DESCRIPTION
- **gui.widgets: move _draw_border_rectangle() to view_base and share**
- **Add unicode/wide char compatible versions of hline/vline**
- **Add a draw_borders_glyphset setting to choose between ┌┬┐/╭┬╮/┏┳┓/╔╦╗**

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [x] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [x] The code was not generated by an LLM **[REQUIRED]**
- [x] All changes follow the code style **[REQUIRED]**
- [?] All new and existing tests pass **[REQUIRED]**
- [x] Changes require config files to be updated
    - [x] Config files have been updated
- [x] Changes require documentation to be updated
    - [x] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated
