### PR TITLE
Fix Python2-related CI failures

### DIFF
--- a/ranger/container/tags.py
+++ b/ranger/container/tags.py
@@ -3,7 +3,7 @@
 
 # TODO: add a __getitem__ method to get the tag of a file
 
-from __future__ import (absolute_import, division, print_function)
+from __future__ import (absolute_import, division, print_function, unicode_literals)
 
 import string
 from io import open

--- a/tests/ranger/container/test_tags.py
+++ b/tests/ranger/container/test_tags.py
@@ -1,5 +1,6 @@
-from __future__ import (absolute_import, division, print_function)
+from __future__ import (absolute_import, division, print_function, unicode_literals)
 
+from io import open
 import os
 import pytest
 

--- a/tests/ranger/ext/test_shutil_generatorized.py
+++ b/tests/ranger/ext/test_shutil_generatorized.py
@@ -1,5 +1,6 @@
 from __future__ import (absolute_import, division, print_function)
 
+from io import open
 import os
 
 from ranger.ext.shutil_generatorized import move


### PR DESCRIPTION
Fixes Python2 CI warnings

Fixes #3265

Most changes are in tests, but one change ended up in tags.py, potentially fixing a python2 bug:

`from __future__ import unicode_literals`

@toonn could you please review/merge this soon?